### PR TITLE
Autobattle fights

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -288,9 +288,14 @@ defmodule Arena.GameUpdater do
   end
 
   def handle_call({:join, client_id}, _from, state) do
-    player_id = get_in(state.game_state, [:client_to_player_map, client_id])
-    response = %{player_id: player_id, game_config: state.game_config}
-    {:reply, {:ok, response}, state}
+    case get_in(state.game_state, [:client_to_player_map, client_id]) do
+      nil ->
+        {:reply, :not_a_client, state}
+
+      player_id ->
+        response = %{player_id: player_id, game_config: state.game_config}
+        {:reply, {:ok, response}, state}
+    end
   end
 
   ##########################

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -87,15 +87,14 @@ defmodule Arena.GameUpdater do
 
     # Resolve collisions between players and projectiles
     {projectiles, players} =
-      resolve_collisions(
+      resolve_projectile_collisions(
         projectiles,
         players,
         game_state.obstacles,
         game_state.external_wall.id
       )
 
-    players =
-      apply_zone_damage(players, game_state.zone, state.game_config.game)
+    players = apply_zone_damage(players, game_state.zone, state.game_config.game)
 
     game_state =
       game_state
@@ -516,9 +515,16 @@ defmodule Arena.GameUpdater do
   defp maybe_receive_zone_damage(player, _elaptime, _zone_damage_interval, _zone_damage),
     do: player
 
-  defp resolve_collisions(projectiles, players, obstacles, external_wall_id) do
-    Enum.reduce(projectiles, {projectiles, players}, fn {projectile_id, projectile},
-                                                        {projectiles_acc, players_acc} ->
+  # This method will decide what to do when a projectile has collided with something in the map
+  # - If collided with something with the same owner skip that collision
+  # - If collided with external wall or obstacle explode projectile
+  # - If collided with another player do the projectile's damage
+  # - Do nothing on unexpected cases
+  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id)
+
+  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id) do
+    Enum.reduce(projectiles, {projectiles, players}, fn {_projectile_id, projectile},
+                                                        {_projectiles_acc, players_acc} = accs ->
       # check if the projectiles is inside the walls
       collides_with =
         case projectile.collides_with do
@@ -529,51 +535,54 @@ defmodule Arena.GameUpdater do
       collided_entity =
         decide_collided_entity(projectile, collides_with, external_wall_id, players_acc)
 
-      # #247 Refactor projectile collision resolution
-      case {
-        collided_entity,
+      apply_collision_updates(
+        projectile,
         Map.get(players, collided_entity),
-        Map.get(obstacles, collided_entity)
-      } do
-        # Projectile hit nothing
-        {nil, nil, nil} ->
-          {projectiles_acc, players_acc}
-
-        # Projectile hit the external wall
-        {entity_id, _, _} when entity_id == external_wall_id ->
-          projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
-          {Map.put(projectiles_acc, projectile_id, projectile), players_acc}
-
-        # Projectile hit a player
-        {_entity_id, player, nil} ->
-          player = Player.change_health(player, projectile.aditional_info.damage)
-
-          projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
-
-          if player.aditional_info.health == 0 do
-            send(self(), {:to_killfeed, projectile.aditional_info.owner_id, player.id})
-          end
-
-          {
-            Map.put(projectiles_acc, projectile_id, projectile),
-            Map.put(players_acc, player.id, player)
-          }
-
-        # Projectile hit an obstacle
-        {_entity_id, nil, obstacle} when not is_nil(obstacle) ->
-          projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
-
-          {
-            Map.put(projectiles_acc, projectile_id, projectile),
-            players_acc
-          }
-
-        # Projectile hit something else
-        _ ->
-          {projectiles_acc, players_acc}
-      end
+        Map.get(obstacles, collided_entity),
+        collided_entity == external_wall_id,
+        accs
+      )
     end)
   end
+
+  defp apply_collision_updates(projectile, player, obstacle, collided_with_external_wall?, accs)
+
+  # Projectile collided an obstacle or went outside of the arena
+  defp apply_collision_updates(
+         projectile,
+         nil,
+         obstacle,
+         collided_with_external_wall?,
+         {projectiles_acc, players_acc}
+       )
+       when not is_nil(obstacle) or collided_with_external_wall? do
+    projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
+
+    {
+      Map.put(projectiles_acc, projectile.id, projectile),
+      players_acc
+    }
+  end
+
+  # Projectile collided a player
+  defp apply_collision_updates(projectile, player, _, _, {projectiles_acc, players_acc})
+       when not is_nil(player) do
+    player = Player.change_health(player, projectile.aditional_info.damage)
+
+    projectile = put_in(projectile, [:aditional_info, :status], :EXPLODED)
+
+    unless Player.alive?(player) do
+      send(self(), {:to_killfeed, projectile.aditional_info.owner_id, player.id})
+    end
+
+    {
+      Map.put(projectiles_acc, projectile.id, projectile),
+      Map.put(players_acc, player.id, player)
+    }
+  end
+
+  # Projectile didn't collide
+  defp apply_collision_updates(_, _, _, _, accs), do: accs
 
   defp decide_collided_entity(_projectile, [], _external_wall_id, _players), do: nil
 

--- a/apps/champions/lib/champions/battle.ex
+++ b/apps/champions/lib/champions/battle.ex
@@ -8,30 +8,6 @@ defmodule Champions.Battle do
   alias GameBackend.Campaigns
   alias GameBackend.Users
 
-  # @doc """
-  # Run an automatic battle between two users. Only validation done is for empty teams.
-
-  # Returns the id of the winner.
-  # """
-  # def pvp_battle(user_1, user_2) do
-  #   user_1_units = Units.get_selected_units(user_1)
-  #   user_2_units = Units.get_selected_units(user_2)
-
-  #   cond do
-  #     user_1_units == [] ->
-  #       {:error, {:user_1, :no_selected_units}}
-
-  #     user_2_units == [] ->
-  #       {:error, {:user_2, :no_selected_units}}
-
-  #     true ->
-  #       case battle(user_1_units, user_2_units) do
-  #         :team_1 -> user_1
-  #         :team_2 -> user_2
-  #       end
-  #   end
-  # end
-
   @doc """
   Plays a level for a user, which means fighting its units with their selected ones.
   Returns :win or :loss accordingly.

--- a/apps/champions/lib/champions/battle.ex
+++ b/apps/champions/lib/champions/battle.ex
@@ -10,7 +10,7 @@ defmodule Champions.Battle do
 
   @doc """
   Plays a level for a user, which means fighting its units with their selected ones.
-  Returns :win or :loss accordingly.
+  Returns `:win` or `:loss` accordingly.
 
   No tracking for level progress is done yet.
   """

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -45,6 +45,7 @@ defmodule Champions.Battle.Simulator do
   require Logger
 
   @maximum_steps 500
+  @ultimate_energy_cost 500
 
   @doc """
   Runs a battle between two teams.
@@ -143,7 +144,7 @@ defmodule Champions.Battle.Simulator do
   defp can_attack(_unit), do: true
 
   # Has enough energy?
-  defp can_cast_ultimate_skill(unit), do: unit.energy >= 500
+  defp can_cast_ultimate_skill(unit), do: unit.energy >= @ultimate_energy_cost
 
   # Is cooldown ready?
   defp can_cast_basic_skill(unit), do: unit.basic_skill.remaining_cooldown <= 0

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -6,7 +6,7 @@ defmodule Champions.Battle.Simulator do
   has no cooldown and it's cast whenever a unit reaches 500 energy. Energy is gained whenever the target attacks.
   The primary skill has a cooldown and it's cast when it's available if the ultimate is not.
 
