### PR TITLE
Autoaim fixes

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -51,6 +51,10 @@ defmodule Arena.Game.Player do
     Map.filter(players, fn {_, player} -> alive?(player) end)
   end
 
+  def targetable_players(players) do
+    Map.filter(players, fn {_, player} -> alive?(player) and not invisible?(player) end)
+  end
+
   def stamina_full?(player) do
     player.aditional_info.available_stamina == player.aditional_info.max_stamina
   end
@@ -147,7 +151,7 @@ defmodule Arena.Game.Player do
 
         skill_direction =
           skill_params.target
-          |> Skill.maybe_auto_aim(skill, player, alive_players(game_state.players))
+          |> Skill.maybe_auto_aim(skill, player, targetable_players(game_state.players))
 
         Process.send_after(
           self(),
@@ -219,6 +223,11 @@ defmodule Arena.Game.Player do
 
     (damage + aditional_damage)
     |> round()
+  end
+
+  def invisible?(player) do
+    get_in(player, [:aditional_info, :effects])
+    |> Enum.any?(fn {_, effect} -> effect.name == "invisible" end)
   end
 
   ####################

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -147,7 +147,7 @@ defmodule Arena.Game.Player do
 
         skill_direction =
           skill_params.target
-          |> Skill.maybe_auto_aim(player, alive_players(game_state.players))
+          |> Skill.maybe_auto_aim(skill, player, alive_players(game_state.players))
 
         Process.send_after(
           self(),

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -259,12 +259,14 @@ defmodule Arena.Game.Skill do
     Physics.add_angle_to_direction(direction, angle)
   end
 
-  def maybe_auto_aim(%{x: x, y: y} = _skill_direction, player, entities)
-      when x == 0.0 and y == 0.0 do
-    Physics.nearest_entity_direction(player, entities)
+  def maybe_auto_aim(%{x: x, y: y}, skill, player, entities) when x == 0.0 and y == 0.0 do
+    case skill.autoaim do
+      true -> Physics.nearest_entity_direction(player, entities)
+      false -> player.direction |> Utils.normalize()
+    end
   end
 
-  def maybe_auto_aim(skill_direction, _player, _entities) do
+  def maybe_auto_aim(skill_direction, _skill, _player, _entities) do
     skill_direction |> Utils.normalize()
   end
 end

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -226,14 +226,21 @@ defmodule Arena.Game.Skill do
   end
 
   defp calculate_angle_directions(amount, angle_between, base_direction) do
-    middle = if rem(amount, 2) == 1, do: [base_direction], else: []
+    base_direction_normalized = Utils.normalize(base_direction)
+    middle = if rem(amount, 2) == 1, do: [base_direction_normalized], else: []
     side_amount = div(amount, 2)
     angles = Enum.map(1..side_amount, fn i -> angle_between * i end)
 
     {add_side, sub_side} =
       Enum.reduce(angles, {[], []}, fn angle, {add_side_acc, sub_side_acc} ->
-        add_side_acc = [Physics.add_angle_to_direction(base_direction, angle) | add_side_acc]
-        sub_side_acc = [Physics.add_angle_to_direction(base_direction, -angle) | sub_side_acc]
+        add_side_acc = [
+          Physics.add_angle_to_direction(base_direction_normalized, angle) | add_side_acc
+        ]
+
+        sub_side_acc = [
+          Physics.add_angle_to_direction(base_direction_normalized, -angle) | sub_side_acc
+        ]
+
         {add_side_acc, sub_side_acc}
       end)
 

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -183,7 +183,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
-      "autoaim": true,
+      "autoaim": false,
       "mechanics": [
         {
           "dash": {
@@ -238,7 +238,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
-      "autoaim": true,
+      "autoaim": false,
       "mechanics": [
         {
           "dash": {

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -60,6 +60,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "circle_hit": {
@@ -76,6 +77,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 300,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "cone_hit": {
@@ -93,6 +95,7 @@
       "execution_duration_ms": 1000,
       "activation_delay_ms": 200,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "leap": {
@@ -114,6 +117,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "simple_shoot": {
@@ -132,6 +136,7 @@
       "execution_duration_ms": 1000,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "repeated_shot": {
@@ -155,6 +160,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": false,
       "mechanics": [
         {
           "multi_shoot": {
@@ -177,6 +183,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "dash": {
@@ -192,6 +199,7 @@
       "execution_duration_ms": 1000,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "multi_cone_hit": {
@@ -211,6 +219,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 700,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "circle_hit": {
@@ -229,6 +238,7 @@
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
+      "autoaim": true,
       "mechanics": [
         {
           "dash": {


### PR DESCRIPTION
- Autoaim will only work if the skill is configured for it, otherwise it will use the player's current direction
- Autoaim will ignore invisible players