### PR TITLE
[gh-301] Fix effects not updating game_state last id

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -222,6 +222,7 @@ defmodule Arena.Game.Skill do
         |> Map.put(last_id, effect)
 
       put_in(game_state, [:players, player.id, :aditional_info, :effects], effects)
+      |> put_in([:last_id], last_id)
     end)
   end
 


### PR DESCRIPTION
Closes #301

The uma invisibility was not stacking because the last_id was not updating in the game_state, causing to further applications of effect to have the same id thus causing to the `:remove_effect` message to remove the previous effect instead of the new one