### PR TITLE
[GH-276] Aim attack

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -140,9 +140,13 @@ defmodule Arena.Game.Player do
       skill ->
         action_name = skill_key_execution_action(skill_key)
 
+        skill_direction = skill_params.target
+        |> Skill.maybe_auto_aim(player.direction)
+
         player =
           add_action(player, action_name, skill.execution_duration_ms)
           |> change_stamina(-1)
+          |> put_in([:direction], skill_direction)
 
         player =
           case stamina_recharging?(player) do

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -34,8 +34,8 @@ defmodule Arena.Game.Skill do
     %{game_state | players: players}
   end
 
-  def do_mechanic(game_state, player, {:cone_hit, cone_hit}, _skill_params) do
-    Process.send_after(self(), {:trigger_mechanic, player.id, {:do_cone_hit, cone_hit}}, 300)
+  def do_mechanic(game_state, player, {:cone_hit, cone_hit}, skill_params) do
+    Process.send_after(self(), {:trigger_mechanic, player.id, {:do_cone_hit, cone_hit}, skill_params}, 300)
     game_state
   end
 
@@ -69,13 +69,13 @@ defmodule Arena.Game.Skill do
     %{game_state | players: players}
   end
 
-  def do_mechanic(game_state, player, {:multi_cone_hit, multi_cone_hit}, _skill_params) do
+  def do_mechanic(game_state, player, {:multi_cone_hit, multi_cone_hit}, skill_params) do
     Enum.each(1..(multi_cone_hit.amount - 1), fn i ->
       mechanic = {:do_cone_hit, multi_cone_hit}
 
       Process.send_after(
         self(),
-        {:trigger_mechanic, player.id, mechanic},
+        {:trigger_mechanic, player.id, mechanic, skill_params},
         i * multi_cone_hit.interval_ms
       )
     end)
@@ -205,5 +205,13 @@ defmodule Arena.Game.Skill do
       end)
 
     Enum.concat([add_side, middle, sub_side])
+  end
+
+  def maybe_auto_aim(%{x: 0.0, y: 0.0}, player_direction) do
+    player_direction
+  end
+
+  def maybe_auto_aim(skill_direction, _player_direction) do
+    skill_direction
   end
 end

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -211,11 +211,11 @@ defmodule Arena.Game.Skill do
     Enum.concat([add_side, middle, sub_side])
   end
 
-  def maybe_auto_aim(%{x: 0.0, y: 0.0}, player_direction) do
-    player_direction
+  def maybe_auto_aim(%{x: 0.0, y: 0.0} = _skill_direction, player, entities) do
+    Physics.nearest_entity_direction(player, entities)
   end
 
-  def maybe_auto_aim(skill_direction, _player_direction) do
+  def maybe_auto_aim(skill_direction, _player, _entities) do
     skill_direction
   end
 end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -139,9 +139,9 @@ defmodule Arena.GameUpdater do
     {:noreply, %{state | game_state: game_state}}
   end
 
-  def handle_info({:trigger_mechanic, player_id, mechanic}, state) do
+  def handle_info({:trigger_mechanic, player_id, mechanic, skill_params}, state) do
     player = Map.get(state.game_state.players, player_id)
-    game_state = Skill.do_mechanic(state.game_state, player, mechanic, %{})
+    game_state = Skill.do_mechanic(state.game_state, player, mechanic, skill_params)
     state = Map.put(state, :game_state, game_state)
     {:noreply, state}
   end

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -25,4 +25,6 @@ defmodule Physics do
 
   def calculate_speed(_position_a, _position_b, _duration_ms),
     do: :erlang.nif_error(:nif_not_loaded)
+
+  def nearest_entity_direction(_entity, _entities), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -100,18 +100,12 @@ fn calculate_triangle_vertices(
 
 #[rustler::nif()]
 fn get_direction_from_positions(position_a: Position, position_b: Position) -> Direction {
-    let x = position_b.x - position_a.x;
-    let y = position_b.y - position_a.y;
-    let len = (x.powi(2) + y.powi(2)).sqrt();
-    Direction {
-        x: x / len,
-        y: y / len,
-    }
+    direction_from_positions(position_a, position_b)
 }
 
 #[rustler::nif()]
 fn calculate_speed(position_a: Position, position_b: Position, duration: u64) -> f32 {
-    let len = distance_between_entities(position_a, position_b);
+    let len = distance_between_positions(position_a, position_b);
     len / duration as f32
 }
 
@@ -120,12 +114,12 @@ fn nearest_entity_direction(entity: Entity, entities: HashMap<u64, Entity>) -> D
     let mut max_distance = 2000.0;
     let mut direction = Direction { x: entity.direction.x, y: entity.direction.y };
 
-    for other_entity in entities.values_mut() {
+    for other_entity in entities.values() {
         if entity.id != other_entity.id {
-            let distance = distance_between_entities(entity.position, other_entity.position);
+            let distance = distance_between_positions(entity.position, other_entity.position);
             if distance < max_distance {
                 max_distance = distance;
-                direction = get_direction_from_positions(entity.position, other_entity.position);
+                direction = direction_from_positions(entity.position, other_entity.position);
             }
         }
     }
@@ -139,6 +133,17 @@ fn distance_between_positions(entity_a_postion: Position, entity_b_postion: Posi
     (x.powi(2) + y.powi(2)).sqrt()
 }
 
+// This is a wrapper function to be able to call it from the rustler nif
+fn direction_from_positions(position_a: Position, position_b: Position) -> Direction {
+    let x = position_b.x - position_a.x;
+    let y = position_b.y - position_a.y;
+    let len = (x.powi(2) + y.powi(2)).sqrt();
+    Direction {
+        x: x / len,
+        y: y / len,
+    }
+}
+
 rustler::init!(
     "Elixir.Physics",
     [
@@ -149,6 +154,7 @@ rustler::init!(
         add_angle_to_direction,
         calculate_triangle_vertices,
         get_direction_from_positions,
-        calculate_speed
+        calculate_speed,
+        nearest_entity_direction
     ]
 );

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -111,10 +111,32 @@ fn get_direction_from_positions(position_a: Position, position_b: Position) -> D
 
 #[rustler::nif()]
 fn calculate_speed(position_a: Position, position_b: Position, duration: u64) -> f32 {
-    let x = position_b.x - position_a.x;
-    let y = position_b.y - position_a.y;
-    let len = (x.powi(2) + y.powi(2)).sqrt();
+    let len = distance_between_entities(position_a, position_b);
     len / duration as f32
+}
+
+#[rustler::nif()]
+fn nearest_entity_direction(entity: Entity, entities: HashMap<u64, Entity>) -> Direction {
+    let mut max_distance = 2000.0;
+    let mut direction = Direction { x: entity.direction.x, y: entity.direction.y };
+
+    for other_entity in entities.values_mut() {
+        if entity.id != other_entity.id {
+            let distance = distance_between_entities(entity.position, other_entity.position);
+            if distance < max_distance {
+                max_distance = distance;
+                direction = get_direction_from_positions(entity.position, other_entity.position);
+            }
+        }
+    }
+
+    direction
+}
+
+fn distance_between_positions(entity_a_postion: Position, entity_b_postion: Position) -> f32 {
+    let x = entity_b_postion.x - entity_a_postion.x;
+    let y = entity_b_postion.y - entity_a_postion.y;
+    (x.powi(2) + y.powi(2)).sqrt()
 }
 
 rustler::init!(


### PR DESCRIPTION
Closes #276 

Allows players to aim (using joystick direction) or autoaim if the player tap the joystick