### PR TITLE
[gh-316] Actually update the kill count on kill

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -149,7 +149,7 @@ defmodule Arena.Entities do
      %Arena.Serialization.Player{
        health: entity.aditional_info.health,
        current_actions: entity.aditional_info.current_actions,
-       kill_count: 0,
+       kill_count: entity.aditional_info.kill_count,
        available_stamina: entity.aditional_info.available_stamina,
        max_stamina: entity.aditional_info.max_stamina,
        stamina_interval: entity.aditional_info.stamina_interval,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -267,9 +267,14 @@ defmodule Arena.GameUpdater do
       update_in(state, [:game_state, :killfeed], fn killfeed -> [entry | killfeed] end)
       |> spawn_power_ups(victim, amount_of_power_ups)
 
+    game_state =
+      update_in(game_state, [:players, killer_id, :aditional_info, :kill_count], fn count ->
+        count + 1
+      end)
+
     broadcast_player_dead(state.game_state.game_id, victim_id)
 
-    {:noreply, state}
+    {:noreply, %{state | game_state: game_state}}
   end
 
   def handle_info({:recharge_stamina, player_id}, state) do


### PR DESCRIPTION
Closes #316

Tests with this [Client branch](https://github.com/lambdaclass/curse_of_mirra/pull/1490)

We'll add a kill count was not being updated every time a player killed someone, this pr will make the counter actually increase