-  Skills possess effects that affect other units' or oneself's stats (the on defined in the effect's `stat_affected` field).
+  Skills possess effects that affect other units' or oneself's stats (the one defined in the effect's `stat_affected` field).
 
   They have different application types (checked are implemented):
   [x] Instant - Applied once, irreversible.
@@ -26,6 +26,12 @@ defmodule Champions.Battle.Simulator do
   [ ] Backline - Heroes in slots 2 to 4
   [ ] Factions
   [ ] Classes
+
+  And different ways in which their amount is interpreted:
+  [x] Additive
+  [x] Multiplicative
+  [x] Additive & based on stat - The amount is a % of one of the caster's stats
+  [ ] Multiplicative & based on stat?
 
   Two units can attack the same unit at the same time and over-kill them. This is expected behavior that results
   from having the battle be simultaneous.

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -2,43 +2,50 @@ defmodule Champions.Battle.Simulator do
   @moduledoc """
   Runs battles.
   """
+  alias GameBackend.Units.Skills.Effect
+  alias GameBackend.Units.Skill
   alias Champions.Units
   alias GameBackend.Units.Unit
 
   require Logger
 
-  @maximum_ticks 500
+  @maximum_steps 500
 
   @doc """
-  team2 = Enum.map(1..6, fn _ -> {:ok, unit} = GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: mili_id})
+  user_1 = Champions.Users.register("User1")
+  user_2 = Champions.Users.register("User2")
+  team1 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
+  team2 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
+  Champions.Battle.Simulator.run_battle team1, team2
   """
   def run_battle(team_1, team_2) do
     unit_ids = team_1 ++ team_2
 
-    team_1 = Enum.into(team_1, %{}, fn unit -> create_unit(unit, 1) end)
-    team_2 = Enum.into(team_2, %{}, fn unit -> create_unit(unit, 2) end)
+    team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
+    team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)
     units = Map.merge(team_1, team_2) |> IO.inspect(label: :units)
 
-    Enum.reduce_while(1..@maximum_ticks, units, fn tick, units ->
+    Enum.reduce_while(1..@maximum_steps, units, fn step, units ->
       new_state =
         Enum.reduce(unit_ids, units, fn unit, units ->
-          Logger.log(:info, "Process tick #{tick} for unit #{unit.id}")
-          process_tick(unit, units)
+          Logger.log(:info, "Process step #{step} for unit #{unit.id}")
+          IO.inspect("Process step #{step} for unit #{unit.id}")
+          process_step(unit, units)
         end)
 
-      check_winner(new_state, tick)
+      check_winner(new_state, step)
     end)
   end
 
-  def process_tick(_unit, units) do
+  def process_step(_unit, units) do
     units
   end
 
-  def check_winner(units, tick) do
+  def check_winner(units, step) do
     winner =
       cond do
-        Enum.all?(units, &(&1.team == 1)) -> :team_1
-        Enum.all?(units, &(&1.team == 2)) -> :team_2
+        Enum.all?(units, fn {_id, unit} -> unit.team == 1 end) -> :team_1
+        Enum.all?(units, fn {_id, unit} -> unit.team == 2 end) -> :team_2
         true -> :none
       end
 
@@ -50,28 +57,41 @@ defmodule Champions.Battle.Simulator do
         {:halt, :team_2}
 
       :none ->
-        if tick == @maximum_ticks,
+        if step == @maximum_steps,
           # Challenger didn't win in the max time, so he lost
           do: {:halt, :team_2},
           else: {:cont, units}
     end
   end
 
-  defp create_unit(%Unit{character: character} = unit, team),
-    do:
+  defp create_unit_map(%Unit{character: character} = unit, team), do:
       {unit.id,
        %{
          max_health: Units.get_max_health(unit),
          health: Units.get_max_health(unit),
          attack: Units.get_attack(unit),
-         speed: Units.get_speed(unit),
          armor: Units.get_armor(unit),
          faction: character.faction,
          # class: character.class,
-         basic_skill: character.basic_skill,
-         ultimate_skill: character.ultimate_skill,
+         basic_skill: create_skill_map(character.basic_skill),
+         ultimate_skill: create_skill_map(character.ultimate_skill),
          energy: 0,
-         ticks_to_next_attack: 5,
          team: team
        }}
+
+  defp create_skill_map(%Skill{} = skill), do:
+    %{
+      targeting_strategy: skill.targeting_strategy,
+      amount_of_targets: skill.amount_of_targets,
+      effects: Enum.map(skill.effects, &create_effect_map/1)
+    }
+
+  defp create_effect_map(%Effect{} = effect), do:
+  %{
+    type: effect.type,
+    stat: effect.stat,
+    based_on_stat: effect.based_on_stat,
+    amount: effect.amount,
+    application_type: effect.application_type
+  }
 end

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -73,7 +73,6 @@ defmodule Champions.Battle.Simulator do
       new_state =
         initial_step_state
         |> Enum.map(fn {id, _unit} -> id end)
-        |> Enum.take_random(Enum.count(units))
         |> Enum.reduce(initial_step_state, fn unit_id, current_state ->
           process_step(initial_step_state[unit_id], initial_step_state, current_state)
         end)

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -1,0 +1,74 @@
+defmodule Champions.Battle.Simulator do
+  @moduledoc """
+  Runs battles.
+  """
+  alias Champions.Units
+  alias GameBackend.Units.Unit
+
+  require Logger
+
+  @maximum_ticks 500
+
+  def run_battle(team_1, team_2) do
+    unit_ids = team_1 + team_2
+
+    team_1 = Enum.into(team_1, %{team: 1}, &create_unit/1)
+    team_2 = Enum.into(team_1, %{team: 2}, &create_unit/1)
+    units = Map.merge(team_1, team_2)
+
+    Enum.reduce_while(1..@maximum_ticks, units, fn tick, units ->
+      new_state =
+        Enum.reduce(unit_ids, units, fn unit, units ->
+          Logger.log(:info, "Process tick #{tick} for unit #{unit}")
+          process_tick(unit, units)
+        end)
+
+      check_winner(new_state, tick)
+    end)
+  end
+
+  def process_tick(_unit, units) do
+    units
+  end
+
+  def check_winner(units, tick) do
+    winner =
+      cond do
+        Enum.all?(units, &(&1.team == 1)) -> :team_1
+        Enum.all?(units, &(&1.team == 2)) -> :team_2
+        true -> :none
+      end
+
+    case winner do
+      :team_1 ->
+        {:halt, :team_1}
+
+      :team_2 ->
+        {:halt, :team_2}
+
+      :none ->
+        if tick == @maximum_ticks,
+          # Challenger didn't win in the max time, so he lost
+          do: {:halt, :team_2},
+          else: {:cont, units}
+    end
+  end
+
+  defp create_unit(%Unit{character: character} = unit),
+    do:
+      {unit.id,
+       %{
+         max_health: Units.get_max_health(unit),
+         health: Units.get_max_health(unit),
+         attack: Units.get_attack(unit),
+         speed: Units.get_speed(unit),
+         armor: Units.get_armor(unit),
+         faction: character.faction,
+         # class: character.class,
+         basic_skill: character.basic_skill,
+         ultimate_skill: character.ultimate_skill,
+         energy: 0,
+         ticks_to_next_attack: character.speed,
+         target_strategy: character.target_strategy
+       }}
+end

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -23,12 +23,11 @@ defmodule Champions.Battle.Simulator do
 
     team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
     team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)
-    units = Map.merge(team_1, team_2) |> IO.inspect(label: :units)
+    units = Map.merge(team_1, team_2)
 
     Enum.reduce_while(1..@maximum_steps, units, fn step, units ->
       new_state =
         Enum.reduce(unit_ids, units, fn unit, units ->
-          Logger.log(:info, "Process step #{step} for unit #{unit.id}")
           IO.inspect("Process step #{step} for unit #{unit.id}")
           process_step(unit, units)
         end)

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -88,12 +88,12 @@ defmodule Champions.Battle.Simulator do
         not can_attack(unit) ->
           current_state
 
-        can_cast_ultimate(unit) ->
+        can_cast_ultimate_skill(unit) ->
           unit
           |> cast_skill(unit.ultimate_skill, initial_step_state, current_state)
           |> put_in([unit.id, :energy], 0)
 
-        can_cast_basic(unit) ->
+        can_cast_basic_skill(unit) ->
           new_state = cast_skill(unit, unit.basic_skill, initial_step_state, current_state)
 
           new_state
@@ -143,10 +143,10 @@ defmodule Champions.Battle.Simulator do
   defp can_attack(_unit), do: true
 
   # Has enough energy?
-  defp can_cast_ultimate(unit), do: unit.energy >= 500
+  defp can_cast_ultimate_skill(unit), do: unit.energy >= 500
 
   # Is cooldown ready?
-  defp can_cast_basic(unit), do: unit.basic_skill.remaining_cooldown <= 0
+  defp can_cast_basic_skill(unit), do: unit.basic_skill.remaining_cooldown <= 0
 
   defp cast_skill(unit, skill, initial_step_state, current_state) do
     target_ids = choose_targets(unit, skill, initial_step_state)

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -12,37 +12,22 @@ defmodule Champions.Battle.Simulator do
   @maximum_steps 500
 
   @doc """
-  user_1 = Champions.Users.register("User1")
-  user_2 = Champions.Users.register("User2")
-  team1 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
-  team2 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
-  Champions.Battle.Simulator.run_battle team1, team2
-  """
-  def run_battle(team_1, team_2) do
-    unit_ids = Enum.map(team_1 ++ team_2, fn unit -> unit.id end)
 
+  """
+  def run_battle(team_1, team_2, seed \\ 1234) do
+    :rand.seed(:default, seed)
     team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
     team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)
     units = Map.merge(team_1, team_2)
 
     Enum.reduce_while(1..@maximum_steps, units, fn step, initial_step_state ->
       new_state =
-        units
+        initial_step_state
         |> Enum.map(fn {id, _unit} -> id end)
-        |> Enum.take_random(Enum.count(unit_ids))
+        |> Enum.take_random(Enum.count(units))
         |> Enum.reduce(initial_step_state, fn unit_id, current_state ->
-          IO.inspect("Process step #{step} for unit #{unit_id}")
           process_step(initial_step_state[unit_id], initial_step_state, current_state)
         end)
-
-      IO.inspect(
-        new_state
-        |> Enum.map(fn {_id, unit} ->
-          Map.take(unit, [:id, :health, :energy])
-          |> Map.put(:skill_cooldown, unit.basic_skill.remaining_cooldown)
-        end),
-        label: :new_state
-      )
 
       remove_dead_units(new_state)
       |> check_winner(step)
@@ -58,13 +43,11 @@ defmodule Champions.Battle.Simulator do
           current_state
 
         can_cast_ultimate(unit) ->
-          IO.inspect("#{unit.id} casting ULTIMATE skill")
           unit
           |> cast_skill(unit.ultimate_skill, initial_step_state, current_state)
           |> put_in([unit.id, :energy], 0)
 
         can_cast_basic(unit) ->
-          IO.inspect("#{unit.id} casting basic skill")
           new_state = cast_skill(unit, unit.basic_skill, initial_step_state, current_state)
 
           new_state
@@ -93,22 +76,20 @@ defmodule Champions.Battle.Simulator do
   defp check_winner(units, step) do
     winner =
       cond do
-        Enum.all?(units, fn {_id, unit} -> unit.team == 1 end) -> :team_1
+        Enum.empty?(units) -> :tie
         Enum.all?(units, fn {_id, unit} -> unit.team == 2 end) -> :team_2
+        Enum.all?(units, fn {_id, unit} -> unit.team == 1 end) -> :team_1
         true -> :none
       end
 
     case winner do
-      :team_1 ->
-        {:halt, :team_1}
-
-      :team_2 ->
-        {:halt, :team_2}
-
       :none ->
         if step == @maximum_steps,
           do: {:halt, :timeout},
           else: {:cont, units}
+
+      result ->
+        {:halt, result}
     end
   end
 
@@ -176,7 +157,7 @@ defmodule Champions.Battle.Simulator do
        ),
        do:
          target[String.to_atom(effect.stat_affected)] +
-           effect.amount * caster[String.to_atom(stat_based_on)] / 100
+           floor(effect.amount * caster[String.to_atom(stat_based_on)] / 100)
 
   defp create_unit_map(%Unit{character: character} = unit, team),
     do:

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -9,17 +9,20 @@ defmodule Champions.Battle.Simulator do
 
   @maximum_ticks 500
 
+  @doc """
+  team2 = Enum.map(1..6, fn _ -> {:ok, unit} = GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: mili_id})
+  """
   def run_battle(team_1, team_2) do
-    unit_ids = team_1 + team_2
+    unit_ids = team_1 ++ team_2
 
-    team_1 = Enum.into(team_1, %{team: 1}, &create_unit/1)
-    team_2 = Enum.into(team_1, %{team: 2}, &create_unit/1)
-    units = Map.merge(team_1, team_2)
+    team_1 = Enum.into(team_1, %{}, fn unit -> create_unit(unit, 1) end)
+    team_2 = Enum.into(team_2, %{}, fn unit -> create_unit(unit, 2) end)
+    units = Map.merge(team_1, team_2) |> IO.inspect(label: :units)
 
     Enum.reduce_while(1..@maximum_ticks, units, fn tick, units ->
       new_state =
         Enum.reduce(unit_ids, units, fn unit, units ->
-          Logger.log(:info, "Process tick #{tick} for unit #{unit}")
+          Logger.log(:info, "Process tick #{tick} for unit #{unit.id}")
           process_tick(unit, units)
         end)
 
@@ -54,7 +57,7 @@ defmodule Champions.Battle.Simulator do
     end
   end
 
-  defp create_unit(%Unit{character: character} = unit),
+  defp create_unit(%Unit{character: character} = unit, team),
     do:
       {unit.id,
        %{
@@ -68,7 +71,7 @@ defmodule Champions.Battle.Simulator do
          basic_skill: character.basic_skill,
          ultimate_skill: character.ultimate_skill,
          energy: 0,
-         ticks_to_next_attack: character.speed,
-         target_strategy: character.target_strategy
+         ticks_to_next_attack: 5,
+         team: team
        }}
 end

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -14,33 +14,83 @@ defmodule Champions.Battle.Simulator do
   @doc """
   user_1 = Champions.Users.register("User1")
   user_2 = Champions.Users.register("User2")
-  team1 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
-  team2 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
+  team1 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
+  team2 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
   Champions.Battle.Simulator.run_battle team1, team2
   """
   def run_battle(team_1, team_2) do
-    unit_ids = team_1 ++ team_2
+    unit_ids = Enum.map(team_1 ++ team_2, fn unit -> unit.id end)
 
     team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
     team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)
     units = Map.merge(team_1, team_2)
 
-    Enum.reduce_while(1..@maximum_steps, units, fn step, units ->
+    Enum.reduce_while(1..@maximum_steps, units, fn step, initial_step_state ->
       new_state =
-        Enum.reduce(unit_ids, units, fn unit, units ->
-          IO.inspect("Process step #{step} for unit #{unit.id}")
-          process_step(unit, units)
+        units
+        |> Enum.map(fn {id, _unit} -> id end)
+        |> Enum.take_random(Enum.count(unit_ids))
+        |> Enum.reduce(initial_step_state, fn unit_id, current_state ->
+          IO.inspect("Process step #{step} for unit #{unit_id}")
+          process_step(initial_step_state[unit_id], initial_step_state, current_state)
         end)
 
-      check_winner(new_state, step)
+      IO.inspect(
+        new_state
+        |> Enum.map(fn {_id, unit} ->
+          Map.take(unit, [:id, :health, :energy])
+          |> Map.put(:skill_cooldown, unit.basic_skill.remaining_cooldown)
+        end),
+        label: :new_state
+      )
+
+      remove_dead_units(new_state)
+      |> check_winner(step)
     end)
   end
 
-  def process_step(_unit, units) do
-    units
+  # initial_step_state: List of units. What we base our decisions on.
+  # current_state: List of units. What we actually modify.
+  defp process_step(unit, initial_step_state, current_state) do
+    new_state =
+      cond do
+        not can_attack(unit) ->
+          current_state
+
+        can_cast_ultimate(unit) ->
+          IO.inspect("#{unit.id} casting ULTIMATE skill")
+          unit
+          |> cast_skill(unit.ultimate_skill, initial_step_state, current_state)
+          |> put_in([unit.id, :energy], 0)
+
+        can_cast_basic(unit) ->
+          IO.inspect("#{unit.id} casting basic skill")
+          new_state = cast_skill(unit, unit.basic_skill, initial_step_state, current_state)
+
+          new_state
+          |> put_in(
+            [unit.id, :basic_skill, :remaining_cooldown],
+            unit.basic_skill.base_cooldown + 1
+          )
+          |> put_in([unit.id, :energy], new_state[unit.id][:energy] + 75)
+
+        true ->
+          current_state
+      end
+
+    put_in(
+      new_state,
+      [unit.id, :basic_skill, :remaining_cooldown],
+      max(new_state[unit.id].basic_skill.remaining_cooldown - 1, 0)
+    )
+
+    # decrease_effects_remaining_steps(unit, current_state)
   end
 
-  def check_winner(units, step) do
+  defp remove_dead_units(units),
+    do: Enum.filter(units, fn {_id, unit} -> unit.health > 0 end) |> Enum.into(%{})
+
+  defp check_winner(units, step) do
     winner =
       cond do
         Enum.all?(units, fn {_id, unit} -> unit.team == 1 end) -> :team_1
@@ -57,15 +107,82 @@ defmodule Champions.Battle.Simulator do
 
       :none ->
         if step == @maximum_steps,
-          # Challenger didn't win in the max time, so he lost
-          do: {:halt, :team_2},
+          do: {:halt, :timeout},
           else: {:cont, units}
     end
   end
 
-  defp create_unit_map(%Unit{character: character} = unit, team), do:
+  # Is immobilized?
+  defp can_attack(_unit), do: true
+
+  # Has energy?
+  defp can_cast_ultimate(unit), do: unit.energy >= 500
+
+  # Is cooldown ready?
+  defp can_cast_basic(unit), do: unit.basic_skill.remaining_cooldown <= 0
+
+  defp cast_skill(unit, skill, initial_step_state, current_state) do
+    Enum.reduce(skill.effects, current_state, fn effect, new_state ->
+      target_ids = choose_targets(unit, effect, initial_step_state)
+
+      targets_after_effect =
+        Enum.map(target_ids, fn id -> apply_effect(effect, unit, new_state[id]) end)
+
+      Enum.reduce(targets_after_effect, new_state, fn target_unit, acc_state ->
+        Map.put(acc_state, target_unit.id, target_unit)
+      end)
+    end)
+  end
+
+  defp choose_targets(
+         %{team: team},
+         %{
+           targeting_strategy: "random",
+           targets_allies: targets_allies,
+           amount_of_targets: amount
+         } =
+           _effect,
+         state
+       ),
+       do:
+         state
+         |> Enum.filter(fn {_id, unit} -> unit.team == team == targets_allies end)
+         |> Enum.take_random(amount)
+         |> Enum.map(fn {id, _unit} -> id end)
+
+  defp apply_effect(%{type: "instant"} = effect, caster, target) do
+    new_value = calculate_value(effect, caster, target)
+    Map.put(target, String.to_atom(effect.stat_affected), new_value)
+  end
+
+  defp calculate_value(
+         %{amount_format: "additive", stat_based_on: nil} = effect,
+         _caster,
+         target
+       ),
+       do: target[String.to_atom(effect.stat_affected)] + effect.amount
+
+  defp calculate_value(
+         %{amount_format: "multiplicative", stat_based_on: nil} = effect,
+         _caster,
+         target
+       ),
+       do: target[String.to_atom(effect.stat_affected)] * effect.amount
+
+  defp calculate_value(
+         %{amount_format: "additive", stat_based_on: stat_based_on} = effect,
+         caster,
+         target
+       ),
+       do:
+         target[String.to_atom(effect.stat_affected)] +
+           effect.amount * caster[String.to_atom(stat_based_on)] / 100
+
+  defp create_unit_map(%Unit{character: character} = unit, team),
+    do:
       {unit.id,
        %{
+         id: unit.id,
          max_health: Units.get_max_health(unit),
          health: Units.get_max_health(unit),
          attack: Units.get_attack(unit),
@@ -78,19 +195,22 @@ defmodule Champions.Battle.Simulator do
          team: team
        }}
 
-  defp create_skill_map(%Skill{} = skill), do:
-    %{
-      targeting_strategy: skill.targeting_strategy,
-      amount_of_targets: skill.amount_of_targets,
-      effects: Enum.map(skill.effects, &create_effect_map/1)
+  defp create_skill_map(%Skill{} = skill),
+    do: %{
+      effects: Enum.map(skill.effects, &create_effect_map/1),
+      base_cooldown: skill.cooldown,
+      remaining_cooldown: skill.cooldown
     }
 
-  defp create_effect_map(%Effect{} = effect), do:
-  %{
-    type: effect.type,
-    stat: effect.stat,
-    based_on_stat: effect.based_on_stat,
-    amount: effect.amount,
-    application_type: effect.application_type
-  }
+  defp create_effect_map(%Effect{} = effect),
+    do: %{
+      type: effect.type,
+      stat_affected: effect.stat_affected,
+      stat_based_on: effect.stat_based_on,
+      amount: effect.amount,
+      amount_format: effect.amount_format,
+      targeting_strategy: effect.targeting_strategy,
+      amount_of_targets: effect.amount_of_targets,
+      targets_allies: effect.targets_allies
+    }
 end

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -1,6 +1,35 @@
 defmodule Champions.Battle.Simulator do
   @moduledoc """
   Runs battles.
+
+  Units have stats that are calculated on battle start (Attack, Max Health, Armor), as well as two skills. The ultimate
+  has no cooldown and it's cast whenever a unit reaches 500 energy. Energy is gained whenever the target attacks.
+  The primary skill has a cooldown and it's cast when it's available if the ultimate is not.
+
+  Skills possess effects that affect other units' or oneself's stats (the on defined in the effect's `stat_affected` field).
+
+  They have different application types (checked are implemented):
+  [x] Instant - Applied once, irreversible.
+  [ ] Permanent - Applied once, is stored in the unit so that it can be reversed (with a dispel, for example)
+  [ ] Duration - Applied once and reverted once its duration ends.
+  [ ] Periodic - Applied many times every x number of steps for a total duration of y steps
+
+  They also have different targeting strategies:
+  [x] Random
+  [ ] Nearest
+  [ ] Furthest
+  [ ] Min Health
+  [ ] Max Health
+  [ ] Min Shield
+  [ ] Max Shield
+  [ ] Frontline - Heroes in slots 1 and 2
+  [ ] Backline - Heroes in slots 2 to 4
+  [ ] Factions
+  [ ] Classes
+
+  Two units can attack the same unit at the same time and over-kill them. This is expected behavior that results
+  from having the battle be simultaneous.
+
   """
   alias GameBackend.Units.Skills.Effect
   alias GameBackend.Units.Skill
@@ -12,14 +41,27 @@ defmodule Champions.Battle.Simulator do
   @maximum_steps 500
 
   @doc """
+  Runs a battle between two teams.
+  Teams are expected to be lists of units with their character and their skills preloaded.
 
+  Returns `:team_1`, `:team_2`, `:tie` or `:timeout`.
+
+  ## Examples
+
+      iex> team_1 = Enum.map(user1.units, GameBackend.Repo.preload([character: [:basic_skill, :ultimate_skill]]))
+      iex> team_2 = Enum.map(user2.units, GameBackend.Repo.preload([character: [:basic_skill, :ultimate_skill]]))
+      iex> run_battle(team_1, team_2)
+      :team_1
   """
-  def run_battle(team_1, team_2, seed \\ 1234) do
+  def run_battle(team_1, team_2, seed \\ 1) do
     :rand.seed(:default, seed)
     team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
     team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)
     units = Map.merge(team_1, team_2)
 
+    # The initial_step_state is what allows the battle to be simultaneous. If we refreshed the accum on every action,
+    # we would be left with a turn-based battle. Instead we take decisions based on the state of the battle at the beggining
+    # of the step regardless of the changes that happened "before" (execution-wise) in this step.
     Enum.reduce_while(1..@maximum_steps, units, fn step, initial_step_state ->
       new_state =
         initial_step_state
@@ -34,8 +76,6 @@ defmodule Champions.Battle.Simulator do
     end)
   end
 
-  # initial_step_state: List of units. What we base our decisions on.
-  # current_state: List of units. What we actually modify.
   defp process_step(unit, initial_step_state, current_state) do
     new_state =
       cond do
@@ -67,7 +107,7 @@ defmodule Champions.Battle.Simulator do
       max(new_state[unit.id].basic_skill.remaining_cooldown - 1, 0)
     )
 
-    # decrease_effects_remaining_steps(unit, current_state)
+    # TODO: decrease_effects_remaining_steps(unit, current_state)
   end
 
   defp remove_dead_units(units),
@@ -93,18 +133,24 @@ defmodule Champions.Battle.Simulator do
     end
   end
 
-  # Is immobilized?
+  # TODO: Is immobilized?
   defp can_attack(_unit), do: true
 
-  # Has energy?
+  # Has enough energy?
   defp can_cast_ultimate(unit), do: unit.energy >= 500
 
   # Is cooldown ready?
   defp can_cast_basic(unit), do: unit.basic_skill.remaining_cooldown <= 0
 
   defp cast_skill(unit, skill, initial_step_state, current_state) do
+    target_ids = choose_targets(unit, skill, initial_step_state)
+
     Enum.reduce(skill.effects, current_state, fn effect, new_state ->
-      target_ids = choose_targets(unit, effect, initial_step_state)
+      # If skill doesn't have targeting strategy, we fall back to the effects'
+      target_ids =
+        if is_nil(target_ids),
+          do: choose_targets(unit, effect, initial_step_state),
+          else: target_ids
 
       targets_after_effect =
         Enum.map(target_ids, fn id -> apply_effect(effect, unit, new_state[id]) end)
@@ -114,6 +160,8 @@ defmodule Champions.Battle.Simulator do
       end)
     end)
   end
+
+  defp choose_targets(_unit, %{targeting_strategy: nil}, _state), do: nil
 
   defp choose_targets(
          %{team: team},
@@ -180,7 +228,10 @@ defmodule Champions.Battle.Simulator do
     do: %{
       effects: Enum.map(skill.effects, &create_effect_map/1),
       base_cooldown: skill.cooldown,
-      remaining_cooldown: skill.cooldown
+      remaining_cooldown: skill.cooldown,
+      targeting_strategy: skill.targeting_strategy,
+      amount_of_targets: skill.amount_of_targets,
+      targets_allies: skill.targets_allies
     }
 
   defp create_effect_map(%Effect{} = effect),

--- a/apps/champions/lib/champions/units.ex
+++ b/apps/champions/lib/champions/units.ex
@@ -45,15 +45,6 @@ defmodule Champions.Units do
   end
 
   @doc """
-  Get a unit's speed stat for battle. Buffs from items and similar belong here.
-
-  For now, we just return the base character's stat.
-  """
-  def get_speed(unit) do
-    unit.character.base_speed
-  end
-
-  @doc """
   Get a unit's armor stat for battle. Buffs from items and similar belong here.
 
   For now, we just return the base character's stat.

--- a/apps/champions/lib/champions/units.ex
+++ b/apps/champions/lib/champions/units.ex
@@ -25,4 +25,40 @@ defmodule Champions.Units do
   def unselect_unit(user_id, unit_id) do
     Units.unselect_unit(user_id, unit_id)
   end
+
+  @doc """
+  Get a unit's max health stat for battle. Buffs from items and similar belong here.
+
+  For now, we just return the base character's stat.
+  """
+  def get_max_health(unit) do
+    unit.character.base_health
+  end
+
+  @doc """
+  Get a unit's attack stat for battle. Buffs from items and similar belong here.
+
+  For now, we just return the base character's stat.
+  """
+  def get_attack(unit) do
+    unit.character.base_attack
+  end
+
+  @doc """
+  Get a unit's speed stat for battle. Buffs from items and similar belong here.
+
+  For now, we just return the base character's stat.
+  """
+  def get_speed(unit) do
+    unit.character.base_speed
+  end
+
+  @doc """
+  Get a unit's armor stat for battle. Buffs from items and similar belong here.
+
+  For now, we just return the base character's stat.
+  """
+  def get_armor(unit) do
+    unit.character.base_armor
+  end
 end

--- a/apps/game_backend/lib/game_backend/units/characters/character.ex
+++ b/apps/game_backend/lib/game_backend/units/characters/character.ex
@@ -6,6 +6,8 @@ defmodule GameBackend.Units.Characters.Character do
   use GameBackend.Schema
   import Ecto.Changeset
 
+  alias GameBackend.Units.Skill
+
   @derive {Jason.Encoder, only: [:active, :name, :faction, :rarity]}
   schema "characters" do
     field(:game_id, :integer)
@@ -14,13 +16,35 @@ defmodule GameBackend.Units.Characters.Character do
     field(:faction, :string)
     field(:rarity, :string)
 
+    field(:base_health, :integer)
+    field(:base_attack, :integer)
+    field(:base_speed, :integer)
+    field(:base_armor, :integer)
+
+    belongs_to(:basic_skill, Skill)
+    belongs_to(:ultimate_skill, Skill)
+
     timestamps()
   end
 
   @doc false
   def changeset(character, attrs) do
     character
-    |> cast(attrs, [:game_id, :name, :active, :faction, :rarity])
+    |> cast(attrs, [
+      :game_id,
+      :name,
+      :active,
+      :faction,
+      :rarity,
+      :basic_skill_id,
+      :ultimate_skill_id,
+      :base_health,
+      :base_attack,
+      :base_speed,
+      :base_armor
+    ])
+    |> cast_assoc(:basic_skill)
+    |> cast_assoc(:ultimate_skill)
     |> validate_required([:game_id, :name, :active, :faction])
   end
 end

--- a/apps/game_backend/lib/game_backend/units/characters/character.ex
+++ b/apps/game_backend/lib/game_backend/units/characters/character.ex
@@ -18,7 +18,6 @@ defmodule GameBackend.Units.Characters.Character do
 
     field(:base_health, :integer)
     field(:base_attack, :integer)
-    field(:base_speed, :integer)
     field(:base_armor, :integer)
 
     belongs_to(:basic_skill, Skill)
@@ -40,7 +39,6 @@ defmodule GameBackend.Units.Characters.Character do
       :ultimate_skill_id,
       :base_health,
       :base_attack,
-      :base_speed,
       :base_armor
     ])
     |> cast_assoc(:basic_skill)

