### PR TITLE
Add duration to projectiles

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -61,7 +61,7 @@
       "mechanics": [
         {
           "simple_shoot": {
-            "duration_ms": 2000
+            "duration_ms": 1000
           }
         }
       ]
@@ -76,7 +76,7 @@
           "repeated_shoot": {
             "interval_ms": 250,
             "amount": 18,
-            "duration_ms": 2000,
+            "duration_ms": 1000,
             "remove_on_collision": true
           }
         }
@@ -92,7 +92,7 @@
           "multi_shoot": {
             "angle_between": 10.0,
             "amount": 3,
-            "duration_ms": 2000,
+            "duration_ms": 1000,
             "remove_on_collision": true
           }
         }

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -61,6 +61,7 @@
       "mechanics": [
         {
           "simple_shoot": {
+            "duration_ms": 2000
           }
         }
       ]
@@ -75,6 +76,7 @@
           "repeated_shoot": {
             "interval_ms": 250,
             "amount": 18,
+            "duration_ms": 2000,
             "remove_on_collision": true
           }
         }
@@ -90,6 +92,7 @@
           "multi_shoot": {
             "angle_between": 10.0,
             "amount": 3,
+            "duration_ms": 2000,
             "remove_on_collision": true
           }
         }


### PR DESCRIPTION
This change adds `duration_ms` field to projectiles config so then when spawning them we can setup a removal of them after that timeout

Also, slight refactoring on duplicated code for `repeated_shoot`