### PR TITLE
Gh246 exclude alive players

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -34,7 +34,7 @@ defmodule Arena.Game.Player do
 
   def trigger_natural_healings(players) do
     Enum.reduce(players, %{}, fn {player_id, player}, players_acc ->
-      player = maybe_trigger_natural_heal(player)
+      player = maybe_trigger_natural_heal(player, alive?(player))
       Map.put(players_acc, player_id, player)
     end)
   end
@@ -45,6 +45,10 @@ defmodule Arena.Game.Player do
 
   def alive?(players, player_id) do
     get_in(players, [player_id, :aditional_info, :health]) > 0
+  end
+
+  def alive_players(players) do
+    Map.filter(players, fn {_, player} -> alive?(player) end)
   end
 
   def stamina_full?(player) do
@@ -134,7 +138,7 @@ defmodule Arena.Game.Player do
     "EXECUTING_SKILL_#{String.upcase(skill_key)}" |> String.to_existing_atom()
   end
 
-  defp maybe_trigger_natural_heal(player) do
+  defp maybe_trigger_natural_heal(player, true) do
     now = System.monotonic_time(:millisecond)
 
     heal_interval? =
@@ -161,4 +165,6 @@ defmodule Arena.Game.Player do
         player
     end
   end
+
+  defp maybe_trigger_natural_heal(player, _), do: player
 end

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -15,8 +15,7 @@ defmodule Arena.Game.Skill do
     circular_damage_area =
       Entities.make_circular_area(player.id, player.position, circle_hit.range)
 
-    alive_players =
-      Map.filter(game_state.players, fn {_id, player} -> Player.alive?(player) end)
+    alive_players = Player.alive_players(game_state.players)
 
     players =
       Physics.check_collisions(circular_damage_area, alive_players)

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -28,7 +28,8 @@ defmodule Arena.GameSocketHandler do
     {:ok, %{player_id: player_id, game_config: config}} =
       GameUpdater.join(state.game_pid, state.client_id)
 
-    state = Map.put(state, :player_id, player_id)
+    state =
+      Map.put(state, :player_id, player_id)
       |> Map.put(:enable, true)
 
     encoded_msg =

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -58,8 +58,7 @@ defmodule Arena.GameUpdater do
   def handle_info(:update_game, %{game_state: game_state} = state) do
     Process.send_after(self(), :update_game, state.game_config.game.tick_rate_ms)
 
-    # #246 Only use alive players
-    entities_to_collide_projectiles = Map.merge(game_state.players, game_state.obstacles)
+    entities_to_collide_projectiles = Map.merge(Player.alive_players(game_state.players), game_state.obstacles)
 
     players =
       game_state.players
@@ -492,7 +491,7 @@ defmodule Arena.GameUpdater do
           entities -> List.delete(entities, external_wall_id)
         end
 
-      collided_entity = decide_collided_entity(projectile, collides_with, external_wall_id)
+      collided_entity = decide_collided_entity(projectile, collides_with, external_wall_id, players_acc)
 
       # #247 Refactor projectile collision resolution
       case {
@@ -540,15 +539,21 @@ defmodule Arena.GameUpdater do
     end)
   end
 
-  defp decide_collided_entity(_projectile, [], _external_wall_id), do: nil
+  defp decide_collided_entity(_projectile, [], _external_wall_id, _players), do: nil
 
-  defp decide_collided_entity(_projectile, [entity_id], external_wall_id)
+  defp decide_collided_entity(_projectile, [entity_id], external_wall_id, _players)
        when entity_id == external_wall_id,
        do: external_wall_id
 
-  defp decide_collided_entity(projectile, [entity_id | other_entities], _external_wall_id)
+  defp decide_collided_entity(projectile, [entity_id | other_entities], _external_wall_id, _players)
        when entity_id == projectile.aditional_info.owner_id,
        do: List.first(other_entities, nil)
 
-  defp decide_collided_entity(_projectile, [entity_id | _], _external_wall_id), do: entity_id
+  defp decide_collided_entity(projectile, [entity_id | other_entities], external_wall_id, players) do
+    player = Map.get(players, entity_id)
+    case player && Player.alive?(player) do
+      false -> decide_collided_entity(projectile, other_entities, external_wall_id, players)
+      _ -> entity_id
+    end
+  end
 end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -181,6 +181,8 @@ defmodule Arena.GameUpdater do
   def handle_info({:to_killfeed, killer_id, victim_id}, state) do
     entry = %{killer_id: killer_id, victim_id: victim_id}
     state = update_in(state, [:game_state, :killfeed], fn killfeed -> [entry | killfeed] end)
+    broadcast_player_dead(state.game_state.game_id, victim_id)
+
     {:noreply, state}
   end
 
@@ -287,6 +289,10 @@ defmodule Arena.GameUpdater do
   ##########################
 
   # Broadcast game update to all players
+  defp broadcast_player_dead(game_id, player_id) do
+    PubSub.broadcast(Arena.PubSub, game_id, {:player_dead, player_id})
+  end
+
   defp broadcast_game_update(state) do
     encoded_state =
       GameEvent.encode(%GameEvent{

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -58,7 +58,8 @@ defmodule Arena.GameUpdater do
   def handle_info(:update_game, %{game_state: game_state} = state) do
     Process.send_after(self(), :update_game, state.game_config.game.tick_rate_ms)
 
-    entities_to_collide_projectiles = Map.merge(Player.alive_players(game_state.players), game_state.obstacles)
+    entities_to_collide_projectiles =
+      Map.merge(Player.alive_players(game_state.players), game_state.obstacles)
 
     players =
       game_state.players
@@ -497,7 +498,8 @@ defmodule Arena.GameUpdater do
           entities -> List.delete(entities, external_wall_id)
         end
 
-      collided_entity = decide_collided_entity(projectile, collides_with, external_wall_id, players_acc)
+      collided_entity =
+        decide_collided_entity(projectile, collides_with, external_wall_id, players_acc)
 
       # #247 Refactor projectile collision resolution
       case {
@@ -551,12 +553,18 @@ defmodule Arena.GameUpdater do
        when entity_id == external_wall_id,
        do: external_wall_id
 
-  defp decide_collided_entity(projectile, [entity_id | other_entities], _external_wall_id, _players)
+  defp decide_collided_entity(
+         projectile,
+         [entity_id | other_entities],
+         _external_wall_id,
+         _players
+       )
        when entity_id == projectile.aditional_info.owner_id,
        do: List.first(other_entities, nil)
 
   defp decide_collided_entity(projectile, [entity_id | other_entities], external_wall_id, players) do
     player = Map.get(players, entity_id)
+
     case player && Player.alive?(player) do
       false -> decide_collided_entity(projectile, other_entities, external_wall_id, players)
       _ -> entity_id


### PR DESCRIPTION
Closes #246 
- [x] Projectiles should only collides with alive players
- [x] Dead players shouldn't be able to move
- [x] Dead players shouldn't be cured
- [x] Killfeed shouldn't be replicated when a player is dead
- [x] Block incomming messages if the player is dead

To test it, use 3 players, and try to execute actions in the browser