--- a/apps/game_backend/lib/game_backend/units/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skill.ex
@@ -5,12 +5,9 @@ defmodule GameBackend.Units.Skill do
   import Ecto.Changeset
 
   alias GameBackend.Units.Skills.Effect
-  alias GameBackend.Units.Skills.TargetingStrategy
 
   schema "skills" do
     embeds_many(:effects, Effect)
-    field(:targeting_strategy, TargetingStrategy)
-    field(:amount_of_targets, :integer)
     field(:cooldown, :integer)
     timestamps()
   end
@@ -18,8 +15,7 @@ defmodule GameBackend.Units.Skill do
   @doc false
   def changeset(skill, attrs \\ %{}) do
     skill
-    |> cast(attrs, [:targeting_strategy, :amount_of_targets])
+    |> cast(attrs, [:cooldown])
     |> cast_embed(:effects)
-    |> validate_required([:targeting_strategy])
   end
 end

--- a/apps/game_backend/lib/game_backend/units/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skill.ex
@@ -5,9 +5,13 @@ defmodule GameBackend.Units.Skill do
   import Ecto.Changeset
 
   alias GameBackend.Units.Skills.Effect
+  alias GameBackend.Units.Skills.TargetingStrategy
 
   schema "skills" do
     embeds_many(:effects, Effect)
