### PR TITLE
[GH-281] Add offset to projectiles

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -118,7 +118,7 @@ defmodule Arena.Game.Skill do
     projectile =
       Entities.new_projectile(
         last_id,
-        player.position,
+        get_real_projectile_spawn_position(player, repeated_shoot),
         player.direction,
         player.id,
         repeated_shoot.remove_on_collision
@@ -139,7 +139,7 @@ defmodule Arena.Game.Skill do
       projectile =
         Entities.new_projectile(
           last_id,
-          player.position,
+          get_real_projectile_spawn_position(player, multishot),
           direction,
           player.id,
           multishot.remove_on_collision
@@ -157,7 +157,13 @@ defmodule Arena.Game.Skill do
     last_id = game_state.last_id + 1
 
     projectile =
-      Entities.new_projectile(last_id, player.position, player.direction, player.id, true)
+      Entities.new_projectile(
+        last_id,
+        get_real_projectile_spawn_position(player, simple_shoot),
+        player.direction,
+        player.id,
+        true
+      )
 
     Process.send_after(self(), {:remove_projectile, projectile.id}, simple_shoot.duration_ms)
 
@@ -179,5 +185,12 @@ defmodule Arena.Game.Skill do
       end)
 
     Enum.concat([add_side, middle, sub_side])
+  end
+
+  defp get_real_projectile_spawn_position(spawner, specs) do
+    real_position_x = spawner.position.x + specs.projectile_offset * spawner.direction.x
+    real_position_y = spawner.position.y + specs.projectile_offset * spawner.direction.y
+
+    %{x: real_position_x, y: real_position_y}
   end
 end

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -61,7 +61,8 @@
       "mechanics": [
         {
           "simple_shoot": {
-            "duration_ms": 1000
+            "duration_ms": 1000,
+            "projectile_offset": 100
           }
         }
       ]
@@ -77,7 +78,8 @@
             "interval_ms": 250,
             "amount": 18,
             "duration_ms": 1000,
-            "remove_on_collision": true
+            "remove_on_collision": true,
+            "projectile_offset": 100
           }
         }
       ]
@@ -93,7 +95,8 @@
             "angle_between": 10.0,
             "amount": 3,
             "duration_ms": 1000,
-            "remove_on_collision": true
+            "remove_on_collision": true,
+            "projectile_offset": 100
           }
         }
       ]


### PR DESCRIPTION
We want a way to configure the projectiles so they don't spawn from the center of the character

Main:

https://github.com/lambdaclass/mirra_backend/assets/106101218/e5aeb081-e30c-44cd-9c8f-f2110b51ee92


This branch:


https://github.com/lambdaclass/mirra_backend/assets/106101218/5e4edfba-0dd3-488a-8282-ea7cc31c3f97

