### PR TITLE
Distinction between player_id and client_id

### DIFF
--- a/apps/arena/config/config.exs
+++ b/apps/arena/config/config.exs
@@ -10,8 +10,8 @@ import Config
 # Configures the endpoint
 dispatch = [
   _: [
-    {"/play/:game_id/:player_id", Arena.GameSocketHandler, []},
-    {"/play/:player_id", Arena.SocketHandler, []},
+    {"/play/:game_id/:client_id", Arena.GameSocketHandler, []},
+    {"/play/:client_id", Arena.SocketHandler, []},
     {:_, Plug.Cowboy.Handler, {ArenaWeb.Endpoint, []}}
   ]
 ]

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -41,7 +41,7 @@ defmodule Arena.GameLauncher do
   def handle_info(:start_game, state) do
     {game_players, remaining_players} = Enum.split(state.players, @players_needed)
 
-    {:ok, game_pid} = GenServer.start(Arena.GameUpdater, %{players: game_players})
+    {:ok, game_pid} = GenServer.start(Arena.GameUpdater, %{clients: game_players})
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()
 

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -34,10 +34,10 @@ defmodule Arena.GameSocketHandler do
   def websocket_handle({:binary, message}, state) do
     case Arena.Protobuf.GameAction.decode(message) do
       %{action_type: {:attack, %{skill: skill}}} ->
-        GameUpdater.attack(state.game_pid, state.client_id, skill)
+        GameUpdater.attack(state.game_pid, state.player_id, skill)
 
       %{action_type: {:move, %{direction: direction}}} ->
-        GameUpdater.move(state.game_pid, state.client_id, {direction.x, direction.y})
+        GameUpdater.move(state.game_pid, state.player_id, {direction.x, direction.y})
 
       _ ->
         {}

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -18,8 +18,10 @@ defmodule Arena.GameSocketHandler do
 
   @impl true
   def websocket_init(state) do
-    Phoenix.PubSub.subscribe(Arena.PubSub, state.game_id)
     Logger.info("Websocket INIT called")
+    Phoenix.PubSub.subscribe(Arena.PubSub, state.game_id)
+    {:ok, player_id} = GameUpdater.join(state.game_pid, state.client_id)
+    state = Map.put(state, :player_id, player_id)
     {:reply, {:binary, Jason.encode!(%{})}, state}
   end
 

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -9,11 +9,11 @@ defmodule Arena.GameSocketHandler do
 
   @impl true
   def init(req, _opts) do
-    player_id = :cowboy_req.binding(:player_id, req)
+    client_id = :cowboy_req.binding(:client_id, req)
     game_id = :cowboy_req.binding(:game_id, req)
     game_pid = game_id |> Base58.decode() |> :erlang.binary_to_term([:safe])
 
-    {:cowboy_websocket, req, %{player_id: player_id, game_pid: game_pid, game_id: game_id}}
+    {:cowboy_websocket, req, %{client_id: client_id, game_pid: game_pid, game_id: game_id}}
   end
 
   @impl true
@@ -32,10 +32,10 @@ defmodule Arena.GameSocketHandler do
   def websocket_handle({:binary, message}, state) do
     case Arena.Protobuf.GameAction.decode(message) do
       %{action_type: {:attack, %{skill: skill}}} ->
-        GameUpdater.attack(state.game_pid, state.player_id, skill)
+        GameUpdater.attack(state.game_pid, state.client_id, skill)
 
       %{action_type: {:move, %{direction: direction}}} ->
-        GameUpdater.move(state.game_pid, state.player_id, {direction.x, direction.y})
+        GameUpdater.move(state.game_pid, state.client_id, {direction.x, direction.y})
 
       _ ->
         {}

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -15,8 +15,8 @@ defmodule Arena.GameUpdater do
   ##################
   # API
   ##################
-  def join(game_pid, player_id) do
-    GenServer.call(game_pid, {:join, player_id})
+  def join(game_pid, client_id) do
+    GenServer.call(game_pid, {:join, client_id})
   end
 
   def move(game_pid, player_id, direction) do
@@ -30,9 +30,9 @@ defmodule Arena.GameUpdater do
   ##################
   # Callbacks
   ##################
-  def init(%{players: players}) do
+  def init(%{clients: clients}) do
     game_id = self() |> :erlang.term_to_binary() |> Base58.encode()
-    state = new_game(game_id, players)
+    state = new_game(game_id, clients)
 
     Process.send_after(self(), :update_game, 1_000)
     {:ok, state}
@@ -95,25 +95,32 @@ defmodule Arena.GameUpdater do
     {:reply, :ok, state}
   end
 
+  def handle_call({:join, client_id}, _from, state) do
+    player_id = get_in(state, [:client_to_player_map, client_id])
+    {:reply, {:ok, player_id}, state}
+  end
+
   ##################
   # Private
   ##################
 
   # Game creation
-  defp new_game(game_id, players) do
+  defp new_game(game_id, clients) do
     new_game =
       Physics.new_game(game_id)
       |> Map.put(:last_id, 0)
       |> Map.put(:players, %{})
       |> Map.put(:projectiles, %{})
+      |> Map.put(:client_to_player_map, %{})
 
-    Enum.reduce(players, new_game, fn {_player_id, _client_id}, new_game ->
+    Enum.reduce(clients, new_game, fn {client_id, _from_pid}, new_game ->
       last_id = new_game.last_id + 1
       players = new_game.players |> Map.put(last_id, Entities.new_player(last_id))
 
       new_game
-      |> Map.put(:last_id, last_id)
-      |> Map.put(:players, players)
+        |> Map.put(:last_id, last_id)
+        |> Map.put(:players, players)
+        |> put_in([:client_to_player_map, client_id], last_id)
     end)
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -58,10 +58,10 @@ defmodule Arena.GameUpdater do
   def handle_call({:move, player_id, _direction = {x, y}}, _from, state) do
     player =
       state.players
-      |> Map.get(String.to_integer(player_id))
+      |> Map.get(player_id)
       |> Map.put(:direction, %{x: x, y: y})
 
-    players = state.players |> Map.put(String.to_integer(player_id), player)
+    players = state.players |> Map.put(player_id, player)
 
     state =
       state
@@ -71,7 +71,7 @@ defmodule Arena.GameUpdater do
   end
 
   def handle_call({:attack, player_id, _skill}, _from, state) do
-    current_player = Map.get(state.players, String.to_integer(player_id))
+    current_player = Map.get(state.players, player_id)
 
     last_id = state.last_id + 1
 

--- a/apps/arena/lib/arena/socket_handler.ex
+++ b/apps/arena/lib/arena/socket_handler.ex
@@ -10,15 +10,15 @@ defmodule Arena.SocketHandler do
 
   @impl true
   def init(req, _opts) do
-    player_id = :cowboy_req.binding(:player_id, req)
+    client_id = :cowboy_req.binding(:client_id, req)
 
-    {:cowboy_websocket, req, %{player_id: player_id}}
+    {:cowboy_websocket, req, %{client_id: client_id}}
   end
 
   @impl true
   def websocket_init(state) do
     Logger.info("Websocket INIT called")
-    GameLauncher.join(state.player_id)
+    GameLauncher.join(state.client_id)
 
     game_state =
       GameState.encode(%GameState{


### PR DESCRIPTION
- Rename variables to properly reflect if it is `client_id` or `player_id`
- Websockets recieve client_id
- `game_socket_handler` tracks the player_id when it join the games and uses that to communicate to the game 

To test this you can try going to http://localhost:3000/board/notanid, everything should keep working as before