+    field(:targeting_strategy, TargetingStrategy)
+    field(:targets_allies, :boolean)
+    field(:amount_of_targets, :integer)
     field(:cooldown, :integer)
     timestamps()
   end
@@ -15,7 +19,7 @@ defmodule GameBackend.Units.Skill do
   @doc false
   def changeset(skill, attrs \\ %{}) do
     skill
-    |> cast(attrs, [:cooldown])
+    |> cast(attrs, [:targeting_strategy, :amount_of_targets])
     |> cast_embed(:effects)
   end
 end

--- a/apps/game_backend/lib/game_backend/units/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skill.ex
@@ -1,0 +1,24 @@
+defmodule GameBackend.Units.Skill do
+  @moduledoc false
+
+  use GameBackend.Schema
+  import Ecto.Changeset
+
+  alias GameBackend.Units.Skills.Effect
+  alias GameBackend.Units.Skills.TargetingStrategy
+
+  schema "skills" do
+    embeds_many(:effects, Effect)
+    field(:targeting_strategy, TargetingStrategy)
+    field(:amount_of_targets, :integer)
+    timestamps()
+  end
+
+  @doc false
+  def changeset(skill, attrs \\ %{}) do
+    skill
+    |> cast(attrs, [:targeting_strategy, :amount_of_targets])
+    |> cast_embed(:effects)
+    |> validate_required([:targeting_strategy])
+  end
+end

