### PR TITLE
[GH-267] Power up feature

### DIFF
--- a/apps/arena/docs/src/README.md
+++ b/apps/arena/docs/src/README.md
@@ -9,6 +9,7 @@
   * [Skills](./configuration/skills.md)
   * [Characters](./configuration/characters.md)
   * [Game](./configuration/game.md)
+  * [Power Ups](./configuration/power_ups.md)
 * [Attributes](./attributes/attributes.md)
   * [Player attributes](./attributes/players.md)
   * [Projectile attributes](./attributes/projectiles.md)

--- a/apps/arena/docs/src/SUMMARY.md
+++ b/apps/arena/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
   * [Skills](./configuration/skills.md)
   * [Characters](./configuration/characters.md)
   * [Game](./configuration/game.md)
+  * [Power Ups](./configuration/power_ups.md)
 * [Attributes](./attributes/attributes.md)
   * [Player attributes](./attributes/players.md)
   * [Projectile attributes](./attributes/projectiles.md)

--- a/apps/arena/docs/src/configuration/configuration.md
+++ b/apps/arena/docs/src/configuration/configuration.md
@@ -10,6 +10,7 @@ The game can be configured through a JSON file which is passed on initiation of 
   "skills": [...]
   "characters": [...]
   "game": [...]
+  "power_ups": [...]
 }
 ```
 
@@ -20,3 +21,4 @@ Read more about each field
 - [Skills](./skills.md)
 - [Characters](./characters.md)
 - [Game](./game.md)
+- [Power Ups](./power_ups.md)

--- a/apps/arena/docs/src/configuration/power_ups.md
+++ b/apps/arena/docs/src/configuration/power_ups.md
@@ -1,0 +1,26 @@
+# Power ups
+
+The power ups are entities droped when a player dies that can be picked up for players and modify how strong a player is 
+
+## Configuration
+
+- `power_ups_per_kill`: Defines how many power ups a player will drop when it dies
+- `minimun_amount`: Defines the minimun amount of power up a player needs to have to drop that amount of power ups
+- `amount_of_drops`: How many power ups a player will drop when it dies with certain amount of power ups
+- `distance_to_power_up`: Distance from the position where the player dies to where the power up will be, it'll spawn in a random direction
+- `power_up_damage_modifier`: How much additional damage the power up will provide
+
+
+
+## Example 
+
+...
+  {
+    "power_ups_per_kill": [
+      {"minimun_amount": 0, "amount_of_drops": 1},
+      {"minimun_amount": 2, "amount_of_drops": 2},
+    ],
+    "distance_to_power_up": 500,
+    "power_up_damage_modifier": 0.10
+  }
+...

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -32,7 +32,8 @@ defmodule Arena.Entities do
         natural_healing_interval: character.natural_healing_interval,
         last_damage_received: now,
         natural_healing_damage_interval: character.natural_healing_damage_interval,
-        character_name: character.name
+        character_name: character.name,
+        power_ups: 0
       }
     }
   end
@@ -54,6 +55,27 @@ defmodule Arena.Entities do
         owner_id: owner_id,
         status: :ACTIVE,
         remove_on_collision: remove_on_collision
+      }
+    }
+  end
+
+  def new_power_up(id, position, direction, owner_id) do
+    %{
+      id: id,
+      category: :power_up,
+      shape: :circle,
+      name: "Power Up" <> Integer.to_string(id),
+      position: position,
+      radius: 4.0,
+      vertices: [],
+      speed: 0.0,
+      direction: direction,
+      is_moving: false,
+      aditional_info: %{
+        damage: 4,
+        owner_id: owner_id,
+        status: :ACTIVE,
+        remove_on_collision: true
       }
     }
   end

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -156,6 +156,7 @@ defmodule Arena.Entities do
        status: entity.aditional_info.status
      }}
   end
+
   def maybe_add_custom_info(entity) when entity.category == :power_up do
     {:power_up,
      %Arena.Serialization.PowerUp{

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -66,15 +66,14 @@ defmodule Arena.Entities do
       shape: :circle,
       name: "Power Up" <> Integer.to_string(id),
       position: position,
-      radius: 4.0,
+      radius: 10.0,
       vertices: [],
       speed: 0.0,
       direction: direction,
       is_moving: false,
       aditional_info: %{
-        damage: 4,
         owner_id: owner_id,
-        status: :ACTIVE,
+        status: :AVAILABLE,
         remove_on_collision: true
       }
     }
@@ -144,7 +143,8 @@ defmodule Arena.Entities do
        max_stamina: entity.aditional_info.max_stamina,
        stamina_interval: entity.aditional_info.stamina_interval,
        recharging_stamina: entity.aditional_info.recharging_stamina,
-       character_name: entity.aditional_info.character_name
+       character_name: entity.aditional_info.character_name,
+       power_ups: entity.aditional_info.power_ups
      }}
   end
 
@@ -152,6 +152,13 @@ defmodule Arena.Entities do
     {:projectile,
      %Arena.Serialization.Projectile{
        damage: entity.aditional_info.damage,
+       owner_id: entity.aditional_info.owner_id,
+       status: entity.aditional_info.status
+     }}
+  end
+  def maybe_add_custom_info(entity) when entity.category == :power_up do
+    {:power_up,
+     %Arena.Serialization.PowerUp{
        owner_id: entity.aditional_info.owner_id,
        status: entity.aditional_info.status
      }}

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -33,7 +33,8 @@ defmodule Arena.Entities do
         last_damage_received: now,
         natural_healing_damage_interval: character.natural_healing_damage_interval,
         character_name: character.name,
-        power_ups: 0
+        power_ups: 0,
+        power_up_damage_modifier: config.power_ups.power_up_damage_modifier
       }
     }
   end

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -149,19 +149,19 @@ defmodule Arena.Game.Player do
 
   """
   def calculate_real_damage(
-    %{
-      aditional_info: %{
-        power_ups: power_up_amount,
-        power_up_damage_modifier: power_up_damage_modifier
-      }
-    } = _player_damage_owner,
-    damage
-  ) do
-aditional_damage = damage * power_up_damage_modifier * power_up_amount
+        %{
+          aditional_info: %{
+            power_ups: power_up_amount,
+            power_up_damage_modifier: power_up_damage_modifier
+          }
+        } = _player_damage_owner,
+        damage
+      ) do
+    aditional_damage = damage * power_up_damage_modifier * power_up_amount
 
-(damage + aditional_damage)
-|> round()
-end
+    (damage + aditional_damage)
+    |> round()
+  end
 
   ####################
   # Internal helpers #

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -132,6 +132,37 @@ defmodule Arena.Game.Player do
     end
   end
 
+  @doc """
+
+  Receives a player that owns the damage and the damage number
+
+  to calculate the real damage we'll use the config "power_up_damage_modifier" multipling that with base damage of the
+  ability and multiply that with the amount of power ups that a player has then adding that to the base damage resulting
+  in the real damage
+
+  e.g.: if you want a 10% increase in damage you can add a 0.10 modifier
+
+  ## Examples
+
+      iex>calculate_real_damage(%{aditional_info: %{power_ups: 1, power_up_damage_modifier: 0.10}}, 40)
+      44
+
+  """
+  def calculate_real_damage(
+    %{
+      aditional_info: %{
+        power_ups: power_up_amount,
+        power_up_damage_modifier: power_up_damage_modifier
+      }
+    } = _player_damage_owner,
+    damage
+  ) do
+aditional_damage = damage * power_up_damage_modifier * power_up_amount
+
+(damage + aditional_damage)
+|> round()
+end
+
   ####################
   # Internal helpers #
   ####################

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -20,8 +20,7 @@ defmodule Arena.Game.Skill do
     players =
       Physics.check_collisions(circular_damage_area, alive_players)
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
-        real_damage =
-          Player.calculate_real_damage(player, circle_hit.damage)
+        real_damage = Player.calculate_real_damage(player, circle_hit.damage)
 
         target_player =
           Map.get(players_acc, player_id)
@@ -58,8 +57,7 @@ defmodule Arena.Game.Skill do
     players =
       Physics.check_collisions(cone_area, alive_players)
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
-        real_damage =
-          Player.calculate_real_damage(player, cone_hit.damage)
+        real_damage = Player.calculate_real_damage(player, cone_hit.damage)
 
         target_player =
           Map.get(players_acc, player_id)

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -20,9 +20,12 @@ defmodule Arena.Game.Skill do
     players =
       Physics.check_collisions(circular_damage_area, alive_players)
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
+        real_damage =
+          Player.calculate_real_damage(player, circle_hit.damage)
+
         target_player =
           Map.get(players_acc, player_id)
-          |> Player.change_health(circle_hit.damage)
+          |> Player.change_health(real_damage)
 
         unless Player.alive?(target_player) do
           send(self(), {:to_killfeed, player.id, target_player.id})
@@ -55,9 +58,12 @@ defmodule Arena.Game.Skill do
     players =
       Physics.check_collisions(cone_area, alive_players)
       |> Enum.reduce(game_state.players, fn player_id, players_acc ->
+        real_damage =
+          Player.calculate_real_damage(player, cone_hit.damage)
+
         target_player =
           Map.get(players_acc, player_id)
-          |> Player.change_health(cone_hit.damage)
+          |> Player.change_health(real_damage)
 
         unless Player.alive?(target_player) do
           send(self(), {:to_killfeed, player.id, target_player.id})

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -332,6 +332,7 @@ defmodule Arena.GameUpdater do
              game_id: state.game_id,
              players: complete_entities(state.players),
              projectiles: complete_entities(state.projectiles),
+             power_ups: complete_entities(state.power_ups),
              server_timestamp: state.server_timestamp,
              player_timestamps: state.player_timestamps,
              zone: state.zone,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -692,8 +692,8 @@ defmodule Arena.GameUpdater do
   end
 
   defp get_amount_of_power_ups(%{aditional_info: %{power_ups: power_ups}}, power_ups_per_kill) do
-    Enum.sort_by(power_ups_per_kill, fn %{amount: minimun} -> minimun end, :desc)
-    |> Enum.find(fn %{amount: minimun} ->
+    Enum.sort_by(power_ups_per_kill, fn %{minimun_amount: minimun} -> minimun end, :desc)
+    |> Enum.find(fn %{minimun_amount: minimun} ->
       minimun <= power_ups
     end)
     |> case do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -558,7 +558,12 @@ defmodule Arena.GameUpdater do
 
         # Projectile hit a player
         {_entity_id, player, nil} ->
-          player = Player.change_health(player, projectile.aditional_info.damage)
+          owner_player = Map.get(players, projectile.aditional_info.owner_id)
+
+          real_damage =
+            Player.calculate_real_damage(owner_player, projectile.aditional_info.damage)
+
+          player = Player.change_health(player, real_damage)
 
           projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
 
@@ -619,8 +624,17 @@ defmodule Arena.GameUpdater do
        when amount > 0 do
     last_id = game_state.last_id + 1
 
-    random_x = victim.position.x + Enum.random(-game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up)
-    random_y = victim.position.y + Enum.random(-game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up)
+    random_x =
+      victim.position.x +
+        Enum.random(
+          -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
+        )
+
+    random_y =
+      victim.position.y +
+        Enum.random(
+          -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
+        )
 
     random_position = %{x: random_x, y: random_y}
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -619,41 +619,37 @@ defmodule Arena.GameUpdater do
   end
 
   defp spawn_power_ups(
-         %{game_state: game_state, game_config: game_config} = state,
+         %{game_config: game_config} = state,
          victim,
          amount
-       )
-       when amount > 0 do
-    last_id = game_state.last_id + 1
+  ) do
+    Enum.reduce(1..amount//1, state, fn _, state ->
+      random_x =
+        victim.position.x +
+          Enum.random(
+            -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
+          )
 
-    random_x =
-      victim.position.x +
-        Enum.random(
-          -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
+      random_y =
+        victim.position.y +
+          Enum.random(
+            -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
+          )
+
+      random_position = %{x: random_x, y: random_y}
+      last_id = state.game_state.last_id + 1
+      power_up =
+        Entities.new_power_up(
+          last_id,
+          random_position,
+          victim.direction,
+          victim.id
         )
 
-    random_y =
-      victim.position.y +
-        Enum.random(
-          -game_config.power_ups.distance_to_power_up..game_config.power_ups.distance_to_power_up
-        )
-
-    random_position = %{x: random_x, y: random_y}
-
-    power_up =
-      Entities.new_power_up(
-        last_id,
-        random_position,
-        victim.direction,
-        victim.id
-      )
-
-    put_in(state, [:game_state, :power_ups, last_id], power_up)
-    |> put_in([:game_state, :last_id], last_id)
-    |> spawn_power_ups(victim, amount - 1)
+      put_in(state, [:game_state, :power_ups, last_id], power_up)
+      |> put_in([:game_state, :last_id], last_id)
+    end)
   end
-
-  defp spawn_power_ups(state, _victim, _amount), do: state
 
   defp get_amount_of_power_ups(%{aditional_info: %{power_ups: power_ups}}, power_ups_per_kill) do
     Enum.sort_by(power_ups_per_kill, fn %{amount: minimun} -> minimun end, :desc)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -622,7 +622,7 @@ defmodule Arena.GameUpdater do
          %{game_config: game_config} = state,
          victim,
          amount
-  ) do
+       ) do
     Enum.reduce(1..amount//1, state, fn _, state ->
       random_x =
         victim.position.x +
@@ -638,6 +638,7 @@ defmodule Arena.GameUpdater do
 
       random_position = %{x: random_x, y: random_y}
       last_id = state.game_state.last_id + 1
+
       power_up =
         Entities.new_power_up(
           last_id,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -200,7 +200,9 @@ defmodule Arena.GameUpdater do
       ) do
     entry = %{killer_id: killer_id, victim_id: victim_id}
     victim = Map.get(game_state.players, victim_id)
-    amount_of_power_ups = get_amount_of_power_ups(victim, game_config.power_ups.power_ups_per_kill)
+
+    amount_of_power_ups =
+      get_amount_of_power_ups(victim, game_config.power_ups.power_ups_per_kill)
 
     state =
       update_in(state, [:game_state, :killfeed], fn killfeed -> [entry | killfeed] end)
@@ -677,11 +679,10 @@ defmodule Arena.GameUpdater do
           Map.has_key?(power_ups_acc, collided_entity_id)
         end)
 
-      power_up =
-        Map.get(power_ups, power_up_collided_id)
+      power_up = Map.get(power_ups, power_up_collided_id)
 
       if power_up && power_up.aditional_info.status == :AVAILABLE && Player.alive?(player) do
-        power_up =  put_in(power_up, [:aditional_info, :status], :TAKEN)
+        power_up = put_in(power_up, [:aditional_info, :status], :TAKEN)
 
         player =
           player

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -95,8 +95,7 @@ defmodule Arena.GameUpdater do
         game_state.external_wall.id
       )
 
-    players =
-      apply_zone_damage(players, game_state.zone, state.game_config.game)
+    players = apply_zone_damage(players, game_state.zone, state.game_config.game)
 
     game_state =
       game_state

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -592,11 +592,13 @@ defmodule Arena.GameUpdater do
   # Projectile collided a player
   defp apply_collision_updates(projectile, player, _, _, {projectiles_acc, players_acc})
        when not is_nil(player) do
-    player = Player.take_damage(player, projectile.aditional_info.damage)
+    attacking_player = Map.get(players_acc, projectile.aditional_info.owner_id)
+    real_damage = Player.calculate_real_damage(attacking_player, projectile.aditional_info.damage)
+    player = Player.take_damage(player, real_damage)
 
     send(
       self(),
-      {:damage_done, projectile.aditional_info.owner_id, projectile.aditional_info.damage}
+      {:damage_done, projectile.aditional_info.owner_id, real_damage}
     )
 
     projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -3,8 +3,8 @@ defmodule Arena.Serialization.ProjectileStatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :ACTIVE, 0
-  field :EXPLODED, 1
+  field(:ACTIVE, 0)
+  field(:EXPLODED, 1)
 end
 
 defmodule Arena.Serialization.PowerUpstatus do
@@ -12,8 +12,8 @@ defmodule Arena.Serialization.PowerUpstatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :AVAILABLE, 0
-  field :TAKEN, 1
+  field(:AVAILABLE, 0)
+  field(:TAKEN, 1)
 end
 
 defmodule Arena.Serialization.PlayerActionType do
@@ -21,12 +21,12 @@ defmodule Arena.Serialization.PlayerActionType do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :MOVING, 0
-  field :STARTING_SKILL_1, 1
-  field :STARTING_SKILL_2, 2
-  field :EXECUTING_SKILL_1, 3
-  field :EXECUTING_SKILL_2, 4
-  field :EXECUTING_SKILL_3, 5
+  field(:MOVING, 0)
+  field(:STARTING_SKILL_1, 1)
+  field(:STARTING_SKILL_2, 2)
+  field(:EXECUTING_SKILL_1, 3)
+  field(:EXECUTING_SKILL_2, 4)
+  field(:EXECUTING_SKILL_3, 5)
 end
 
 defmodule Arena.Serialization.Direction do
@@ -34,8 +34,8 @@ defmodule Arena.Serialization.Direction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule Arena.Serialization.Position do
@@ -43,8 +43,8 @@ defmodule Arena.Serialization.Position do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule Arena.Serialization.GameEvent do
@@ -52,12 +52,12 @@ defmodule Arena.Serialization.GameEvent do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :event, 0
+  oneof(:event, 0)
 
-  field :joined, 1, type: Arena.Serialization.GameJoined, oneof: 0
-  field :update, 2, type: Arena.Serialization.GameState, oneof: 0
-  field :finished, 3, type: Arena.Serialization.GameFinished, oneof: 0
-  field :ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0
+  field(:joined, 1, type: Arena.Serialization.GameJoined, oneof: 0)
+  field(:update, 2, type: Arena.Serialization.GameState, oneof: 0)
+  field(:finished, 3, type: Arena.Serialization.GameFinished, oneof: 0)
+  field(:ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0)
 end
 
 defmodule Arena.Serialization.GameFinished.PlayersEntry do
@@ -65,8 +65,8 @@ defmodule Arena.Serialization.GameFinished.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameFinished do
@@ -74,12 +74,13 @@ defmodule Arena.Serialization.GameFinished do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :winner, 1, type: Arena.Serialization.Entity
+  field(:winner, 1, type: Arena.Serialization.Entity)
 
-  field :players, 2,
+  field(:players, 2,
     repeated: true,
     type: Arena.Serialization.GameFinished.PlayersEntry,
     map: true
+  )
 end
 
 defmodule Arena.Serialization.PingUpdate do
@@ -87,7 +88,7 @@ defmodule Arena.Serialization.PingUpdate do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :latency, 1, type: :uint64
+  field(:latency, 1, type: :uint64)
 end
 
 defmodule Arena.Serialization.GameJoined do
@@ -95,8 +96,8 @@ defmodule Arena.Serialization.GameJoined do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :player_id, 1, type: :uint64, json_name: "playerId"
-  field :config, 2, type: Arena.Serialization.Configuration
+  field(:player_id, 1, type: :uint64, json_name: "playerId")
+  field(:config, 2, type: Arena.Serialization.Configuration)
 end
 
 defmodule Arena.Serialization.Configuration do
@@ -104,9 +105,9 @@ defmodule Arena.Serialization.Configuration do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game, 1, type: Arena.Serialization.ConfigGame
-  field :map, 2, type: Arena.Serialization.ConfigMap
-  field :characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter
+  field(:game, 1, type: Arena.Serialization.ConfigGame)
+  field(:map, 2, type: Arena.Serialization.ConfigMap)
+  field(:characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter)
 end
 
 defmodule Arena.Serialization.ConfigGame do
@@ -114,7 +115,7 @@ defmodule Arena.Serialization.ConfigGame do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
+  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
 
 defmodule Arena.Serialization.ConfigMap do
@@ -122,7 +123,7 @@ defmodule Arena.Serialization.ConfigMap do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
@@ -130,8 +131,8 @@ defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :string
-  field :value, 2, type: Arena.Serialization.ConfigSkill
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Arena.Serialization.ConfigSkill)
 end
 
 defmodule Arena.Serialization.ConfigCharacter do
@@ -139,17 +140,18 @@ defmodule Arena.Serialization.ConfigCharacter do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :active, 2, type: :bool
-  field :base_speed, 3, type: :float, json_name: "baseSpeed"
-  field :base_size, 4, type: :float, json_name: "baseSize"
-  field :base_health, 5, type: :uint64, json_name: "baseHealth"
-  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
+  field(:name, 1, type: :string)
+  field(:active, 2, type: :bool)
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
+  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
+  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
 
-  field :skills, 7,
+  field(:skills, 7,
     repeated: true,
     type: Arena.Serialization.ConfigCharacter.SkillsEntry,
     map: true
+  )
 end
 
 defmodule Arena.Serialization.ConfigSkill do
@@ -157,9 +159,9 @@ defmodule Arena.Serialization.ConfigSkill do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
-  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
+  field(:name, 1, type: :string)
+  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
+  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do
@@ -167,8 +169,8 @@ defmodule Arena.Serialization.GameState.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState.ProjectilesEntry do
@@ -176,8 +178,8 @@ defmodule Arena.Serialization.GameState.ProjectilesEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
@@ -185,8 +187,8 @@ defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :int64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :int64)
 end
 
 defmodule Arena.Serialization.GameState.PowerUpsEntry do
@@ -194,8 +196,8 @@ defmodule Arena.Serialization.GameState.PowerUpsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState do
@@ -203,29 +205,32 @@ defmodule Arena.Serialization.GameState do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game_id, 1, type: :string, json_name: "gameId"
-  field :players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true
+  field(:game_id, 1, type: :string, json_name: "gameId")
+  field(:players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true)
 
-  field :projectiles, 3,
+  field(:projectiles, 3,
     repeated: true,
     type: Arena.Serialization.GameState.ProjectilesEntry,
     map: true
+  )
 
-  field :player_timestamps, 4,
+  field(:player_timestamps, 4,
     repeated: true,
     type: Arena.Serialization.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
+  )
 
-  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
-  field :zone, 6, type: Arena.Serialization.Zone
-  field :killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry
+  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
+  field(:zone, 6, type: Arena.Serialization.Zone)
+  field(:killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry)
 
-  field :power_ups, 8,
+  field(:power_ups, 8,
     repeated: true,
     type: Arena.Serialization.GameState.PowerUpsEntry,
     json_name: "powerUps",
     map: true
+  )
 end
 
 defmodule Arena.Serialization.Entity do
@@ -233,23 +238,23 @@ defmodule Arena.Serialization.Entity do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :aditional_info, 0
+  oneof(:aditional_info, 0)
 
-  field :id, 1, type: :uint64
-  field :category, 2, type: :string
-  field :shape, 3, type: :string
-  field :name, 4, type: :string
-  field :position, 5, type: Arena.Serialization.Position
-  field :radius, 6, type: :float
-  field :vertices, 7, repeated: true, type: Arena.Serialization.Position
-  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
-  field :speed, 9, type: :float
-  field :direction, 10, type: Arena.Serialization.Direction
-  field :is_moving, 11, type: :bool, json_name: "isMoving"
-  field :player, 12, type: Arena.Serialization.Player, oneof: 0
-  field :projectile, 13, type: Arena.Serialization.Projectile, oneof: 0
-  field :obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0
-  field :power_up, 15, type: Arena.Serialization.PowerUp, json_name: "powerUp", oneof: 0
+  field(:id, 1, type: :uint64)
+  field(:category, 2, type: :string)
+  field(:shape, 3, type: :string)
+  field(:name, 4, type: :string)
+  field(:position, 5, type: Arena.Serialization.Position)
+  field(:radius, 6, type: :float)
+  field(:vertices, 7, repeated: true, type: Arena.Serialization.Position)
+  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
+  field(:speed, 9, type: :float)
+  field(:direction, 10, type: Arena.Serialization.Direction)
+  field(:is_moving, 11, type: :bool, json_name: "isMoving")
+  field(:player, 12, type: Arena.Serialization.Player, oneof: 0)
+  field(:projectile, 13, type: Arena.Serialization.Projectile, oneof: 0)
+  field(:obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0)
+  field(:power_up, 15, type: Arena.Serialization.PowerUp, json_name: "powerUp", oneof: 0)
 end
 
 defmodule Arena.Serialization.Player do
@@ -257,20 +262,21 @@ defmodule Arena.Serialization.Player do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :health, 1, type: :uint64
-  field :kill_count, 2, type: :uint64, json_name: "killCount"
+  field(:health, 1, type: :uint64)
+  field(:kill_count, 2, type: :uint64, json_name: "killCount")
 
-  field :current_actions, 3,
+  field(:current_actions, 3,
     repeated: true,
     type: Arena.Serialization.PlayerAction,
     json_name: "currentActions"
+  )
 
-  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
-  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
-  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
-  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
-  field :character_name, 8, type: :string, json_name: "characterName"
-  field :power_ups, 9, type: :uint64, json_name: "powerUps"
+  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
+  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
+  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
+  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
+  field(:character_name, 8, type: :string, json_name: "characterName")
+  field(:power_ups, 9, type: :uint64, json_name: "powerUps")
 end
 
 defmodule Arena.Serialization.Projectile do
@@ -278,9 +284,9 @@ defmodule Arena.Serialization.Projectile do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :damage, 1, type: :uint64
-  field :owner_id, 2, type: :uint64, json_name: "ownerId"
-  field :status, 3, type: Arena.Serialization.ProjectileStatus, enum: true
+  field(:damage, 1, type: :uint64)
+  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
+  field(:status, 3, type: Arena.Serialization.ProjectileStatus, enum: true)
 end
 
 defmodule Arena.Serialization.Obstacle do
@@ -288,7 +294,7 @@ defmodule Arena.Serialization.Obstacle do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :color, 1, type: :string
+  field(:color, 1, type: :string)
 end
 
 defmodule Arena.Serialization.PowerUp do
@@ -296,8 +302,8 @@ defmodule Arena.Serialization.PowerUp do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :owner_id, 1, type: :uint64, json_name: "ownerId"
-  field :status, 2, type: Arena.Serialization.PowerUpstatus, enum: true
+  field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: Arena.Serialization.PowerUpstatus, enum: true)
 end
 
 defmodule Arena.Serialization.PlayerAction do
@@ -305,8 +311,8 @@ defmodule Arena.Serialization.PlayerAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :action, 1, type: Arena.Serialization.PlayerActionType, enum: true
-  field :duration, 2, type: :uint64
+  field(:action, 1, type: Arena.Serialization.PlayerActionType, enum: true)
+  field(:duration, 2, type: :uint64)
 end
 
 defmodule Arena.Serialization.Move do
@@ -314,7 +320,7 @@ defmodule Arena.Serialization.Move do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :direction, 1, type: Arena.Serialization.Direction
+  field(:direction, 1, type: Arena.Serialization.Direction)
 end
 
 defmodule Arena.Serialization.Attack do
@@ -322,7 +328,7 @@ defmodule Arena.Serialization.Attack do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :skill, 1, type: :string
+  field(:skill, 1, type: :string)
 end
 
 defmodule Arena.Serialization.GameAction do
@@ -330,11 +336,11 @@ defmodule Arena.Serialization.GameAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :move, 1, type: Arena.Serialization.Move, oneof: 0
-  field :attack, 2, type: Arena.Serialization.Attack, oneof: 0
-  field :timestamp, 3, type: :int64
+  field(:move, 1, type: Arena.Serialization.Move, oneof: 0)
+  field(:attack, 2, type: Arena.Serialization.Attack, oneof: 0)
+  field(:timestamp, 3, type: :int64)
 end
 
 defmodule Arena.Serialization.Zone do
@@ -342,7 +348,7 @@ defmodule Arena.Serialization.Zone do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule Arena.Serialization.KillEntry do
@@ -350,6 +356,6 @@ defmodule Arena.Serialization.KillEntry do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :killer_id, 1, type: :uint64, json_name: "killerId"
-  field :victim_id, 2, type: :uint64, json_name: "victimId"
+  field(:killer_id, 1, type: :uint64, json_name: "killerId")
+  field(:victim_id, 2, type: :uint64, json_name: "victimId")
 end

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -3,8 +3,8 @@ defmodule Arena.Serialization.ProjectileStatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :ACTIVE, 0
-  field :EXPLODED, 1
+  field(:ACTIVE, 0)
+  field(:EXPLODED, 1)
 end
 
 defmodule Arena.Serialization.PowerUpstatus do
@@ -12,8 +12,8 @@ defmodule Arena.Serialization.PowerUpstatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :AVAILABLE, 0
-  field :TAKEN, 1
+  field(:AVAILABLE, 0)
+  field(:TAKEN, 1)
 end
 
 defmodule Arena.Serialization.PlayerActionType do
@@ -21,12 +21,12 @@ defmodule Arena.Serialization.PlayerActionType do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :MOVING, 0
-  field :STARTING_SKILL_1, 1
-  field :STARTING_SKILL_2, 2
-  field :EXECUTING_SKILL_1, 3
-  field :EXECUTING_SKILL_2, 4
-  field :EXECUTING_SKILL_3, 5
+  field(:MOVING, 0)
+  field(:STARTING_SKILL_1, 1)
+  field(:STARTING_SKILL_2, 2)
+  field(:EXECUTING_SKILL_1, 3)
+  field(:EXECUTING_SKILL_2, 4)
+  field(:EXECUTING_SKILL_3, 5)
 end
 
 defmodule Arena.Serialization.Direction do
@@ -34,8 +34,8 @@ defmodule Arena.Serialization.Direction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule Arena.Serialization.Position do
@@ -43,8 +43,8 @@ defmodule Arena.Serialization.Position do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule Arena.Serialization.GameEvent do
@@ -52,12 +52,12 @@ defmodule Arena.Serialization.GameEvent do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :event, 0
+  oneof(:event, 0)
 
-  field :joined, 1, type: Arena.Serialization.GameJoined, oneof: 0
-  field :update, 2, type: Arena.Serialization.GameState, oneof: 0
-  field :finished, 3, type: Arena.Serialization.GameFinished, oneof: 0
-  field :ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0
+  field(:joined, 1, type: Arena.Serialization.GameJoined, oneof: 0)
+  field(:update, 2, type: Arena.Serialization.GameState, oneof: 0)
+  field(:finished, 3, type: Arena.Serialization.GameFinished, oneof: 0)
+  field(:ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0)
 end
 
 defmodule Arena.Serialization.GameFinished.PlayersEntry do
@@ -65,8 +65,8 @@ defmodule Arena.Serialization.GameFinished.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameFinished do
@@ -74,12 +74,13 @@ defmodule Arena.Serialization.GameFinished do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :winner, 1, type: Arena.Serialization.Entity
+  field(:winner, 1, type: Arena.Serialization.Entity)
 
-  field :players, 2,
+  field(:players, 2,
     repeated: true,
     type: Arena.Serialization.GameFinished.PlayersEntry,
     map: true
+  )
 end
 
 defmodule Arena.Serialization.PingUpdate do
@@ -87,7 +88,7 @@ defmodule Arena.Serialization.PingUpdate do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :latency, 1, type: :uint64
+  field(:latency, 1, type: :uint64)
 end
 
 defmodule Arena.Serialization.GameJoined do
@@ -95,8 +96,8 @@ defmodule Arena.Serialization.GameJoined do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :player_id, 1, type: :uint64, json_name: "playerId"
-  field :config, 2, type: Arena.Serialization.Configuration
+  field(:player_id, 1, type: :uint64, json_name: "playerId")
+  field(:config, 2, type: Arena.Serialization.Configuration)
 end
 
 defmodule Arena.Serialization.Configuration do
@@ -104,9 +105,9 @@ defmodule Arena.Serialization.Configuration do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game, 1, type: Arena.Serialization.ConfigGame
-  field :map, 2, type: Arena.Serialization.ConfigMap
-  field :characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter
+  field(:game, 1, type: Arena.Serialization.ConfigGame)
+  field(:map, 2, type: Arena.Serialization.ConfigMap)
+  field(:characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter)
 end
 
 defmodule Arena.Serialization.ConfigGame do
@@ -114,7 +115,7 @@ defmodule Arena.Serialization.ConfigGame do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
+  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
 
 defmodule Arena.Serialization.ConfigMap do
@@ -122,7 +123,7 @@ defmodule Arena.Serialization.ConfigMap do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
@@ -130,8 +131,8 @@ defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :string
-  field :value, 2, type: Arena.Serialization.ConfigSkill
+  field(:key, 1, type: :string)
+  field(:value, 2, type: Arena.Serialization.ConfigSkill)
 end
 
 defmodule Arena.Serialization.ConfigCharacter do
@@ -139,17 +140,18 @@ defmodule Arena.Serialization.ConfigCharacter do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :active, 2, type: :bool
-  field :base_speed, 3, type: :float, json_name: "baseSpeed"
-  field :base_size, 4, type: :float, json_name: "baseSize"
-  field :base_health, 5, type: :uint64, json_name: "baseHealth"
-  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
+  field(:name, 1, type: :string)
+  field(:active, 2, type: :bool)
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
+  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
+  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
 
-  field :skills, 7,
+  field(:skills, 7,
     repeated: true,
     type: Arena.Serialization.ConfigCharacter.SkillsEntry,
     map: true
+  )
 end
 
 defmodule Arena.Serialization.ConfigSkill do
@@ -157,9 +159,9 @@ defmodule Arena.Serialization.ConfigSkill do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
-  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
+  field(:name, 1, type: :string)
+  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
+  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do
@@ -167,8 +169,8 @@ defmodule Arena.Serialization.GameState.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState.ProjectilesEntry do
@@ -176,8 +178,8 @@ defmodule Arena.Serialization.GameState.ProjectilesEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
@@ -185,8 +187,8 @@ defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :int64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :int64)
 end
 
 defmodule Arena.Serialization.GameState.DamageTakenEntry do
@@ -194,8 +196,8 @@ defmodule Arena.Serialization.GameState.DamageTakenEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :uint64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
 end
 
 defmodule Arena.Serialization.GameState.DamageDoneEntry do
@@ -203,8 +205,8 @@ defmodule Arena.Serialization.GameState.DamageDoneEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :uint64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
 end
 
 defmodule Arena.Serialization.GameState.PowerUpsEntry do
@@ -212,8 +214,8 @@ defmodule Arena.Serialization.GameState.PowerUpsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: Arena.Serialization.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: Arena.Serialization.Entity)
 end
 
 defmodule Arena.Serialization.GameState do
@@ -221,41 +223,46 @@ defmodule Arena.Serialization.GameState do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game_id, 1, type: :string, json_name: "gameId"
-  field :players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true
+  field(:game_id, 1, type: :string, json_name: "gameId")
+  field(:players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true)
 
-  field :projectiles, 3,
+  field(:projectiles, 3,
     repeated: true,
     type: Arena.Serialization.GameState.ProjectilesEntry,
     map: true
+  )
 
-  field :player_timestamps, 4,
+  field(:player_timestamps, 4,
     repeated: true,
     type: Arena.Serialization.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
+  )
 
-  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
-  field :zone, 6, type: Arena.Serialization.Zone
-  field :killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry
+  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
+  field(:zone, 6, type: Arena.Serialization.Zone)
+  field(:killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry)
 
-  field :damage_taken, 8,
+  field(:damage_taken, 8,
     repeated: true,
     type: Arena.Serialization.GameState.DamageTakenEntry,
     json_name: "damageTaken",
     map: true
+  )
 
-  field :damage_done, 9,
+  field(:damage_done, 9,
     repeated: true,
     type: Arena.Serialization.GameState.DamageDoneEntry,
     json_name: "damageDone",
     map: true
+  )
 
-  field :power_ups, 10,
+  field(:power_ups, 10,
     repeated: true,
     type: Arena.Serialization.GameState.PowerUpsEntry,
     json_name: "powerUps",
     map: true
+  )
 end
 
 defmodule Arena.Serialization.Entity do
@@ -263,23 +270,23 @@ defmodule Arena.Serialization.Entity do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :aditional_info, 0
+  oneof(:aditional_info, 0)
 
-  field :id, 1, type: :uint64
-  field :category, 2, type: :string
-  field :shape, 3, type: :string
-  field :name, 4, type: :string
-  field :position, 5, type: Arena.Serialization.Position
-  field :radius, 6, type: :float
-  field :vertices, 7, repeated: true, type: Arena.Serialization.Position
-  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
-  field :speed, 9, type: :float
-  field :direction, 10, type: Arena.Serialization.Direction
-  field :is_moving, 11, type: :bool, json_name: "isMoving"
-  field :player, 12, type: Arena.Serialization.Player, oneof: 0
-  field :projectile, 13, type: Arena.Serialization.Projectile, oneof: 0
-  field :obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0
-  field :power_up, 15, type: Arena.Serialization.PowerUp, json_name: "powerUp", oneof: 0
+  field(:id, 1, type: :uint64)
+  field(:category, 2, type: :string)
+  field(:shape, 3, type: :string)
+  field(:name, 4, type: :string)
+  field(:position, 5, type: Arena.Serialization.Position)
+  field(:radius, 6, type: :float)
+  field(:vertices, 7, repeated: true, type: Arena.Serialization.Position)
+  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
+  field(:speed, 9, type: :float)
+  field(:direction, 10, type: Arena.Serialization.Direction)
+  field(:is_moving, 11, type: :bool, json_name: "isMoving")
+  field(:player, 12, type: Arena.Serialization.Player, oneof: 0)
+  field(:projectile, 13, type: Arena.Serialization.Projectile, oneof: 0)
+  field(:obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0)
+  field(:power_up, 15, type: Arena.Serialization.PowerUp, json_name: "powerUp", oneof: 0)
 end
 
 defmodule Arena.Serialization.Player do
@@ -287,20 +294,21 @@ defmodule Arena.Serialization.Player do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :health, 1, type: :uint64
-  field :kill_count, 2, type: :uint64, json_name: "killCount"
+  field(:health, 1, type: :uint64)
+  field(:kill_count, 2, type: :uint64, json_name: "killCount")
 
-  field :current_actions, 3,
+  field(:current_actions, 3,
     repeated: true,
     type: Arena.Serialization.PlayerAction,
     json_name: "currentActions"
+  )
 
-  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
-  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
-  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
-  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
-  field :character_name, 8, type: :string, json_name: "characterName"
-  field :power_ups, 9, type: :uint64, json_name: "powerUps"
+  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
+  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
+  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
+  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
+  field(:character_name, 8, type: :string, json_name: "characterName")
+  field(:power_ups, 9, type: :uint64, json_name: "powerUps")
 end
 
 defmodule Arena.Serialization.Projectile do
@@ -308,9 +316,9 @@ defmodule Arena.Serialization.Projectile do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :damage, 1, type: :uint64
-  field :owner_id, 2, type: :uint64, json_name: "ownerId"
-  field :status, 3, type: Arena.Serialization.ProjectileStatus, enum: true
+  field(:damage, 1, type: :uint64)
+  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
+  field(:status, 3, type: Arena.Serialization.ProjectileStatus, enum: true)
 end
 
 defmodule Arena.Serialization.Obstacle do
@@ -318,7 +326,7 @@ defmodule Arena.Serialization.Obstacle do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :color, 1, type: :string
+  field(:color, 1, type: :string)
 end
 
 defmodule Arena.Serialization.PowerUp do
@@ -326,8 +334,8 @@ defmodule Arena.Serialization.PowerUp do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :owner_id, 1, type: :uint64, json_name: "ownerId"
-  field :status, 2, type: Arena.Serialization.PowerUpstatus, enum: true
+  field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: Arena.Serialization.PowerUpstatus, enum: true)
 end
 
 defmodule Arena.Serialization.PlayerAction do
@@ -335,8 +343,8 @@ defmodule Arena.Serialization.PlayerAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :action, 1, type: Arena.Serialization.PlayerActionType, enum: true
-  field :duration, 2, type: :uint64
+  field(:action, 1, type: Arena.Serialization.PlayerActionType, enum: true)
+  field(:duration, 2, type: :uint64)
 end
 
 defmodule Arena.Serialization.Move do
@@ -344,7 +352,7 @@ defmodule Arena.Serialization.Move do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :direction, 1, type: Arena.Serialization.Direction
+  field(:direction, 1, type: Arena.Serialization.Direction)
 end
 
 defmodule Arena.Serialization.Attack do
@@ -352,7 +360,7 @@ defmodule Arena.Serialization.Attack do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :skill, 1, type: :string
+  field(:skill, 1, type: :string)
 end
 
 defmodule Arena.Serialization.GameAction do
@@ -360,11 +368,11 @@ defmodule Arena.Serialization.GameAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :move, 1, type: Arena.Serialization.Move, oneof: 0
-  field :attack, 2, type: Arena.Serialization.Attack, oneof: 0
-  field :timestamp, 3, type: :int64
+  field(:move, 1, type: Arena.Serialization.Move, oneof: 0)
+  field(:attack, 2, type: Arena.Serialization.Attack, oneof: 0)
+  field(:timestamp, 3, type: :int64)
 end
 
 defmodule Arena.Serialization.Zone do
@@ -372,7 +380,7 @@ defmodule Arena.Serialization.Zone do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule Arena.Serialization.KillEntry do
@@ -380,6 +388,6 @@ defmodule Arena.Serialization.KillEntry do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :killer_id, 1, type: :uint64, json_name: "killerId"
-  field :victim_id, 2, type: :uint64, json_name: "victimId"
+  field(:killer_id, 1, type: :uint64, json_name: "killerId")
+  field(:victim_id, 2, type: :uint64, json_name: "victimId")
 end

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -1,325 +1,355 @@
 defmodule Arena.Serialization.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:ACTIVE, 0)
-  field(:EXPLODED, 1)
+  field :ACTIVE, 0
+  field :EXPLODED, 1
+end
+
+defmodule Arena.Serialization.PowerUpstatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :AVAILABLE, 0
+  field :TAKEN, 1
 end
 
 defmodule Arena.Serialization.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:MOVING, 0)
-  field(:STARTING_SKILL_1, 1)
-  field(:STARTING_SKILL_2, 2)
-  field(:EXECUTING_SKILL_1, 3)
-  field(:EXECUTING_SKILL_2, 4)
-  field(:EXECUTING_SKILL_3, 5)
+  field :MOVING, 0
+  field :STARTING_SKILL_1, 1
+  field :STARTING_SKILL_2, 2
+  field :EXECUTING_SKILL_1, 3
+  field :EXECUTING_SKILL_2, 4
+  field :EXECUTING_SKILL_3, 5
 end
 
 defmodule Arena.Serialization.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:x, 1, type: :float)
-  field(:y, 2, type: :float)
+  field :x, 1, type: :float
+  field :y, 2, type: :float
 end
 
 defmodule Arena.Serialization.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:x, 1, type: :float)
-  field(:y, 2, type: :float)
+  field :x, 1, type: :float
+  field :y, 2, type: :float
 end
 
 defmodule Arena.Serialization.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:event, 0)
+  oneof :event, 0
 
-  field(:joined, 1, type: Arena.Serialization.GameJoined, oneof: 0)
-  field(:update, 2, type: Arena.Serialization.GameState, oneof: 0)
-  field(:finished, 3, type: Arena.Serialization.GameFinished, oneof: 0)
-  field(:ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0)
+  field :joined, 1, type: Arena.Serialization.GameJoined, oneof: 0
+  field :update, 2, type: Arena.Serialization.GameState, oneof: 0
+  field :finished, 3, type: Arena.Serialization.GameFinished, oneof: 0
+  field :ping, 4, type: Arena.Serialization.PingUpdate, oneof: 0
 end
 
 defmodule Arena.Serialization.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: Arena.Serialization.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: Arena.Serialization.Entity
 end
 
 defmodule Arena.Serialization.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:winner, 1, type: Arena.Serialization.Entity)
+  field :winner, 1, type: Arena.Serialization.Entity
 
-  field(:players, 2,
+  field :players, 2,
     repeated: true,
     type: Arena.Serialization.GameFinished.PlayersEntry,
     map: true
-  )
 end
 
 defmodule Arena.Serialization.PingUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:latency, 1, type: :uint64)
+  field :latency, 1, type: :uint64
 end
 
 defmodule Arena.Serialization.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:player_id, 1, type: :uint64, json_name: "playerId")
-  field(:config, 2, type: Arena.Serialization.Configuration)
+  field :player_id, 1, type: :uint64, json_name: "playerId"
+  field :config, 2, type: Arena.Serialization.Configuration
 end
 
 defmodule Arena.Serialization.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:game, 1, type: Arena.Serialization.ConfigGame)
-  field(:map, 2, type: Arena.Serialization.ConfigMap)
-  field(:characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter)
+  field :game, 1, type: Arena.Serialization.ConfigGame
+  field :map, 2, type: Arena.Serialization.ConfigMap
+  field :characters, 3, repeated: true, type: Arena.Serialization.ConfigCharacter
 end
 
 defmodule Arena.Serialization.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
+  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
 end
 
 defmodule Arena.Serialization.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:radius, 1, type: :float)
+  field :radius, 1, type: :float
 end
 
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: Arena.Serialization.ConfigSkill)
+  field :key, 1, type: :string
+  field :value, 2, type: Arena.Serialization.ConfigSkill
 end
 
 defmodule Arena.Serialization.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:name, 1, type: :string)
-  field(:active, 2, type: :bool)
-  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
-  field(:base_size, 4, type: :float, json_name: "baseSize")
-  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
-  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
+  field :name, 1, type: :string
+  field :active, 2, type: :bool
+  field :base_speed, 3, type: :float, json_name: "baseSpeed"
+  field :base_size, 4, type: :float, json_name: "baseSize"
+  field :base_health, 5, type: :uint64, json_name: "baseHealth"
+  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
 
-  field(:skills, 7,
+  field :skills, 7,
     repeated: true,
     type: Arena.Serialization.ConfigCharacter.SkillsEntry,
     map: true
-  )
 end
 
 defmodule Arena.Serialization.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:name, 1, type: :string)
-  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
-  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
+  field :name, 1, type: :string
+  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
+  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: Arena.Serialization.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: Arena.Serialization.Entity
 end
 
 defmodule Arena.Serialization.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: Arena.Serialization.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: Arena.Serialization.Entity
 end
 
 defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: :int64)
+  field :key, 1, type: :uint64
+  field :value, 2, type: :int64
+end
+
+defmodule Arena.Serialization.GameState.PowerUpsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :key, 1, type: :uint64
+  field :value, 2, type: Arena.Serialization.Entity
 end
 
 defmodule Arena.Serialization.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:game_id, 1, type: :string, json_name: "gameId")
-  field(:players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true)
+  field :game_id, 1, type: :string, json_name: "gameId"
+  field :players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true
 
-  field(:projectiles, 3,
+  field :projectiles, 3,
     repeated: true,
     type: Arena.Serialization.GameState.ProjectilesEntry,
     map: true
-  )
 
-  field(:player_timestamps, 4,
+  field :player_timestamps, 4,
     repeated: true,
     type: Arena.Serialization.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
-  )
 
-  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
-  field(:zone, 6, type: Arena.Serialization.Zone)
-  field(:killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry)
+  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
+  field :zone, 6, type: Arena.Serialization.Zone
+  field :killfeed, 7, repeated: true, type: Arena.Serialization.KillEntry
+
+  field :power_ups, 8,
+    repeated: true,
+    type: Arena.Serialization.GameState.PowerUpsEntry,
+    json_name: "powerUps",
+    map: true
 end
 
 defmodule Arena.Serialization.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:aditional_info, 0)
+  oneof :aditional_info, 0
 
-  field(:id, 1, type: :uint64)
-  field(:category, 2, type: :string)
-  field(:shape, 3, type: :string)
-  field(:name, 4, type: :string)
-  field(:position, 5, type: Arena.Serialization.Position)
-  field(:radius, 6, type: :float)
-  field(:vertices, 7, repeated: true, type: Arena.Serialization.Position)
-  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
-  field(:speed, 9, type: :float)
-  field(:direction, 10, type: Arena.Serialization.Direction)
-  field(:is_moving, 11, type: :bool, json_name: "isMoving")
-  field(:player, 12, type: Arena.Serialization.Player, oneof: 0)
-  field(:projectile, 13, type: Arena.Serialization.Projectile, oneof: 0)
-  field(:obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0)
+  field :id, 1, type: :uint64
+  field :category, 2, type: :string
+  field :shape, 3, type: :string
+  field :name, 4, type: :string
+  field :position, 5, type: Arena.Serialization.Position
+  field :radius, 6, type: :float
+  field :vertices, 7, repeated: true, type: Arena.Serialization.Position
+  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
+  field :speed, 9, type: :float
+  field :direction, 10, type: Arena.Serialization.Direction
+  field :is_moving, 11, type: :bool, json_name: "isMoving"
+  field :player, 12, type: Arena.Serialization.Player, oneof: 0
+  field :projectile, 13, type: Arena.Serialization.Projectile, oneof: 0
+  field :obstacle, 14, type: Arena.Serialization.Obstacle, oneof: 0
+  field :power_up, 15, type: Arena.Serialization.PowerUp, json_name: "powerUp", oneof: 0
 end
 
 defmodule Arena.Serialization.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:health, 1, type: :uint64)
-  field(:kill_count, 2, type: :uint64, json_name: "killCount")
+  field :health, 1, type: :uint64
+  field :kill_count, 2, type: :uint64, json_name: "killCount"
 
-  field(:current_actions, 3,
+  field :current_actions, 3,
     repeated: true,
     type: Arena.Serialization.PlayerAction,
     json_name: "currentActions"
-  )
 
-  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
-  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
-  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
-  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
-  field(:character_name, 8, type: :string, json_name: "characterName")
+  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
+  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
+  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
+  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
+  field :character_name, 8, type: :string, json_name: "characterName"
+  field :power_ups, 9, type: :uint64, json_name: "powerUps"
 end
 
 defmodule Arena.Serialization.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:damage, 1, type: :uint64)
-  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
-  field(:status, 3, type: Arena.Serialization.ProjectileStatus, enum: true)
+  field :damage, 1, type: :uint64
+  field :owner_id, 2, type: :uint64, json_name: "ownerId"
+  field :status, 3, type: Arena.Serialization.ProjectileStatus, enum: true
 end
 
 defmodule Arena.Serialization.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:color, 1, type: :string)
+  field :color, 1, type: :string
+end
+
+defmodule Arena.Serialization.PowerUp do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :owner_id, 1, type: :uint64, json_name: "ownerId"
+  field :status, 2, type: Arena.Serialization.PowerUpstatus, enum: true
 end
 
 defmodule Arena.Serialization.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:action, 1, type: Arena.Serialization.PlayerActionType, enum: true)
-  field(:duration, 2, type: :uint64)
+  field :action, 1, type: Arena.Serialization.PlayerActionType, enum: true
+  field :duration, 2, type: :uint64
 end
 
 defmodule Arena.Serialization.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:direction, 1, type: Arena.Serialization.Direction)
+  field :direction, 1, type: Arena.Serialization.Direction
 end
 
 defmodule Arena.Serialization.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:skill, 1, type: :string)
+  field :skill, 1, type: :string
 end
 
 defmodule Arena.Serialization.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:action_type, 0)
+  oneof :action_type, 0
 
-  field(:move, 1, type: Arena.Serialization.Move, oneof: 0)
-  field(:attack, 2, type: Arena.Serialization.Attack, oneof: 0)
-  field(:timestamp, 3, type: :int64)
+  field :move, 1, type: Arena.Serialization.Move, oneof: 0
+  field :attack, 2, type: Arena.Serialization.Attack, oneof: 0
+  field :timestamp, 3, type: :int64
 end
 
 defmodule Arena.Serialization.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:radius, 1, type: :float)
+  field :radius, 1, type: :float
 end
 
 defmodule Arena.Serialization.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:killer_id, 1, type: :uint64, json_name: "killerId")
-  field(:victim_id, 2, type: :uint64, json_name: "victimId")
+  field :killer_id, 1, type: :uint64, json_name: "killerId"
+  field :victim_id, 2, type: :uint64, json_name: "victimId"
 end

--- a/apps/arena/native/physics/src/map.rs
+++ b/apps/arena/native/physics/src/map.rs
@@ -50,7 +50,7 @@ pub enum Category {
     Player,
     Projectile,
     Obstacle,
-    PowerUp
+    PowerUp,
 }
 
 impl Entity {

--- a/apps/arena/native/physics/src/map.rs
+++ b/apps/arena/native/physics/src/map.rs
@@ -50,6 +50,7 @@ pub enum Category {
     Player,
     Projectile,
     Obstacle,
+    PowerUp
 }
 
 impl Entity {

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -210,9 +210,9 @@
   ],
   "power_ups": {
     "power_ups_per_kill": [
-      {"amount": 0, "amount_of_drops": 1},
-      {"amount": 2, "amount_of_drops": 2},
-      {"amount": 6, "amount_of_drops": 3}
+      {"minimun_amount": 0, "amount_of_drops": 1},
+      {"minimun_amount": 2, "amount_of_drops": 2},
+      {"minimun_amount": 6, "amount_of_drops": 3}
     ],
     "distance_to_power_up": 500,
     "power_up_damage_modifier": 0.10

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -47,7 +47,7 @@
   },
   "game": {
     "tick_rate_ms": 30,
-    "zone_shrink_start_ms": 20000,
+    "zone_shrink_start_ms": 9999999,
     "zone_stop_interval_ms": 30000,
     "zone_start_interval_ms": 20000,
     "zone_damage_interval_ms": 1000,
@@ -279,11 +279,20 @@
   ],
   "power_ups": {
     "power_ups_per_kill": [
-      {"minimun_amount": 0, "amount_of_drops": 1},
-      {"minimun_amount": 2, "amount_of_drops": 2},
-      {"minimun_amount": 6, "amount_of_drops": 3}
+      {
+        "minimun_amount": 0,
+        "amount_of_drops": 1
+      },
+      {
+        "minimun_amount": 2,
+        "amount_of_drops": 2
+      },
+      {
+        "minimun_amount": 6,
+        "amount_of_drops": 3
+      }
     ],
     "distance_to_power_up": 500,
-    "power_up_damage_modifier": 0.10
+    "power_up_damage_modifier": 100
   }
 }

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -47,7 +47,7 @@
   },
   "game": {
     "tick_rate_ms": 30,
-    "zone_shrink_start_ms": 9999999,
+    "zone_shrink_start_ms": 20000,
     "zone_stop_interval_ms": 30000,
     "zone_start_interval_ms": 20000,
     "zone_damage_interval_ms": 1000,
@@ -293,6 +293,6 @@
       }
     ],
     "distance_to_power_up": 500,
-    "power_up_damage_modifier": 100
+    "power_up_damage_modifier": 0.10
   }
 }

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -17,7 +17,7 @@
   },
   "game": {
     "tick_rate_ms": 30,
-    "zone_shrink_start_ms": 20000,
+    "zone_shrink_start_ms": 999999999,
     "zone_stop_interval_ms": 30000,
     "zone_start_interval_ms": 20000,
     "zone_damage_interval_ms": 1000,
@@ -207,5 +207,14 @@
         "3": "sneak"
       }
     }
-  ]
+  ],
+  "power_ups": {
+    "power_ups_per_kill": [
+      {"amount": 0, "amount_of_drops": 1},
+      {"amount": 2, "amount_of_drops": 2},
+      {"amount": 6, "amount_of_drops": 3}
+    ],
+    "distance_to_power_up": 500,
+    "power_up_damage_multiplier": 10
+  }
 }

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -17,7 +17,7 @@
   },
   "game": {
     "tick_rate_ms": 30,
-    "zone_shrink_start_ms": 999999999,
+    "zone_shrink_start_ms": 20000,
     "zone_stop_interval_ms": 30000,
     "zone_start_interval_ms": 20000,
     "zone_damage_interval_ms": 1000,
@@ -215,6 +215,6 @@
       {"amount": 6, "amount_of_drops": 3}
     ],
     "distance_to_power_up": 500,
-    "power_up_damage_multiplier": 10
+    "power_up_damage_modifier": 0.10
   }
 }

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -3,8 +3,8 @@ defmodule GameClient.Protobuf.ProjectileStatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :ACTIVE, 0
-  field :EXPLODED, 1
+  field(:ACTIVE, 0)
+  field(:EXPLODED, 1)
 end
 
 defmodule GameClient.Protobuf.PowerUpstatus do
@@ -12,8 +12,8 @@ defmodule GameClient.Protobuf.PowerUpstatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :AVAILABLE, 0
-  field :TAKEN, 1
+  field(:AVAILABLE, 0)
+  field(:TAKEN, 1)
 end
 
 defmodule GameClient.Protobuf.PlayerActionType do
@@ -21,12 +21,12 @@ defmodule GameClient.Protobuf.PlayerActionType do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :MOVING, 0
-  field :STARTING_SKILL_1, 1
-  field :STARTING_SKILL_2, 2
-  field :EXECUTING_SKILL_1, 3
-  field :EXECUTING_SKILL_2, 4
-  field :EXECUTING_SKILL_3, 5
+  field(:MOVING, 0)
+  field(:STARTING_SKILL_1, 1)
+  field(:STARTING_SKILL_2, 2)
+  field(:EXECUTING_SKILL_1, 3)
+  field(:EXECUTING_SKILL_2, 4)
+  field(:EXECUTING_SKILL_3, 5)
 end
 
 defmodule GameClient.Protobuf.Direction do
@@ -34,8 +34,8 @@ defmodule GameClient.Protobuf.Direction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule GameClient.Protobuf.Position do
@@ -43,8 +43,8 @@ defmodule GameClient.Protobuf.Position do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule GameClient.Protobuf.GameEvent do
@@ -52,12 +52,12 @@ defmodule GameClient.Protobuf.GameEvent do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :event, 0
+  oneof(:event, 0)
 
-  field :joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0
-  field :update, 2, type: GameClient.Protobuf.GameState, oneof: 0
-  field :finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0
-  field :ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0
+  field(:joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0)
+  field(:update, 2, type: GameClient.Protobuf.GameState, oneof: 0)
+  field(:finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0)
+  field(:ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0)
 end
 
 defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
@@ -65,8 +65,8 @@ defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameFinished do
@@ -74,12 +74,13 @@ defmodule GameClient.Protobuf.GameFinished do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :winner, 1, type: GameClient.Protobuf.Entity
+  field(:winner, 1, type: GameClient.Protobuf.Entity)
 
-  field :players, 2,
+  field(:players, 2,
     repeated: true,
     type: GameClient.Protobuf.GameFinished.PlayersEntry,
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.PingUpdate do
@@ -87,7 +88,7 @@ defmodule GameClient.Protobuf.PingUpdate do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :latency, 1, type: :uint64
+  field(:latency, 1, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.GameJoined do
@@ -95,8 +96,8 @@ defmodule GameClient.Protobuf.GameJoined do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :player_id, 1, type: :uint64, json_name: "playerId"
-  field :config, 2, type: GameClient.Protobuf.Configuration
+  field(:player_id, 1, type: :uint64, json_name: "playerId")
+  field(:config, 2, type: GameClient.Protobuf.Configuration)
 end
 
 defmodule GameClient.Protobuf.Configuration do
@@ -104,9 +105,9 @@ defmodule GameClient.Protobuf.Configuration do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game, 1, type: GameClient.Protobuf.ConfigGame
-  field :map, 2, type: GameClient.Protobuf.ConfigMap
-  field :characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter
+  field(:game, 1, type: GameClient.Protobuf.ConfigGame)
+  field(:map, 2, type: GameClient.Protobuf.ConfigMap)
+  field(:characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter)
 end
 
 defmodule GameClient.Protobuf.ConfigGame do
@@ -114,7 +115,7 @@ defmodule GameClient.Protobuf.ConfigGame do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
+  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
 
 defmodule GameClient.Protobuf.ConfigMap do
@@ -122,7 +123,7 @@ defmodule GameClient.Protobuf.ConfigMap do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
@@ -130,8 +131,8 @@ defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :string
-  field :value, 2, type: GameClient.Protobuf.ConfigSkill
+  field(:key, 1, type: :string)
+  field(:value, 2, type: GameClient.Protobuf.ConfigSkill)
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter do
@@ -139,17 +140,18 @@ defmodule GameClient.Protobuf.ConfigCharacter do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :active, 2, type: :bool
-  field :base_speed, 3, type: :float, json_name: "baseSpeed"
-  field :base_size, 4, type: :float, json_name: "baseSize"
-  field :base_health, 5, type: :uint64, json_name: "baseHealth"
-  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
+  field(:name, 1, type: :string)
+  field(:active, 2, type: :bool)
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
+  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
+  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
 
-  field :skills, 7,
+  field(:skills, 7,
     repeated: true,
     type: GameClient.Protobuf.ConfigCharacter.SkillsEntry,
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.ConfigSkill do
@@ -157,9 +159,9 @@ defmodule GameClient.Protobuf.ConfigSkill do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
-  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
+  field(:name, 1, type: :string)
+  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
+  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do
@@ -167,8 +169,8 @@ defmodule GameClient.Protobuf.GameState.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
@@ -176,8 +178,8 @@ defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
@@ -185,8 +187,8 @@ defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :int64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :int64)
 end
 
 defmodule GameClient.Protobuf.GameState.DamageTakenEntry do
@@ -194,8 +196,8 @@ defmodule GameClient.Protobuf.GameState.DamageTakenEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :uint64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.GameState.DamageDoneEntry do
@@ -203,8 +205,8 @@ defmodule GameClient.Protobuf.GameState.DamageDoneEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :uint64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
@@ -212,8 +214,8 @@ defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState do
@@ -221,41 +223,46 @@ defmodule GameClient.Protobuf.GameState do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game_id, 1, type: :string, json_name: "gameId"
-  field :players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true
+  field(:game_id, 1, type: :string, json_name: "gameId")
+  field(:players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true)
 
-  field :projectiles, 3,
+  field(:projectiles, 3,
     repeated: true,
     type: GameClient.Protobuf.GameState.ProjectilesEntry,
     map: true
+  )
 
-  field :player_timestamps, 4,
+  field(:player_timestamps, 4,
     repeated: true,
     type: GameClient.Protobuf.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
+  )
 
-  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
-  field :zone, 6, type: GameClient.Protobuf.Zone
-  field :killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry
+  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
+  field(:zone, 6, type: GameClient.Protobuf.Zone)
+  field(:killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry)
 
-  field :damage_taken, 8,
+  field(:damage_taken, 8,
     repeated: true,
     type: GameClient.Protobuf.GameState.DamageTakenEntry,
     json_name: "damageTaken",
     map: true
+  )
 
-  field :damage_done, 9,
+  field(:damage_done, 9,
     repeated: true,
     type: GameClient.Protobuf.GameState.DamageDoneEntry,
     json_name: "damageDone",
     map: true
+  )
 
-  field :power_ups, 10,
+  field(:power_ups, 10,
     repeated: true,
     type: GameClient.Protobuf.GameState.PowerUpsEntry,
     json_name: "powerUps",
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.Entity do
@@ -263,23 +270,23 @@ defmodule GameClient.Protobuf.Entity do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :aditional_info, 0
+  oneof(:aditional_info, 0)
 
-  field :id, 1, type: :uint64
-  field :category, 2, type: :string
-  field :shape, 3, type: :string
-  field :name, 4, type: :string
-  field :position, 5, type: GameClient.Protobuf.Position
-  field :radius, 6, type: :float
-  field :vertices, 7, repeated: true, type: GameClient.Protobuf.Position
-  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
-  field :speed, 9, type: :float
-  field :direction, 10, type: GameClient.Protobuf.Direction
-  field :is_moving, 11, type: :bool, json_name: "isMoving"
-  field :player, 12, type: GameClient.Protobuf.Player, oneof: 0
-  field :projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0
-  field :obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0
-  field :power_up, 15, type: GameClient.Protobuf.PowerUp, json_name: "powerUp", oneof: 0
+  field(:id, 1, type: :uint64)
+  field(:category, 2, type: :string)
+  field(:shape, 3, type: :string)
+  field(:name, 4, type: :string)
+  field(:position, 5, type: GameClient.Protobuf.Position)
+  field(:radius, 6, type: :float)
+  field(:vertices, 7, repeated: true, type: GameClient.Protobuf.Position)
+  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
+  field(:speed, 9, type: :float)
+  field(:direction, 10, type: GameClient.Protobuf.Direction)
+  field(:is_moving, 11, type: :bool, json_name: "isMoving")
+  field(:player, 12, type: GameClient.Protobuf.Player, oneof: 0)
+  field(:projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0)
+  field(:obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0)
+  field(:power_up, 15, type: GameClient.Protobuf.PowerUp, json_name: "powerUp", oneof: 0)
 end
 
 defmodule GameClient.Protobuf.Player do
@@ -287,20 +294,21 @@ defmodule GameClient.Protobuf.Player do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :health, 1, type: :uint64
-  field :kill_count, 2, type: :uint64, json_name: "killCount"
+  field(:health, 1, type: :uint64)
+  field(:kill_count, 2, type: :uint64, json_name: "killCount")
 
-  field :current_actions, 3,
+  field(:current_actions, 3,
     repeated: true,
     type: GameClient.Protobuf.PlayerAction,
     json_name: "currentActions"
+  )
 
-  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
-  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
-  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
-  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
-  field :character_name, 8, type: :string, json_name: "characterName"
-  field :power_ups, 9, type: :uint64, json_name: "powerUps"
+  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
+  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
+  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
+  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
+  field(:character_name, 8, type: :string, json_name: "characterName")
+  field(:power_ups, 9, type: :uint64, json_name: "powerUps")
 end
 
 defmodule GameClient.Protobuf.Projectile do
@@ -308,9 +316,9 @@ defmodule GameClient.Protobuf.Projectile do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :damage, 1, type: :uint64
-  field :owner_id, 2, type: :uint64, json_name: "ownerId"
-  field :status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true
+  field(:damage, 1, type: :uint64)
+  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
+  field(:status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true)
 end
 
 defmodule GameClient.Protobuf.Obstacle do
@@ -318,7 +326,7 @@ defmodule GameClient.Protobuf.Obstacle do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :color, 1, type: :string
+  field(:color, 1, type: :string)
 end
 
 defmodule GameClient.Protobuf.PowerUp do
@@ -326,8 +334,8 @@ defmodule GameClient.Protobuf.PowerUp do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :owner_id, 1, type: :uint64, json_name: "ownerId"
-  field :status, 2, type: GameClient.Protobuf.PowerUpstatus, enum: true
+  field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: GameClient.Protobuf.PowerUpstatus, enum: true)
 end
 
 defmodule GameClient.Protobuf.PlayerAction do
@@ -335,8 +343,8 @@ defmodule GameClient.Protobuf.PlayerAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true
-  field :duration, 2, type: :uint64
+  field(:action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true)
+  field(:duration, 2, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.Move do
@@ -344,7 +352,7 @@ defmodule GameClient.Protobuf.Move do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :direction, 1, type: GameClient.Protobuf.Direction
+  field(:direction, 1, type: GameClient.Protobuf.Direction)
 end
 
 defmodule GameClient.Protobuf.Attack do
@@ -352,7 +360,7 @@ defmodule GameClient.Protobuf.Attack do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :skill, 1, type: :string
+  field(:skill, 1, type: :string)
 end
 
 defmodule GameClient.Protobuf.GameAction do
@@ -360,11 +368,11 @@ defmodule GameClient.Protobuf.GameAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :move, 1, type: GameClient.Protobuf.Move, oneof: 0
-  field :attack, 2, type: GameClient.Protobuf.Attack, oneof: 0
-  field :timestamp, 3, type: :int64
+  field(:move, 1, type: GameClient.Protobuf.Move, oneof: 0)
+  field(:attack, 2, type: GameClient.Protobuf.Attack, oneof: 0)
+  field(:timestamp, 3, type: :int64)
 end
 
 defmodule GameClient.Protobuf.Zone do
@@ -372,7 +380,7 @@ defmodule GameClient.Protobuf.Zone do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule GameClient.Protobuf.KillEntry do
@@ -380,6 +388,6 @@ defmodule GameClient.Protobuf.KillEntry do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :killer_id, 1, type: :uint64, json_name: "killerId"
-  field :victim_id, 2, type: :uint64, json_name: "victimId"
+  field(:killer_id, 1, type: :uint64, json_name: "killerId")
+  field(:victim_id, 2, type: :uint64, json_name: "victimId")
 end

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -3,8 +3,8 @@ defmodule GameClient.Protobuf.ProjectileStatus do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :ACTIVE, 0
-  field :EXPLODED, 1
+  field(:ACTIVE, 0)
+  field(:EXPLODED, 1)
 end
 
 defmodule GameClient.Protobuf.PlayerActionType do
@@ -12,12 +12,12 @@ defmodule GameClient.Protobuf.PlayerActionType do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :MOVING, 0
-  field :STARTING_SKILL_1, 1
-  field :STARTING_SKILL_2, 2
-  field :EXECUTING_SKILL_1, 3
-  field :EXECUTING_SKILL_2, 4
-  field :EXECUTING_SKILL_3, 5
+  field(:MOVING, 0)
+  field(:STARTING_SKILL_1, 1)
+  field(:STARTING_SKILL_2, 2)
+  field(:EXECUTING_SKILL_1, 3)
+  field(:EXECUTING_SKILL_2, 4)
+  field(:EXECUTING_SKILL_3, 5)
 end
 
 defmodule GameClient.Protobuf.Direction do
@@ -25,8 +25,8 @@ defmodule GameClient.Protobuf.Direction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule GameClient.Protobuf.Position do
@@ -34,8 +34,8 @@ defmodule GameClient.Protobuf.Position do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :x, 1, type: :float
-  field :y, 2, type: :float
+  field(:x, 1, type: :float)
+  field(:y, 2, type: :float)
 end
 
 defmodule GameClient.Protobuf.GameEvent do
@@ -43,12 +43,12 @@ defmodule GameClient.Protobuf.GameEvent do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :event, 0
+  oneof(:event, 0)
 
-  field :joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0
-  field :update, 2, type: GameClient.Protobuf.GameState, oneof: 0
-  field :finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0
-  field :ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0
+  field(:joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0)
+  field(:update, 2, type: GameClient.Protobuf.GameState, oneof: 0)
+  field(:finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0)
+  field(:ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0)
 end
 
 defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
@@ -56,8 +56,8 @@ defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameFinished do
@@ -65,12 +65,13 @@ defmodule GameClient.Protobuf.GameFinished do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :winner, 1, type: GameClient.Protobuf.Entity
+  field(:winner, 1, type: GameClient.Protobuf.Entity)
 
-  field :players, 2,
+  field(:players, 2,
     repeated: true,
     type: GameClient.Protobuf.GameFinished.PlayersEntry,
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.PingUpdate do
@@ -78,7 +79,7 @@ defmodule GameClient.Protobuf.PingUpdate do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :latency, 1, type: :uint64
+  field(:latency, 1, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.GameJoined do
@@ -86,8 +87,8 @@ defmodule GameClient.Protobuf.GameJoined do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :player_id, 1, type: :uint64, json_name: "playerId"
-  field :config, 2, type: GameClient.Protobuf.Configuration
+  field(:player_id, 1, type: :uint64, json_name: "playerId")
+  field(:config, 2, type: GameClient.Protobuf.Configuration)
 end
 
 defmodule GameClient.Protobuf.Configuration do
@@ -95,9 +96,9 @@ defmodule GameClient.Protobuf.Configuration do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game, 1, type: GameClient.Protobuf.ConfigGame
-  field :map, 2, type: GameClient.Protobuf.ConfigMap
-  field :characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter
+  field(:game, 1, type: GameClient.Protobuf.ConfigGame)
+  field(:map, 2, type: GameClient.Protobuf.ConfigMap)
+  field(:characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter)
 end
 
 defmodule GameClient.Protobuf.ConfigGame do
@@ -105,7 +106,7 @@ defmodule GameClient.Protobuf.ConfigGame do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
+  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
 
 defmodule GameClient.Protobuf.ConfigMap do
@@ -113,7 +114,7 @@ defmodule GameClient.Protobuf.ConfigMap do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
@@ -121,8 +122,8 @@ defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :string
-  field :value, 2, type: GameClient.Protobuf.ConfigSkill
+  field(:key, 1, type: :string)
+  field(:value, 2, type: GameClient.Protobuf.ConfigSkill)
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter do
@@ -130,17 +131,18 @@ defmodule GameClient.Protobuf.ConfigCharacter do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :active, 2, type: :bool
-  field :base_speed, 3, type: :float, json_name: "baseSpeed"
-  field :base_size, 4, type: :float, json_name: "baseSize"
-  field :base_health, 5, type: :uint64, json_name: "baseHealth"
-  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
+  field(:name, 1, type: :string)
+  field(:active, 2, type: :bool)
+  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
+  field(:base_size, 4, type: :float, json_name: "baseSize")
+  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
+  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
 
-  field :skills, 7,
+  field(:skills, 7,
     repeated: true,
     type: GameClient.Protobuf.ConfigCharacter.SkillsEntry,
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.ConfigSkill do
@@ -148,9 +150,9 @@ defmodule GameClient.Protobuf.ConfigSkill do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
-  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
-  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
+  field(:name, 1, type: :string)
+  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
+  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do
@@ -158,8 +160,8 @@ defmodule GameClient.Protobuf.GameState.PlayersEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
@@ -167,8 +169,8 @@ defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
@@ -176,8 +178,8 @@ defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: :int64
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: :int64)
 end
 
 defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
@@ -185,8 +187,8 @@ defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
 
   use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :key, 1, type: :uint64
-  field :value, 2, type: GameClient.Protobuf.Entity
+  field(:key, 1, type: :uint64)
+  field(:value, 2, type: GameClient.Protobuf.Entity)
 end
 
 defmodule GameClient.Protobuf.GameState do
@@ -194,29 +196,32 @@ defmodule GameClient.Protobuf.GameState do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :game_id, 1, type: :string, json_name: "gameId"
-  field :players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true
+  field(:game_id, 1, type: :string, json_name: "gameId")
+  field(:players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true)
 
-  field :projectiles, 3,
+  field(:projectiles, 3,
     repeated: true,
     type: GameClient.Protobuf.GameState.ProjectilesEntry,
     map: true
+  )
 
-  field :player_timestamps, 4,
+  field(:player_timestamps, 4,
     repeated: true,
     type: GameClient.Protobuf.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
+  )
 
-  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
-  field :zone, 6, type: GameClient.Protobuf.Zone
-  field :killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry
+  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
+  field(:zone, 6, type: GameClient.Protobuf.Zone)
+  field(:killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry)
 
-  field :power_ups, 8,
+  field(:power_ups, 8,
     repeated: true,
     type: GameClient.Protobuf.GameState.PowerUpsEntry,
     json_name: "powerUps",
     map: true
+  )
 end
 
 defmodule GameClient.Protobuf.Entity do
@@ -224,22 +229,22 @@ defmodule GameClient.Protobuf.Entity do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :aditional_info, 0
+  oneof(:aditional_info, 0)
 
-  field :id, 1, type: :uint64
-  field :category, 2, type: :string
-  field :shape, 3, type: :string
-  field :name, 4, type: :string
-  field :position, 5, type: GameClient.Protobuf.Position
-  field :radius, 6, type: :float
-  field :vertices, 7, repeated: true, type: GameClient.Protobuf.Position
-  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
-  field :speed, 9, type: :float
-  field :direction, 10, type: GameClient.Protobuf.Direction
-  field :is_moving, 11, type: :bool, json_name: "isMoving"
-  field :player, 12, type: GameClient.Protobuf.Player, oneof: 0
-  field :projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0
-  field :obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0
+  field(:id, 1, type: :uint64)
+  field(:category, 2, type: :string)
+  field(:shape, 3, type: :string)
+  field(:name, 4, type: :string)
+  field(:position, 5, type: GameClient.Protobuf.Position)
+  field(:radius, 6, type: :float)
+  field(:vertices, 7, repeated: true, type: GameClient.Protobuf.Position)
+  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
+  field(:speed, 9, type: :float)
+  field(:direction, 10, type: GameClient.Protobuf.Direction)
+  field(:is_moving, 11, type: :bool, json_name: "isMoving")
+  field(:player, 12, type: GameClient.Protobuf.Player, oneof: 0)
+  field(:projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0)
+  field(:obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0)
 end
 
 defmodule GameClient.Protobuf.Player do
@@ -247,20 +252,21 @@ defmodule GameClient.Protobuf.Player do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :health, 1, type: :uint64
-  field :kill_count, 2, type: :uint64, json_name: "killCount"
+  field(:health, 1, type: :uint64)
+  field(:kill_count, 2, type: :uint64, json_name: "killCount")
 
-  field :current_actions, 3,
+  field(:current_actions, 3,
     repeated: true,
     type: GameClient.Protobuf.PlayerAction,
     json_name: "currentActions"
+  )
 
-  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
-  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
-  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
-  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
-  field :character_name, 8, type: :string, json_name: "characterName"
-  field :power_ups, 9, type: :uint64, json_name: "powerUps"
+  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
+  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
+  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
+  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
+  field(:character_name, 8, type: :string, json_name: "characterName")
+  field(:power_ups, 9, type: :uint64, json_name: "powerUps")
 end
 
 defmodule GameClient.Protobuf.Projectile do
@@ -268,9 +274,9 @@ defmodule GameClient.Protobuf.Projectile do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :damage, 1, type: :uint64
-  field :owner_id, 2, type: :uint64, json_name: "ownerId"
-  field :status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true
+  field(:damage, 1, type: :uint64)
+  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
+  field(:status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true)
 end
 
 defmodule GameClient.Protobuf.Obstacle do
@@ -278,7 +284,7 @@ defmodule GameClient.Protobuf.Obstacle do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :color, 1, type: :string
+  field(:color, 1, type: :string)
 end
 
 defmodule GameClient.Protobuf.PlayerAction do
@@ -286,8 +292,8 @@ defmodule GameClient.Protobuf.PlayerAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true
-  field :duration, 2, type: :uint64
+  field(:action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true)
+  field(:duration, 2, type: :uint64)
 end
 
 defmodule GameClient.Protobuf.Move do
@@ -295,7 +301,7 @@ defmodule GameClient.Protobuf.Move do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :direction, 1, type: GameClient.Protobuf.Direction
+  field(:direction, 1, type: GameClient.Protobuf.Direction)
 end
 
 defmodule GameClient.Protobuf.Attack do
@@ -303,7 +309,7 @@ defmodule GameClient.Protobuf.Attack do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :skill, 1, type: :string
+  field(:skill, 1, type: :string)
 end
 
 defmodule GameClient.Protobuf.GameAction do
@@ -311,11 +317,11 @@ defmodule GameClient.Protobuf.GameAction do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :move, 1, type: GameClient.Protobuf.Move, oneof: 0
-  field :attack, 2, type: GameClient.Protobuf.Attack, oneof: 0
-  field :timestamp, 3, type: :int64
+  field(:move, 1, type: GameClient.Protobuf.Move, oneof: 0)
+  field(:attack, 2, type: GameClient.Protobuf.Attack, oneof: 0)
+  field(:timestamp, 3, type: :int64)
 end
 
 defmodule GameClient.Protobuf.Zone do
@@ -323,7 +329,7 @@ defmodule GameClient.Protobuf.Zone do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :radius, 1, type: :float
+  field(:radius, 1, type: :float)
 end
 
 defmodule GameClient.Protobuf.KillEntry do
@@ -331,6 +337,6 @@ defmodule GameClient.Protobuf.KillEntry do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :killer_id, 1, type: :uint64, json_name: "killerId"
-  field :victim_id, 2, type: :uint64, json_name: "victimId"
+  field(:killer_id, 1, type: :uint64, json_name: "killerId")
+  field(:victim_id, 2, type: :uint64, json_name: "victimId")
 end

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -1,325 +1,336 @@
 defmodule GameClient.Protobuf.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:ACTIVE, 0)
-  field(:EXPLODED, 1)
+  field :ACTIVE, 0
+  field :EXPLODED, 1
 end
 
 defmodule GameClient.Protobuf.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:MOVING, 0)
-  field(:STARTING_SKILL_1, 1)
-  field(:STARTING_SKILL_2, 2)
-  field(:EXECUTING_SKILL_1, 3)
-  field(:EXECUTING_SKILL_2, 4)
-  field(:EXECUTING_SKILL_3, 5)
+  field :MOVING, 0
+  field :STARTING_SKILL_1, 1
+  field :STARTING_SKILL_2, 2
+  field :EXECUTING_SKILL_1, 3
+  field :EXECUTING_SKILL_2, 4
+  field :EXECUTING_SKILL_3, 5
 end
 
 defmodule GameClient.Protobuf.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:x, 1, type: :float)
-  field(:y, 2, type: :float)
+  field :x, 1, type: :float
+  field :y, 2, type: :float
 end
 
 defmodule GameClient.Protobuf.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:x, 1, type: :float)
-  field(:y, 2, type: :float)
+  field :x, 1, type: :float
+  field :y, 2, type: :float
 end
 
 defmodule GameClient.Protobuf.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:event, 0)
+  oneof :event, 0
 
-  field(:joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0)
-  field(:update, 2, type: GameClient.Protobuf.GameState, oneof: 0)
-  field(:finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0)
-  field(:ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0)
+  field :joined, 1, type: GameClient.Protobuf.GameJoined, oneof: 0
+  field :update, 2, type: GameClient.Protobuf.GameState, oneof: 0
+  field :finished, 3, type: GameClient.Protobuf.GameFinished, oneof: 0
+  field :ping, 4, type: GameClient.Protobuf.PingUpdate, oneof: 0
 end
 
 defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: GameClient.Protobuf.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: GameClient.Protobuf.Entity
 end
 
 defmodule GameClient.Protobuf.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:winner, 1, type: GameClient.Protobuf.Entity)
+  field :winner, 1, type: GameClient.Protobuf.Entity
 
-  field(:players, 2,
+  field :players, 2,
     repeated: true,
     type: GameClient.Protobuf.GameFinished.PlayersEntry,
     map: true
-  )
 end
 
 defmodule GameClient.Protobuf.PingUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:latency, 1, type: :uint64)
+  field :latency, 1, type: :uint64
 end
 
 defmodule GameClient.Protobuf.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:player_id, 1, type: :uint64, json_name: "playerId")
-  field(:config, 2, type: GameClient.Protobuf.Configuration)
+  field :player_id, 1, type: :uint64, json_name: "playerId"
+  field :config, 2, type: GameClient.Protobuf.Configuration
 end
 
 defmodule GameClient.Protobuf.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:game, 1, type: GameClient.Protobuf.ConfigGame)
-  field(:map, 2, type: GameClient.Protobuf.ConfigMap)
-  field(:characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter)
+  field :game, 1, type: GameClient.Protobuf.ConfigGame
+  field :map, 2, type: GameClient.Protobuf.ConfigMap
+  field :characters, 3, repeated: true, type: GameClient.Protobuf.ConfigCharacter
 end
 
 defmodule GameClient.Protobuf.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
+  field :tick_rate_ms, 1, type: :float, json_name: "tickRateMs"
 end
 
 defmodule GameClient.Protobuf.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:radius, 1, type: :float)
+  field :radius, 1, type: :float
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: GameClient.Protobuf.ConfigSkill)
+  field :key, 1, type: :string
+  field :value, 2, type: GameClient.Protobuf.ConfigSkill
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:name, 1, type: :string)
-  field(:active, 2, type: :bool)
-  field(:base_speed, 3, type: :float, json_name: "baseSpeed")
-  field(:base_size, 4, type: :float, json_name: "baseSize")
-  field(:base_health, 5, type: :uint64, json_name: "baseHealth")
-  field(:max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize")
+  field :name, 1, type: :string
+  field :active, 2, type: :bool
+  field :base_speed, 3, type: :float, json_name: "baseSpeed"
+  field :base_size, 4, type: :float, json_name: "baseSize"
+  field :base_health, 5, type: :uint64, json_name: "baseHealth"
+  field :max_inventory_size, 6, type: :uint64, json_name: "maxInventorySize"
 
-  field(:skills, 7,
+  field :skills, 7,
     repeated: true,
     type: GameClient.Protobuf.ConfigCharacter.SkillsEntry,
     map: true
-  )
 end
 
 defmodule GameClient.Protobuf.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:name, 1, type: :string)
-  field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
-  field(:execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs")
+  field :name, 1, type: :string
+  field :cooldown_ms, 2, type: :uint64, json_name: "cooldownMs"
+  field :execution_duration_ms, 3, type: :uint64, json_name: "executionDurationMs"
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: GameClient.Protobuf.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: GameClient.Protobuf.Entity
 end
 
 defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: GameClient.Protobuf.Entity)
+  field :key, 1, type: :uint64
+  field :value, 2, type: GameClient.Protobuf.Entity
 end
 
 defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:key, 1, type: :uint64)
-  field(:value, 2, type: :int64)
+  field :key, 1, type: :uint64
+  field :value, 2, type: :int64
+end
+
+defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :key, 1, type: :uint64
+  field :value, 2, type: GameClient.Protobuf.Entity
 end
 
 defmodule GameClient.Protobuf.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:game_id, 1, type: :string, json_name: "gameId")
-  field(:players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true)
+  field :game_id, 1, type: :string, json_name: "gameId"
+  field :players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true
 
-  field(:projectiles, 3,
+  field :projectiles, 3,
     repeated: true,
     type: GameClient.Protobuf.GameState.ProjectilesEntry,
     map: true
-  )
 
-  field(:player_timestamps, 4,
+  field :player_timestamps, 4,
     repeated: true,
     type: GameClient.Protobuf.GameState.PlayerTimestampsEntry,
     json_name: "playerTimestamps",
     map: true
-  )
 
-  field(:server_timestamp, 5, type: :int64, json_name: "serverTimestamp")
-  field(:zone, 6, type: GameClient.Protobuf.Zone)
-  field(:killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry)
+  field :server_timestamp, 5, type: :int64, json_name: "serverTimestamp"
+  field :zone, 6, type: GameClient.Protobuf.Zone
+  field :killfeed, 7, repeated: true, type: GameClient.Protobuf.KillEntry
+
+  field :power_ups, 8,
+    repeated: true,
+    type: GameClient.Protobuf.GameState.PowerUpsEntry,
+    json_name: "powerUps",
+    map: true
 end
 
 defmodule GameClient.Protobuf.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:aditional_info, 0)
+  oneof :aditional_info, 0
 
-  field(:id, 1, type: :uint64)
-  field(:category, 2, type: :string)
-  field(:shape, 3, type: :string)
-  field(:name, 4, type: :string)
-  field(:position, 5, type: GameClient.Protobuf.Position)
-  field(:radius, 6, type: :float)
-  field(:vertices, 7, repeated: true, type: GameClient.Protobuf.Position)
-  field(:collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith")
-  field(:speed, 9, type: :float)
-  field(:direction, 10, type: GameClient.Protobuf.Direction)
-  field(:is_moving, 11, type: :bool, json_name: "isMoving")
-  field(:player, 12, type: GameClient.Protobuf.Player, oneof: 0)
-  field(:projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0)
-  field(:obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0)
+  field :id, 1, type: :uint64
+  field :category, 2, type: :string
+  field :shape, 3, type: :string
+  field :name, 4, type: :string
+  field :position, 5, type: GameClient.Protobuf.Position
+  field :radius, 6, type: :float
+  field :vertices, 7, repeated: true, type: GameClient.Protobuf.Position
+  field :collides_with, 8, repeated: true, type: :uint64, json_name: "collidesWith"
+  field :speed, 9, type: :float
+  field :direction, 10, type: GameClient.Protobuf.Direction
+  field :is_moving, 11, type: :bool, json_name: "isMoving"
+  field :player, 12, type: GameClient.Protobuf.Player, oneof: 0
+  field :projectile, 13, type: GameClient.Protobuf.Projectile, oneof: 0
+  field :obstacle, 14, type: GameClient.Protobuf.Obstacle, oneof: 0
 end
 
 defmodule GameClient.Protobuf.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:health, 1, type: :uint64)
-  field(:kill_count, 2, type: :uint64, json_name: "killCount")
+  field :health, 1, type: :uint64
+  field :kill_count, 2, type: :uint64, json_name: "killCount"
 
-  field(:current_actions, 3,
+  field :current_actions, 3,
     repeated: true,
     type: GameClient.Protobuf.PlayerAction,
     json_name: "currentActions"
-  )
 
-  field(:available_stamina, 4, type: :uint64, json_name: "availableStamina")
-  field(:max_stamina, 5, type: :uint64, json_name: "maxStamina")
-  field(:stamina_interval, 6, type: :uint64, json_name: "staminaInterval")
-  field(:recharging_stamina, 7, type: :bool, json_name: "rechargingStamina")
-  field(:character_name, 8, type: :string, json_name: "characterName")
+  field :available_stamina, 4, type: :uint64, json_name: "availableStamina"
+  field :max_stamina, 5, type: :uint64, json_name: "maxStamina"
+  field :stamina_interval, 6, type: :uint64, json_name: "staminaInterval"
+  field :recharging_stamina, 7, type: :bool, json_name: "rechargingStamina"
+  field :character_name, 8, type: :string, json_name: "characterName"
+  field :power_ups, 9, type: :uint64, json_name: "powerUps"
 end
 
 defmodule GameClient.Protobuf.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:damage, 1, type: :uint64)
-  field(:owner_id, 2, type: :uint64, json_name: "ownerId")
-  field(:status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true)
+  field :damage, 1, type: :uint64
+  field :owner_id, 2, type: :uint64, json_name: "ownerId"
+  field :status, 3, type: GameClient.Protobuf.ProjectileStatus, enum: true
 end
 
 defmodule GameClient.Protobuf.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:color, 1, type: :string)
+  field :color, 1, type: :string
 end
 
 defmodule GameClient.Protobuf.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true)
-  field(:duration, 2, type: :uint64)
+  field :action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true
+  field :duration, 2, type: :uint64
 end
 
 defmodule GameClient.Protobuf.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:direction, 1, type: GameClient.Protobuf.Direction)
+  field :direction, 1, type: GameClient.Protobuf.Direction
 end
 
 defmodule GameClient.Protobuf.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:skill, 1, type: :string)
+  field :skill, 1, type: :string
 end
 
 defmodule GameClient.Protobuf.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:action_type, 0)
+  oneof :action_type, 0
 
-  field(:move, 1, type: GameClient.Protobuf.Move, oneof: 0)
-  field(:attack, 2, type: GameClient.Protobuf.Attack, oneof: 0)
-  field(:timestamp, 3, type: :int64)
+  field :move, 1, type: GameClient.Protobuf.Move, oneof: 0
+  field :attack, 2, type: GameClient.Protobuf.Attack, oneof: 0
+  field :timestamp, 3, type: :int64
 end
 
 defmodule GameClient.Protobuf.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:radius, 1, type: :float)
+  field :radius, 1, type: :float
 end
 
 defmodule GameClient.Protobuf.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:killer_id, 1, type: :uint64, json_name: "killerId")
-  field(:victim_id, 2, type: :uint64, json_name: "victimId")
+  field :killer_id, 1, type: :uint64, json_name: "killerId"
+  field :victim_id, 2, type: :uint64, json_name: "victimId"
 end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -1,328 +1,307 @@
 defmodule Gateway.Serialization.WebSocketRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:request_type, 0)
+  oneof :request_type, 0
 
-  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
+  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
 
-  field(:get_user_by_username, 2,
+  field :get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
-  )
 
-  field(:create_user, 3,
-    type: Gateway.Serialization.CreateUser,
-    json_name: "createUser",
-    oneof: 0
-  )
+  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
 
-  field(:get_campaigns, 4,
+  field :get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
-  )
 
-  field(:get_campaign, 5,
+  field :get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
-  )
 
-  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
+  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
+  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
+  field :select_unit, 8, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
 
-  field(:fight_level, 7,
-    type: Gateway.Serialization.FightLevel,
-    json_name: "fightLevel",
-    oneof: 0
-  )
-
-  field(:select_unit, 8,
-    type: Gateway.Serialization.SelectUnit,
-    json_name: "selectUnit",
-    oneof: 0
-  )
-
-  field(:unselect_unit, 9,
+  field :unselect_unit, 9,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
-  )
 
-  field(:equip_item, 10, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
+  field :equip_item, 10, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
 
-  field(:unequip_item, 11,
+  field :unequip_item, 11,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
-  )
 
-  field(:get_item, 12, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
+  field :get_item, 12, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
 
-  field(:level_up_item, 13,
+  field :level_up_item, 13,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.GetUser do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.CreateUser do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetCampaign do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:campaign_number, 2, type: :uint32, json_name: "campaignNumber")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :campaign_number, 2, type: :uint32, json_name: "campaignNumber"
 end
 
 defmodule Gateway.Serialization.GetLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.FightLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.SelectUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
-  field(:slot, 3, type: :uint32)
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
+  field :slot, 3, type: :uint32
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.EquipItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
-  field(:unit_id, 3, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
+  field :unit_id, 3, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.UnequipItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.GetItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof(:response_type, 0)
+  oneof :response_type, 0
 
-  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
-  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
-  field(:item, 3, type: Gateway.Serialization.Item, oneof: 0)
-  field(:campaigns, 4, type: Gateway.Serialization.Campaigns, oneof: 0)
-  field(:campaign, 5, type: Gateway.Serialization.Campaign, oneof: 0)
-  field(:level, 6, type: Gateway.Serialization.Level, oneof: 0)
+  field :user, 1, type: Gateway.Serialization.User, oneof: 0
+  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
+  field :item, 3, type: Gateway.Serialization.Item, oneof: 0
+  field :campaigns, 4, type: Gateway.Serialization.Campaigns, oneof: 0
+  field :campaign, 5, type: Gateway.Serialization.Campaign, oneof: 0
+  field :level, 6, type: Gateway.Serialization.Level, oneof: 0
 
-  field(:battle_result, 7,
+  field :battle_result, 7,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
-  )
 
-  field(:error, 8, type: Gateway.Serialization.Error, oneof: 0)
+  field :error, 8, type: Gateway.Serialization.Error, oneof: 0
 end
 
 defmodule Gateway.Serialization.User do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:id, 1, type: :string)
-  field(:username, 2, type: :string)
-  field(:currencies, 3, repeated: true, type: Gateway.Serialization.UserCurrency)
-  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
-  field(:items, 5, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :username, 2, type: :string
+  field :currencies, 3, repeated: true, type: Gateway.Serialization.UserCurrency
+  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
+  field :items, 5, repeated: true, type: Gateway.Serialization.Item
 end
 
 defmodule Gateway.Serialization.UserCurrency do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :uint32)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :uint32
 end
 
 defmodule Gateway.Serialization.Currency do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:name, 1, type: :string)
+  field :name, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Unit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:id, 1, type: :string)
-  field(:unit_level, 2, type: :uint32, json_name: "unitLevel")
-  field(:tier, 3, type: :uint32)
-  field(:selected, 4, type: :bool)
-  field(:slot, 5, type: :uint32)
-  field(:level_id, 6, type: :string, json_name: "levelId")
-  field(:user_id, 7, type: :string, json_name: "userId")
-  field(:character, 8, type: Gateway.Serialization.Character)
-  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :unit_level, 2, type: :uint32, json_name: "unitLevel"
+  field :tier, 3, type: :uint32
+  field :selected, 4, type: :bool
+  field :slot, 5, type: :uint32
+  field :level_id, 6, type: :string, json_name: "levelId"
+  field :user_id, 7, type: :string, json_name: "userId"
+  field :character, 8, type: Gateway.Serialization.Character
+  field :items, 9, repeated: true, type: Gateway.Serialization.Item
 end
 
 defmodule Gateway.Serialization.Character do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:active, 1, type: :bool)
-  field(:name, 2, type: :string)
-  field(:faction, 3, type: :string)
-  field(:rarity, 4, type: :string)
+  field :active, 1, type: :bool
+  field :name, 2, type: :string
+  field :faction, 3, type: :string
+  field :rarity, 4, type: :string
 end
 
 defmodule Gateway.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:id, 1, type: :string)
-  field(:level, 2, type: :uint32)
-  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
-  field(:user_id, 4, type: :string, json_name: "userId")
-  field(:unit_id, 5, type: :string, json_name: "unitId")
+  field :id, 1, type: :string
+  field :level, 2, type: :uint32
+  field :template, 3, type: Gateway.Serialization.ItemTemplate
+  field :user_id, 4, type: :string, json_name: "userId"
+  field :unit_id, 5, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:id, 1, type: :string)
-  field(:name, 2, type: :string)
-  field(:type, 3, type: :string)
+  field :id, 1, type: :string
+  field :name, 2, type: :string
+  field :type, 3, type: :string
 end
 
 defmodule Gateway.Serialization.Campaigns do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
+  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
 end
 
 defmodule Gateway.Serialization.Campaign do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:levels, 1, repeated: true, type: Gateway.Serialization.Level)
+  field :levels, 1, repeated: true, type: Gateway.Serialization.Level
 end
 
 defmodule Gateway.Serialization.Level do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:id, 1, type: :string)
-  field(:level_number, 2, type: :uint32, json_name: "levelNumber")
-  field(:campaign, 3, type: :uint32)
-  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
+  field :id, 1, type: :string
+  field :level_number, 2, type: :uint32, json_name: "levelNumber"
+  field :campaign, 3, type: :uint32
+  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
 end
 
 defmodule Gateway.Serialization.BattleResult do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:result, 1, type: :string)
+  field :result, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Error do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field(:reason, 1, type: :string)
+  field :reason, 1, type: :string
 end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -3,49 +3,57 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :request_type, 0
+  oneof(:request_type, 0)
 
-  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
+  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
 
-  field :get_user_by_username, 2,
+  field(:get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
+  )
 
-  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
+  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
 
-  field :get_campaigns, 4,
+  field(:get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
+  )
 
-  field :get_campaign, 5,
+  field(:get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
+  )
 
-  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
-  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
-  field :select_unit, 8, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
+  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
 
-  field :unselect_unit, 9,
+  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
+
+  field(:select_unit, 8, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
+
+  field(:unselect_unit, 9,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
+  )
 
-  field :equip_item, 10, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
+  field(:equip_item, 10, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
 
-  field :unequip_item, 11,
+  field(:unequip_item, 11,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
+  )
 
-  field :get_item, 12, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
+  field(:get_item, 12, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
 
-  field :level_up_item, 13,
+  field(:level_up_item, 13,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -53,7 +61,7 @@ defmodule Gateway.Serialization.GetUser do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
@@ -61,7 +69,7 @@ defmodule Gateway.Serialization.GetUserByUsername do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.CreateUser do
@@ -69,7 +77,7 @@ defmodule Gateway.Serialization.CreateUser do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
@@ -77,7 +85,7 @@ defmodule Gateway.Serialization.GetCampaigns do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetCampaign do
@@ -85,8 +93,8 @@ defmodule Gateway.Serialization.GetCampaign do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :campaign_number, 2, type: :uint32, json_name: "campaignNumber"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:campaign_number, 2, type: :uint32, json_name: "campaignNumber")
 end
 
 defmodule Gateway.Serialization.GetLevel do
@@ -94,8 +102,8 @@ defmodule Gateway.Serialization.GetLevel do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.FightLevel do
@@ -103,8 +111,8 @@ defmodule Gateway.Serialization.FightLevel do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -112,9 +120,9 @@ defmodule Gateway.Serialization.SelectUnit do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
-  field :slot, 3, type: :uint32
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field(:slot, 3, type: :uint32)
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
@@ -122,8 +130,8 @@ defmodule Gateway.Serialization.UnselectUnit do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.EquipItem do
@@ -131,9 +139,9 @@ defmodule Gateway.Serialization.EquipItem do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
-  field :unit_id, 3, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
+  field(:unit_id, 3, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.UnequipItem do
@@ -141,8 +149,8 @@ defmodule Gateway.Serialization.UnequipItem do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.GetItem do
@@ -150,8 +158,8 @@ defmodule Gateway.Serialization.GetItem do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
@@ -159,8 +167,8 @@ defmodule Gateway.Serialization.LevelUpItem do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
@@ -168,21 +176,22 @@ defmodule Gateway.Serialization.WebSocketResponse do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  oneof :response_type, 0
+  oneof(:response_type, 0)
 
-  field :user, 1, type: Gateway.Serialization.User, oneof: 0
-  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
-  field :item, 3, type: Gateway.Serialization.Item, oneof: 0
-  field :campaigns, 4, type: Gateway.Serialization.Campaigns, oneof: 0
-  field :campaign, 5, type: Gateway.Serialization.Campaign, oneof: 0
-  field :level, 6, type: Gateway.Serialization.Level, oneof: 0
+  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
+  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
+  field(:item, 3, type: Gateway.Serialization.Item, oneof: 0)
+  field(:campaigns, 4, type: Gateway.Serialization.Campaigns, oneof: 0)
+  field(:campaign, 5, type: Gateway.Serialization.Campaign, oneof: 0)
+  field(:level, 6, type: Gateway.Serialization.Level, oneof: 0)
 
-  field :battle_result, 7,
+  field(:battle_result, 7,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
+  )
 
-  field :error, 8, type: Gateway.Serialization.Error, oneof: 0
+  field(:error, 8, type: Gateway.Serialization.Error, oneof: 0)
 end
 
 defmodule Gateway.Serialization.User do
@@ -190,11 +199,11 @@ defmodule Gateway.Serialization.User do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :id, 1, type: :string
-  field :username, 2, type: :string
-  field :currencies, 3, repeated: true, type: Gateway.Serialization.UserCurrency
-  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
-  field :items, 5, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:username, 2, type: :string)
+  field(:currencies, 3, repeated: true, type: Gateway.Serialization.UserCurrency)
+  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
+  field(:items, 5, repeated: true, type: Gateway.Serialization.Item)
 end
 
 defmodule Gateway.Serialization.UserCurrency do
@@ -202,8 +211,8 @@ defmodule Gateway.Serialization.UserCurrency do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :uint32
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :uint32)
 end
 
 defmodule Gateway.Serialization.Currency do
@@ -211,7 +220,7 @@ defmodule Gateway.Serialization.Currency do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :name, 1, type: :string
+  field(:name, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Unit do
@@ -219,15 +228,15 @@ defmodule Gateway.Serialization.Unit do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :id, 1, type: :string
-  field :unit_level, 2, type: :uint32, json_name: "unitLevel"
-  field :tier, 3, type: :uint32
-  field :selected, 4, type: :bool
-  field :slot, 5, type: :uint32
-  field :level_id, 6, type: :string, json_name: "levelId"
-  field :user_id, 7, type: :string, json_name: "userId"
-  field :character, 8, type: Gateway.Serialization.Character
-  field :items, 9, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:unit_level, 2, type: :uint32, json_name: "unitLevel")
+  field(:tier, 3, type: :uint32)
+  field(:selected, 4, type: :bool)
+  field(:slot, 5, type: :uint32)
+  field(:level_id, 6, type: :string, json_name: "levelId")
+  field(:user_id, 7, type: :string, json_name: "userId")
+  field(:character, 8, type: Gateway.Serialization.Character)
+  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
 end
 
 defmodule Gateway.Serialization.Character do
@@ -235,10 +244,10 @@ defmodule Gateway.Serialization.Character do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :active, 1, type: :bool
-  field :name, 2, type: :string
-  field :faction, 3, type: :string
-  field :rarity, 4, type: :string
+  field(:active, 1, type: :bool)
+  field(:name, 2, type: :string)
+  field(:faction, 3, type: :string)
+  field(:rarity, 4, type: :string)
 end
 
 defmodule Gateway.Serialization.Item do
@@ -246,11 +255,11 @@ defmodule Gateway.Serialization.Item do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :id, 1, type: :string
-  field :level, 2, type: :uint32
-  field :template, 3, type: Gateway.Serialization.ItemTemplate
-  field :user_id, 4, type: :string, json_name: "userId"
-  field :unit_id, 5, type: :string, json_name: "unitId"
+  field(:id, 1, type: :string)
+  field(:level, 2, type: :uint32)
+  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
+  field(:user_id, 4, type: :string, json_name: "userId")
+  field(:unit_id, 5, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
@@ -258,9 +267,9 @@ defmodule Gateway.Serialization.ItemTemplate do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :id, 1, type: :string
-  field :name, 2, type: :string
-  field :type, 3, type: :string
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:type, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.Campaigns do
@@ -268,7 +277,7 @@ defmodule Gateway.Serialization.Campaigns do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
+  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
 end
 
 defmodule Gateway.Serialization.Campaign do
@@ -276,7 +285,7 @@ defmodule Gateway.Serialization.Campaign do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :levels, 1, repeated: true, type: Gateway.Serialization.Level
+  field(:levels, 1, repeated: true, type: Gateway.Serialization.Level)
 end
 
 defmodule Gateway.Serialization.Level do
@@ -284,10 +293,10 @@ defmodule Gateway.Serialization.Level do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :id, 1, type: :string
-  field :level_number, 2, type: :uint32, json_name: "levelNumber"
-  field :campaign, 3, type: :uint32
-  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
+  field(:id, 1, type: :string)
+  field(:level_number, 2, type: :uint32, json_name: "levelNumber")
+  field(:campaign, 3, type: :uint32)
+  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
 end
 
 defmodule Gateway.Serialization.BattleResult do
@@ -295,7 +304,7 @@ defmodule Gateway.Serialization.BattleResult do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :result, 1, type: :string
+  field(:result, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Error do
@@ -303,5 +312,5 @@ defmodule Gateway.Serialization.Error do
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  field :reason, 1, type: :string
+  field(:reason, 1, type: :string)
 end

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -85,6 +85,7 @@ message GameState {
   int64 server_timestamp = 5;
   Zone zone = 6;
   repeated KillEntry killfeed = 7;
+  map<uint64, Entity> power_ups = 8;
 }
 
 /*
@@ -117,6 +118,7 @@ message Entity {
     Player player = 12;
     Projectile projectile = 13;
     Obstacle obstacle = 14;
+    PowerUp power_up = 15;
   }
 }
 
@@ -145,6 +147,16 @@ enum ProjectileStatus {
 
 message Obstacle {
   string color = 1;
+}
+
+message PowerUp {
+  uint64 owner_id = 1;
+  PowerUpstatus status = 2;
+}
+
+enum  PowerUpstatus {
+  AVAILABLE = 0;
+  TAKEN = 1;
 }
 
 message PlayerAction {

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -129,6 +129,7 @@ message Player {
   uint64 stamina_interval = 6;
   bool recharging_stamina = 7;
   string character_name = 8;
+  uint64 power_ups = 9;
 }
 
 message Projectile {


### PR DESCRIPTION
Closes #267

Now whenever a player dies it'll drop a power up, the amount dropped will depend on how many power ups the player had at the moment hi dies

When a player walks over a power up it should pick him up 