### PR TITLE
Add intermediate step to expired projectiles

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -75,8 +75,26 @@ defmodule Arena.GameUpdater do
       |> Physics.move_entities(ticks_to_move, state.game_state.external_wall)
       |> update_collisions(game_state.players, %{})
 
+    # We need to send the exploded projectiles to the client at least once
+    updated_expired_projectiles =
+      game_state.projectiles
+      |> Enum.filter(fn {_projectile_id, projectile} ->
+        projectile.aditional_info.status == :EXPIRED
+      end)
+      |> Enum.reduce(%{}, fn {_projectile_id, projectile}, acc ->
+        projectile =
+          put_in(
+            projectile,
+            [:aditional_info, :status],
+            :EXPLODED
+          )
+
+        Map.put(acc, projectile.id, projectile)
+      end)
+
     projectiles =
-      remove_exploded_projectiles(game_state.projectiles)
+      game_state.projectiles
+      |> remove_exploded_and_expired_projectiles()
       |> Physics.move_entities(ticks_to_move, game_state.external_wall)
       |> update_collisions(
         game_state.projectiles,
@@ -84,6 +102,7 @@ defmodule Arena.GameUpdater do
           game_state.external_wall.id => game_state.external_wall
         })
       )
+      |> Map.merge(updated_expired_projectiles)
 
     # Resolve collisions between players and projectiles
     {projectiles, players} =
@@ -236,7 +255,7 @@ defmodule Arena.GameUpdater do
           put_in(
             state,
             [:game_state, :projectiles, projectile_id, :aditional_info, :status],
-            :EXPLODED
+            :EXPIRED
           )
 
         {:noreply, state}
@@ -488,9 +507,9 @@ defmodule Arena.GameUpdater do
     end
   end
 
-  def remove_exploded_projectiles(projectiles) do
-    Map.filter(projectiles, fn {_key, projectile} ->
-      projectile.aditional_info.status != :EXPLODED
+  def remove_exploded_and_expired_projectiles(projectiles) do
+    Map.reject(projectiles, fn {_key, projectile} ->
+      projectile.aditional_info.status in [:EXPLODED, :EXPIRED]
     end)
   end
 


### PR DESCRIPTION
After the merge of #279 We noticed in the client pr number [#1438](https://github.com/lambdaclass/curse_of_mirra/pull/1438) that the expired projectiles remained with the same bug, this is caused by the `game_update` deleting the expired projectile from the list without sending it with a `:EXPLODED` status not even once, so solve this we'll add the `:EXPIRED` intermediate status instead of `:EXPLODED`