--- a/apps/game_backend/lib/game_backend/units/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skill.ex
@@ -19,7 +19,7 @@ defmodule GameBackend.Units.Skill do
   @doc false
   def changeset(skill, attrs \\ %{}) do
     skill
-    |> cast(attrs, [:targeting_strategy, :amount_of_targets])
+    |> cast(attrs, [:targeting_strategy, :amount_of_targets, :cooldown, :targets_allies])
     |> cast_embed(:effects)
   end
 end

--- a/apps/game_backend/lib/game_backend/units/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skill.ex
@@ -11,6 +11,7 @@ defmodule GameBackend.Units.Skill do
     embeds_many(:effects, Effect)
     field(:targeting_strategy, TargetingStrategy)
     field(:amount_of_targets, :integer)
+    field(:cooldown, :integer)
     timestamps()
   end
 

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -4,24 +4,46 @@ defmodule GameBackend.Units.Skills.Effect do
   use GameBackend.Schema
   import Ecto.Changeset
 
+  alias GameBackend.Units.Skills.TargetingStrategy
   alias GameBackend.Units.Skills.Type
 
   @primary_key false
   embedded_schema do
     field(:type, Type)
-    field(:stat, :string)
-    field(:based_on_stat, :string) # amount will be treated as the % of this stat if its set
+
+    field(:stat_affected, :string)
+    # amount will be treated as the % of this stat if its set
+    field(:stat_based_on, :string)
     field(:amount, :integer)
