### PR TITLE
Validate client_id when joining a game

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -285,9 +285,14 @@ defmodule Arena.GameUpdater do
   end
 
   def handle_call({:join, client_id}, _from, state) do
-    player_id = get_in(state.game_state, [:client_to_player_map, client_id])
-    response = %{player_id: player_id, game_config: state.game_config}
-    {:reply, {:ok, response}, state}
+    case get_in(state.game_state, [:client_to_player_map, client_id]) do
+      nil ->
+        {:reply, :not_a_client, state}
+
+      player_id ->
+        response = %{player_id: player_id, game_config: state.game_config}
+        {:reply, {:ok, response}, state}
+    end
   end
 
   ##########################


### PR DESCRIPTION
This will make it so if you try to join a game you need to know the `game_id` **and** a `client_id` of one of the users at the time it launched

In the case you don't pass a valid `client_id` this will crash the websocket for that connection (no reason to have a nice handling for bad behaviour)