### PR TITLE
[GH-275] Send damage information each tick

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -19,7 +19,7 @@ defmodule Arena.Game.Player do
   end
 
   def take_damage(player, damage) do
-    send(self(), {:damage_received, player.id, damage})
+    send(self(), {:damage_taken, player.id, damage})
 
     Map.update!(player, :aditional_info, fn info ->
       %{

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -18,18 +18,16 @@ defmodule Arena.Game.Player do
     end)
   end
 
-  def change_health(player, health_change) do
+  def take_damage(player, damage) do
+    send(self(), {:damage_received, player.id, damage})
+
     Map.update!(player, :aditional_info, fn info ->
       %{
         info
-        | health: max(info.health - health_change, 0),
+        | health: max(info.health - damage, 0),
           last_damage_received: System.monotonic_time(:millisecond)
       }
     end)
-  end
-
-  def change_health(players, player_id, health_change) do
-    Map.update!(players, player_id, fn player -> change_health(player, health_change) end)
   end
 
   def trigger_natural_healings(players) do

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -22,7 +22,9 @@ defmodule Arena.Game.Skill do
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
         target_player =
           Map.get(players_acc, player_id)
-          |> Player.change_health(circle_hit.damage)
+          |> Player.take_damage(circle_hit.damage)
+
+        send(self(), {:damage_done, player.id, circle_hit.damage})
 
         unless Player.alive?(target_player) do
           send(self(), {:to_killfeed, player.id, target_player.id})
@@ -57,7 +59,9 @@ defmodule Arena.Game.Skill do
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
         target_player =
           Map.get(players_acc, player_id)
-          |> Player.change_health(cone_hit.damage)
+          |> Player.take_damage(cone_hit.damage)
+
+        send(self(), {:damage_done, player.id, cone_hit.damage})
 
         unless Player.alive?(target_player) do
           send(self(), {:to_killfeed, player.id, target_player.id})

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -99,7 +99,7 @@ defmodule Arena.GameUpdater do
       |> Map.put(:projectiles, projectiles)
 
     broadcast_game_update(game_state)
-    game_state = %{game_state | killfeed: []}
+    game_state = %{game_state | killfeed: [], damage_taken: %{}, damage_done: %{}}
 
     {:noreply, %{state | game_state: game_state}}
   end
@@ -236,6 +236,26 @@ defmodule Arena.GameUpdater do
       state
       |> put_in([:game_state, :last_id], last_id)
       |> put_in([:game_state, :projectiles], projectiles)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:damage_done, player_id, damage}, state) do
+    state =
+      update_in(state, [:game_state, :damage_done, player_id], fn
+        nil -> damage
+        current -> current + damage
+      end)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:damage_taken, player_id, damage}, state) do
+    state =
+      update_in(state, [:game_state, :damage_taken, player_id], fn
+        nil -> damage
+        current -> current + damage
+      end)
 
     {:noreply, state}
   end
@@ -408,6 +428,8 @@ defmodule Arena.GameUpdater do
           |> Map.put(:last_id, last_id)
           |> Map.put(:players, players)
           |> Map.put(:killfeed, [])
+          |> Map.put(:damage_taken, %{})
+          |> Map.put(:damage_done, %{})
           |> put_in([:client_to_player_map, client_id], last_id)
           |> put_in([:player_timestamps, last_id], 0)
 
@@ -506,7 +528,7 @@ defmodule Arena.GameUpdater do
 
   defp maybe_receive_zone_damage(player, elapse_time, zone_damage_interval, zone_damage)
        when elapse_time > zone_damage_interval do
-    Player.change_health(player, zone_damage)
+    Player.take_damage(player, zone_damage)
   end
 
   defp maybe_receive_zone_damage(player, _elaptime, _zone_damage_interval, _zone_damage),
@@ -542,7 +564,12 @@ defmodule Arena.GameUpdater do
 
         # Projectile hit a player
         {_entity_id, player, nil} ->
-          player = Player.change_health(player, projectile.aditional_info.damage)
+          player = Player.take_damage(player, projectile.aditional_info.damage)
+
+          send(
+            self(),
+            {:damage_done, projectile.aditional_info.owner_id, projectile.aditional_info.damage}
+          )
 
           projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -335,7 +335,9 @@ defmodule Arena.GameUpdater do
              server_timestamp: DateTime.utc_now() |> DateTime.to_unix(:millisecond),
              player_timestamps: state.player_timestamps,
              zone: state.zone,
-             killfeed: state.killfeed
+             killfeed: state.killfeed,
+             damage_taken: state.damage_taken,
+             damage_done: state.damage_done
            }}
       })
 

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -182,6 +182,24 @@ defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
   field(:value, 2, type: :int64)
 end
 
+defmodule Arena.Serialization.GameState.DamageTakenEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
+end
+
+defmodule Arena.Serialization.GameState.DamageDoneEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
+end
+
 defmodule Arena.Serialization.GameState do
   @moduledoc false
 
@@ -206,6 +224,20 @@ defmodule Arena.Serialization.GameState do
   field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
   field(:zone, 6, type: Arena.Serialization.Zone)
   field(:killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry)
+
+  field(:damage_taken, 8,
+    repeated: true,
+    type: Arena.Serialization.GameState.DamageTakenEntry,
+    json_name: "damageTaken",
+    map: true
+  )
+
+  field(:damage_done, 9,
+    repeated: true,
+    type: Arena.Serialization.GameState.DamageDoneEntry,
+    json_name: "damageDone",
+    map: true
+  )
 end
 
 defmodule Arena.Serialization.Entity do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -85,6 +85,8 @@ message GameState {
   int64 server_timestamp = 5;
   Zone zone = 6;
   repeated KillEntry killfeed = 7;
+  map<uint64, uint64> damage_taken = 8;
+  map<uint64, uint64> damage_done = 9;
 }
 
 /*


### PR DESCRIPTION
Closes #275 

With this change we start keeping track of the damage done and received on each tick for each player, similar to how the killfeed worked

You can test it with https://github.com/lambdaclass/curse_of_mirra/pull/1437 (and adding some logs)