-    field(:application_type, :string)
+    field(:amount_format, :string)
+    field(:amount_of_targets, :integer)
+    field(:targeting_strategy, TargetingStrategy)
+    field(:targets_allies, :boolean)
   end
 
   @doc false
   def changeset(effect, attrs \\ %{}) do
     effect
-    |> cast(attrs, [:type, :stat, :based_on_stat, :amount, :application_type])
-    |> validate_inclusion(:stat, ["health", "max_health", "attack", "energy", "armor"])
-    |> validate_inclusion(:application_type, ["additive", "multiplicative"])
-    |> validate_required([:type, :stat, :amount, :application_type])
+    |> cast(attrs, [
+      :type,
+      :stat_affected,
+      :stat_based_on,
+      :amount,
+      :amount_format,
+      :amount_of_targets,
+      :targeting_strategy,
+      :targets_allies
+    ])
+    |> validate_inclusion(:stat_affected, ["health", "max_health", "attack", "energy", "armor"])
+    |> validate_inclusion(:amount_format, ["additive", "multiplicative"])
+    |> validate_required([
+      :type,
+      :stat_affected,
+      :amount,
+      :amount_format,
+      :targeting_strategy,
+      :targets_allies
+    ])
   end
 
   @doc """

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -4,7 +4,6 @@ defmodule GameBackend.Units.Skills.Effect do
   use GameBackend.Schema
   import Ecto.Changeset
 
-  alias GameBackend.Units.Characters.Character
   alias GameBackend.Units.Skills.Type
 
   @primary_key false
@@ -13,16 +12,16 @@ defmodule GameBackend.Units.Skills.Effect do
     field(:stat, :string)
     field(:based_on_stat, :string) # amount will be treated as the % of this stat if its set
     field(:amount, :integer)
-    field(:amount_type, :string)
+    field(:application_type, :string)
   end
 
   @doc false
   def changeset(effect, attrs \\ %{}) do
     effect
-    |> cast(attrs, [:type, :stat, :based_on_stat, :amount, :amount_type])
+    |> cast(attrs, [:type, :stat, :based_on_stat, :amount, :application_type])
     |> validate_inclusion(:stat, ["health", "max_health", "attack", "speed", "energy", "armor"])
-    |> validate_inclusion(:amount_type, ["additive", "multiplicative"])
-    |> validate_required([:type, :stat, :amount, :amount_type])
+    |> validate_inclusion(:application_type, ["additive", "multiplicative"])
+    |> validate_required([:type, :stat, :amount, :application_type])
   end
 
   @doc """

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -19,7 +19,7 @@ defmodule GameBackend.Units.Skills.Effect do
   def changeset(effect, attrs \\ %{}) do
     effect
     |> cast(attrs, [:type, :stat, :based_on_stat, :amount, :application_type])
