### PR TITLE
move player with incomming move message

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -55,12 +55,12 @@ defmodule Arena.GameUpdater do
     entities_to_collide = Map.merge(game_state.players, game_state.projectiles)
 
     players =
-      update_entities(game_state.players, entities_to_collide, game_state.external_wall)
+      update_collisions(game_state.players, entities_to_collide)
 
     projectiles =
-      game_state.projectiles
-      |> remove_exploded_projectiles()
-      |> update_entities(entities_to_collide, game_state.external_wall)
+      remove_exploded_projectiles(game_state.projectiles)
+      |> Physics.move_entities(game_state.external_wall)
+      |> update_collisions(entities_to_collide)
 
     # Resolve collisions between players and projectiles
     {projectiles, players} =
@@ -186,6 +186,7 @@ defmodule Arena.GameUpdater do
       player
       |> Map.put(:direction, direction)
       |> Map.put(:is_moving, is_moving)
+      |> Physics.move_entity(state.game_state.external_wall)
       |> Map.put(
         :aditional_info,
         Map.merge(player.aditional_info, %{current_actions: current_actions})
@@ -419,11 +420,9 @@ defmodule Arena.GameUpdater do
     end)
   end
 
-  # Move entities and add game fields
-  defp update_entities(entities, entities_to_collide, external_wall) do
-    new_state = Physics.move_entities(entities, external_wall)
-
-    Enum.reduce(new_state, %{}, fn {key, value}, acc ->
+  # Check entities collisiona
+  defp update_collisions(entities, entities_to_collide) do
+    Enum.reduce(entities, %{}, fn {key, value}, acc ->
       entity =
         Map.get(entities, key)
         |> Map.merge(value)

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -11,4 +11,5 @@ defmodule Physics do
   def add(_arg1, _arg2), do: :erlang.nif_error(:nif_not_loaded)
   def check_collisions(_entity, _entities), do: :erlang.nif_error(:nif_not_loaded)
   def move_entities(_entities, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
+  def move_entity(_entity, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/apps/arena/native/physics/src/collision_detection.rs
+++ b/apps/arena/native/physics/src/collision_detection.rs
@@ -139,7 +139,7 @@ pub(crate) fn point_polygon_colision(point: &Entity, polygon: &Entity) -> bool {
 /*
  * Calculates the distance between two positions
  */
-pub(crate) fn calculate_distance(a: &Position, b: &Position) -> f64 {
+pub(crate) fn calculate_distance(a: &Position, b: &Position) -> f32 {
     let x = a.x - b.x;
     let y = a.y - b.y;
     (x.powi(2) + y.powi(2)).sqrt()

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -39,7 +39,7 @@ fn move_entity(entity: Entity, external_wall: Entity) -> Entity {
             entity.move_to_next_valid_position(&external_wall);
         }
     }
-    
+
     entity
 }
 
@@ -53,4 +53,7 @@ fn check_collisions(entity: Entity, entities: HashMap<u64, Entity>) -> Vec<u64> 
     entity.collides_with(ent)
 }
 
-rustler::init!("Elixir.Physics", [add, check_collisions, move_entities, move_entity]);
+rustler::init!(
+    "Elixir.Physics",
+    [add, check_collisions, move_entities, move_entity]
+);

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -30,6 +30,20 @@ fn move_entities(entities: HashMap<u64, Entity>, external_wall: Entity) -> HashM
 }
 
 #[rustler::nif()]
+fn move_entity(entity: Entity, external_wall: Entity) -> Entity {
+    let mut entity: Entity = entity;
+    if entity.is_moving {
+        entity.move_entity();
+
+        if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
+            entity.move_to_next_valid_position(&external_wall);
+        }
+    }
+    
+    entity
+}
+
+#[rustler::nif()]
 /// Check players inside the player_id radius
 /// Return a list of the players id inside the radius Vec<player_id>
 fn check_collisions(entity: Entity, entities: HashMap<u64, Entity>) -> Vec<u64> {
@@ -39,4 +53,4 @@ fn check_collisions(entity: Entity, entities: HashMap<u64, Entity>) -> Vec<u64> 
     entity.collides_with(ent)
 }
 
-rustler::init!("Elixir.Physics", [add, check_collisions, move_entities]);
+rustler::init!("Elixir.Physics", [add, check_collisions, move_entities, move_entity]);

--- a/apps/arena/native/physics/src/map.rs
+++ b/apps/arena/native/physics/src/map.rs
@@ -14,14 +14,14 @@ pub struct Polygon {
 
 #[derive(NifMap, Clone, Copy)]
 pub struct Position {
-    pub(crate) x: f64,
-    pub(crate) y: f64,
+    pub(crate) x: f32,
+    pub(crate) y: f32,
 }
 
 #[derive(NifMap, Clone, Copy)]
 pub struct Direction {
-    pub(crate) x: f64,
-    pub(crate) y: f64,
+    pub(crate) x: f32,
+    pub(crate) y: f32,
 }
 
 #[derive(NifMap, Clone)]
@@ -29,9 +29,9 @@ pub struct Entity {
     pub id: u64,
     pub shape: Shape,
     pub position: Position,
-    pub radius: f64,
+    pub radius: f32,
     pub vertices: Vec<Position>,
-    pub speed: f64,
+    pub speed: f32,
     pub category: Category,
     pub direction: Direction,
     pub is_moving: bool,
@@ -177,7 +177,7 @@ impl Entity {
 pub(crate) fn is_vertice_inside_circle(
     vertice: &Position,
     circle_center: &Position,
-    circle_radius: f64,
+    circle_radius: f32,
 ) -> bool {
     let circle_center_dist =
         ((vertice.x - circle_center.x).powi(2) + (vertice.y - circle_center.y).powi(2)).sqrt();


### PR DESCRIPTION
This PR temporarily solves movement.
We were executing less movements than the client, so you felt a pull backwards when you walked.