### PR TITLE
Modify make format command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ generate-js-protos:
 generate-protos: generate-ex-protos generate-js-protos
 
 format:
-	mix format --check-formatted
+	mix format
 	cd native/physics && cargo fmt --all
 
 lints:


### PR DESCRIPTION
Remove --check-formatted flag from make format command
The CI still runs the `mix format --check-formatted` command