-    |> validate_inclusion(:stat, ["health", "max_health", "attack", "speed", "energy", "armor"])
+    |> validate_inclusion(:stat, ["health", "max_health", "attack", "energy", "armor"])
     |> validate_inclusion(:application_type, ["additive", "multiplicative"])
     |> validate_required([:type, :stat, :amount, :application_type])
   end

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -1,0 +1,32 @@
+defmodule GameBackend.Units.Skills.Effect do
+  @moduledoc false
+
+  use GameBackend.Schema
+  import Ecto.Changeset
+
+  alias GameBackend.Units.Characters.Character
+  alias GameBackend.Units.Skills.Type
+
+  @primary_key false
+  embedded_schema do
+    field(:type, Type)
+    field(:stat, :string)
+    field(:based_on_stat, :string) # amount will be treated as the % of this stat if its set
+    field(:amount, :integer)
+    field(:amount_type, :string)
+  end
+
+  @doc false
+  def changeset(effect, attrs \\ %{}) do
+    effect
+    |> cast(attrs, [:type, :stat, :based_on_stat, :amount, :amount_type])
+    |> validate_inclusion(:stat, ["health", "max_health", "attack", "speed", "energy", "armor"])
+    |> validate_inclusion(:amount_type, ["additive", "multiplicative"])
+    |> validate_required([:type, :stat, :amount, :amount_type])
+  end
+
+  @doc """
+  Changeset for editing a level's basic attributes.
+  """
+  def edit_changeset(level, attrs), do: cast(level, attrs, [:campaign])
+end

--- a/apps/game_backend/lib/game_backend/units/skills/targeting_strategy.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/targeting_strategy.ex
@@ -1,0 +1,67 @@
+defmodule GameBackend.Units.Skills.TargetingStrategy do
+  @moduledoc """
+  The TargetingStrategy type for skills.
+  """
+
+  use Ecto.Type
+
+  def type(), do: :string
+
+  def cast("random"), do: {:ok, "random"}
+  def cast("nearest"), do: {:ok, "nearest"}
+  def cast("furthest"), do: {:ok, "furthest"}
+  def cast("min_health"), do: {:ok, "min_health"}
+  def cast("max_health"), do: {:ok, "max_health"}
+  def cast("min_shield"), do: {:ok, "min_shield"}
+  def cast("max_shield"), do: {:ok, "max_shield"}
+  def cast("frontline"), do: {:ok, "frontline"}
+  def cast("backline"), do: {:ok, "backline"}
+  def cast(%{"factions" => factions}), do: {:ok, {"factions", factions}}
+  def cast(%{"classes" => classes}), do: {:ok, {"classes", classes}}
+  def cast(_), do: :error
+
+  def load(string), do: {:ok, targeting_strategy_from_string(string)}
+
+  def dump(time), do: {:ok, targeting_strategy_to_string(time)}
+
+  defp targeting_strategy_to_string("random"), do: "random"
+  defp targeting_strategy_to_string("nearest"), do: "nearest"
+  defp targeting_strategy_to_string("furthest"), do: "furthest"
+  defp targeting_strategy_to_string("min_health"), do: "min_health"
+  defp targeting_strategy_to_string("max_health"), do: "max_health"
+  defp targeting_strategy_to_string("min_shield"), do: "min_shield"
+  defp targeting_strategy_to_string("max_shield"), do: "max_shield"
+  defp targeting_strategy_to_string("frontline"), do: "frontline"
+  defp targeting_strategy_to_string("backline"), do: "backline"
+
+  defp targeting_strategy_to_string({"factions", factions}),
+    do: "factions,#{Enum.join(factions, ",")}"
+
+  defp targeting_strategy_to_string({"classes", classes}),
+    do: "classes,#{Enum.join(classes, ",")}"
+
+  defp targeting_strategy_to_string(_), do: nil
+
+  defp targeting_strategy_from_string("random"), do: "random"
+  defp targeting_strategy_from_string("nearest"), do: "nearest"
+  defp targeting_strategy_from_string("furthest"), do: "furthest"
+  defp targeting_strategy_from_string("min_health"), do: "min_health"
+  defp targeting_strategy_from_string("max_health"), do: "max_health"
+  defp targeting_strategy_from_string("min_shield"), do: "min_shield"
+  defp targeting_strategy_from_string("max_shield"), do: "max_shield"
+  defp targeting_strategy_from_string("frontline"), do: "frontline"
+  defp targeting_strategy_from_string("backline"), do: "backline"
+
+  defp targeting_strategy_from_string(string) when is_binary(string) do
+    case String.split(string, ",") do
+      ["factions", factions] ->
+        {"factions", factions}
+
+      ["classes", classes] ->
+        {"classes", classes}
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/apps/game_backend/lib/game_backend/units/skills/type.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/type.ex
@@ -1,0 +1,72 @@
+defmodule GameBackend.Units.Skills.Type do
+  @moduledoc """
+  The Type type for skill effects.
+  """
+
+  use Ecto.Type
+
+  def type(), do: :string
+
+  def cast("instant"), do: {:ok, "instant"}
+  def cast("permanent"), do: {:ok, "permanent"}
+  def cast(%{"duration" => duration}), do: {:ok, %{"duration" => duration}}
+
+  def cast(%{
+        "interval" => interval,
+        "trigger_count" => trigger_count
+      }),
+      do:
+        {:ok,
+         %{
+           "interval" => interval,
+           "trigger_count" => trigger_count
+         }}
+
+  def cast(_), do: :error
+
+  def load(string), do: {:ok, time_type_from_string(string)}
+
+  def dump(time), do: {:ok, time_type_to_string(time)}
+
+  defp time_type_to_string(effect_time_type) do
+    case effect_time_type do
+      "instant" ->
+        "instant"
+
+      "permanent" ->
+        "permanent"
+
+      %{"duration" => duration} ->
+        "duration,#{duration}"
+
+      %{
+        "interval" => interval,
+        "trigger_count" => trigger_count
+      } ->
+        "periodic,#{interval},#{trigger_count}"
+
+      _ ->
+        nil
+    end
+  end
+
+  defp time_type_from_string("instant"), do: "instant"
+  defp time_type_from_string("permanent"), do: "permanent"
+
+  defp time_type_from_string(string) when is_binary(string) do
+    case String.split(string, ",") do
+      ["duration", duration] ->
+        {"duration", %{duration: String.to_integer(duration)}}
+
+      ["periodic", interval, trigger_count] ->
+        {"periodic",
+         %{
+           interval: String.to_integer(interval),
+           trigger_count: String.to_integer(trigger_count)
+         }}
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/apps/game_backend/lib/game_backend/units/skills/type.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/type.ex
@@ -8,7 +8,6 @@ defmodule GameBackend.Units.Skills.Type do
   def type(), do: :string
 
   def cast("instant"), do: {:ok, "instant"}
