### PR TITLE
[GH-247] Refactor projectile collision handler

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -87,7 +87,7 @@ defmodule Arena.GameUpdater do
 
     # Resolve collisions between players and projectiles
     {projectiles, players} =
-      resolve_collisions(
+      resolve_projectile_collisions(
         projectiles,
         players,
         game_state.obstacles,
@@ -520,9 +520,9 @@ defmodule Arena.GameUpdater do
   # - If collided with external wall or obstacle explode projectile
   # - If collided with another player do the projectile's damage
   # - Do nothing on unexpected cases
-  defp resolve_collisions(projectiles, players, obstacles, external_wall_id)
+  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id)
 
-  defp resolve_collisions(projectiles, players, obstacles, external_wall_id) do
+  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id) do
     Enum.reduce(projectiles, {projectiles, players}, fn {_projectile_id, projectile},
                                                         {_projectiles_acc, players_acc} = accs ->
       # check if the projectiles is inside the walls

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -571,7 +571,7 @@ defmodule Arena.GameUpdater do
 
     projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
 
-    if player.aditional_info.health == 0 do
+    unless Player.alive?(player) do
       send(self(), {:to_killfeed, projectile.aditional_info.owner_id, player.id})
     end
 


### PR DESCRIPTION
closes #247

I'll add a simple description about what the method `resolve_collisions` will do when the projectile collide with different elements in the map

Extracted case call to a private function that handles different collision cases
Since the wall collision do the same as the obstacle one we'll handle them in the same case