-  def cast("permanent"), do: {:ok, "permanent"}
   def cast(%{"duration" => duration}), do: {:ok, %{"duration" => duration}}
 
   def cast(%{
@@ -33,9 +32,6 @@ defmodule GameBackend.Units.Skills.Type do
       "instant" ->
         "instant"
 
-      "permanent" ->
-        "permanent"
-
       %{"duration" => duration} ->
         "duration,#{duration}"
 
@@ -51,7 +47,6 @@ defmodule GameBackend.Units.Skills.Type do
   end
 
   defp time_type_from_string("instant"), do: "instant"
-  defp time_type_from_string("permanent"), do: "permanent"
 
   defp time_type_from_string(string) when is_binary(string) do
     case String.split(string, ",") do

--- a/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
+++ b/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
@@ -4,8 +4,7 @@ defmodule GameBackend.Repo.Migrations.BattleStats do
   def change do
     create table(:skills) do
       add :effects, :map
-      add :targeting_strategy, :string
-      add :amount_of_targets, :integer
+      add :cooldown, :integer
       timestamps()
     end
 

--- a/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
+++ b/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
@@ -15,7 +15,6 @@ defmodule GameBackend.Repo.Migrations.BattleStats do
 
       add :base_health, :integer
       add :base_attack, :integer
-      add :base_speed, :integer
       add :base_armor, :integer
     end
   end

--- a/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
+++ b/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
@@ -1,0 +1,22 @@
+defmodule GameBackend.Repo.Migrations.BattleStats do
+  use Ecto.Migration
+
+  def change do
+    create table(:skills) do
+      add :effects, :map
+      add :targeting_strategy, :string
+      add :amount_of_targets, :integer
+      timestamps()
+    end
+
+    alter table :characters do
+      add :basic_skill_id, references(:skills)
+      add :ultimate_skill_id, references(:skills)
+
+      add :base_health, :integer
+      add :base_attack, :integer
+      add :base_speed, :integer
+      add :base_armor, :integer
+    end
+  end
+end

--- a/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
+++ b/apps/game_backend/priv/repo/migrations/20240219203649_battle_stats.exs
@@ -5,6 +5,9 @@ defmodule GameBackend.Repo.Migrations.BattleStats do
     create table(:skills) do
       add :effects, :map
       add :cooldown, :integer
+      add :targeting_strategy, :string
+      add :targets_allies, :bool
+      add :amount_of_targets, :integer
       timestamps()
     end
 

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -13,7 +13,11 @@ defmodule Gateway.Serialization.WebSocketRequest do
     oneof: 0
   )
 
-  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
+  field(:create_user, 3,
+    type: Gateway.Serialization.CreateUser,
+    json_name: "createUser",
+    oneof: 0
+  )
 
   field(:get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
@@ -29,9 +33,17 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
 
-  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
+  field(:fight_level, 7,
+    type: Gateway.Serialization.FightLevel,
+    json_name: "fightLevel",
+    oneof: 0
+  )
 
-  field(:select_unit, 8, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
+  field(:select_unit, 8,
+    type: Gateway.Serialization.SelectUnit,
+    json_name: "selectUnit",
+    oneof: 0
+  )
 
   field(:unselect_unit, 9,
     type: Gateway.Serialization.UnselectUnit,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -21,26 +21,30 @@ Characters.insert_character(%{
   basic_skill: %{
     effects: [%{
       type: "instant",
-      stat: "health",
-      amount: 80,
+      stat_affected: "health",
+      amount: -80,
       based_on_stat: "attack",
-      application_type: "additive"
+      amount_format: "additive",
+      targeting_strategy: "random", # TODO: Change back to nearest
+      amount_of_targets: 2,
+      targets_allies: false
     }],
-    targeting_strategy: "nearest",
-    amount_of_targets: 2
+    cooldown: 5
   },
   ultimate_skill: %{
     effects: [
       %{
         type: "instant",
-        stat: "health",
-        amount: 205,
+        stat_affected: "health",
+        amount: -205,
         based_on_stat: "attack",
-        application_type: "additive"
+        amount_format: "additive",
+        targeting_strategy: "random", # TODO: Change back to nearest
+        amount_of_targets: 2,
+        targets_allies: false
       }
-    ],
-    targeting_strategy: "nearest",
-    amount_of_targets: 2
+      # TODO: Add stun effect
+      ],
   }
 })
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -14,7 +14,35 @@ Characters.insert_character(%{
   active: true,
   name: "Muflus",
   faction: "Araban",
-  rarity: "Epic"
+  rarity: "Epic",
+  base_health: 621,
+  base_attack: 63,
+  base_speed: 115,
+  base_armor: 78,
+  basic_skill: %{
+    effects: [%{
+      type: "instant",
+      stat: "health",
+      amount: 80,
+      based_on_stat: "attack",
+      amount_type: "additive"
+    }],
+    targeting_strategy: "nearest",
+    amount_of_targets: 2
+  },
+  ultimate_skill: %{
+    effects: [
+      %{
+        type: "instant",
+        stat: "health",
+        amount: 205,
+        based_on_stat: "attack",
+        amount_type: "additive"
+      }
+    ],
+    targeting_strategy: "nearest",
+    amount_of_targets: 2
+  }
 })
 
 Characters.insert_character(%{

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,7 +17,6 @@ Characters.insert_character(%{
   rarity: "Epic",
   base_health: 621,
   base_attack: 63,
-  base_speed: 115,
   base_armor: 78,
   basic_skill: %{
     effects: [%{

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -23,7 +23,7 @@ Characters.insert_character(%{
       type: "instant",
       stat_affected: "health",
       amount: -80,
-      based_on_stat: "attack",
+      stat_based_on: "attack",
       amount_format: "additive",
       targeting_strategy: "random", # TODO: Change back to nearest
       amount_of_targets: 2,
@@ -37,7 +37,7 @@ Characters.insert_character(%{
         type: "instant",
         stat_affected: "health",
         amount: -205,
-        based_on_stat: "attack",
+        stat_based_on: "attack",
         amount_format: "additive",
         targeting_strategy: "random", # TODO: Change back to nearest
         amount_of_targets: 2,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -25,7 +25,7 @@ Characters.insert_character(%{
       stat: "health",
       amount: 80,
       based_on_stat: "attack",
-      amount_type: "additive"
+      application_type: "additive"
     }],
     targeting_strategy: "nearest",
     amount_of_targets: 2
@@ -37,7 +37,7 @@ Characters.insert_character(%{
         stat: "health",
         amount: 205,
         based_on_stat: "attack",
-        amount_type: "additive"
+        application_type: "additive"
       }
     ],
     targeting_strategy: "nearest",


### PR DESCRIPTION
Implements battle simulation. Battle rules can be found [here](https://docs.google.com/spreadsheets/d/177mvJS75LecaAEpyYotQEcrmhGJWI424UnkE2JHLmyY/edit#gid=64342728) and [here](https://www.notion.so/lambdaclass/Combat-1d675e46fa28498f84d184b31f15690f?pvs=4), but I'll make an effort to summarize them in this description.

Battle happens between up to 6 units on two teams (we don't validate this in the battle simulation though, it should happen before that). Each has an assigned position which they do not move out of. Units have stats that grow with level and items: ATK used for skill damage, HP that if reaches 0 you die, SHIELD that will block damage (not designed yet). They also have energy, which they gain by casting their **basic skill** (among others). They do so whenever its cooldown is ready. When units accumuluate 500 energy, they cast their **ultimate skill**.

Skills are made of effects and a targeting strategy. Effects also have targeting strategies themselves in case we want a skill to target differently for its effects (effect 1: attack 1 *enemy*, effect 2: heal *myself*, both part of the same skill).

Battles are *simultaneous*, meaning that many characters can attack in the same step (as opposed to a turn-based combat where only one character attacks at a time). This is achieved by taking decisions in every step based on the **initial** state of the battle for that step. For example, if we have 2 units that perform the same attack in a step:
- Unit 1 recieves the initial state of the step, decides based on that (hit lowest hp enemy). Let's say target is hit and dies.
- Unit 2 recieves the *same* initial state that unit 2 did. It also decides based on it (hit lowest hp enemy). The target will be the same as Unit 1, since it was the lowest hp. It does not matter that Unit 1 will kill them with their attack, Unit 2 will hit them as well since those actions are taking place at the same time.


Effects have different targetting strategies, stats they can affect, ways they affect the target stat (additive/multiplicative) and ways their amount is interpreted (flat / % based on stat like ATK).

There are many features that are missing in this PR, but it's ready for review & merge because the general outline is finished and future implementations could expand on it. The most important ones are:
- Status effects (stun, slow...)
- Implementation of other targeting strategies
- On-kill effects
- On-getting-hit effects (receive energy)



Sample code to run a battle between two muflus:
```
  user_1 = Champions.Users.register("User1")
  user_2 = Champions.Users.register("User2")
  team1 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
  team2 = Enum.map([1], fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, unit_level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill]) end)
  Champions.Battle.Simulator.run_battle team1, team2
```