### PR TITLE
[GH-334] Refactor every game update (tick) action 

### DIFF
--- a/apps/arena/docs/src/configuration/power_ups.md
+++ b/apps/arena/docs/src/configuration/power_ups.md
@@ -5,7 +5,7 @@ The power ups are entities droped when a player dies that can be picked up for p
 ## Configuration
 
 - `power_ups_per_kill`: Defines how many power ups a player will drop when it dies
-- `minimun_amount`: Defines the minimun amount of power up a player needs to have to drop that amount of power ups
+- `minimum_amount`: Defines the minimum amount of power up a player needs to have to drop that amount of power ups
 - `amount_of_drops`: How many power ups a player will drop when it dies with certain amount of power ups
 - `power_up`: Determines the specs of the power up that will be dropped
 - `distance_to_power_up`: Distance from the position where the player dies to where the power up will be, it'll spawn in a random direction
@@ -19,8 +19,8 @@ The power ups are entities droped when a player dies that can be picked up for p
 ...
   {
     "power_ups_per_kill": [
-      {"minimun_amount": 0, "amount_of_drops": 1},
-      {"minimun_amount": 2, "amount_of_drops": 2},
+      {"minimum_amount": 0, "amount_of_drops": 1},
+      {"minimum_amount": 2, "amount_of_drops": 2},
     ],
     "power_up": {
       "distance_to_power_up": 500,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -623,7 +623,8 @@ defmodule Arena.GameUpdater do
           nil ->
             {players_acc, power_ups_acc}
 
-          power_up ->
+          power_up_id ->
+            power_up = Map.get(power_ups_acc, power_up_id)
             process_power_up(player, power_up, players_acc, power_ups_acc)
         end
       end)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -566,7 +566,7 @@ defmodule Arena.GameUpdater do
     # We don't want to move recently exploded projectiles
     {recently_exploded_projectiles, alive_projectiles} =
       projectiles
-      |> Enum.split_with(fn {_projectile_id, projectile} ->
+      |> Map.split_with(fn {_projectile_id, projectile} ->
         projectile.aditional_info.status == :EXPLODED
       end)
 
@@ -576,13 +576,13 @@ defmodule Arena.GameUpdater do
       |> Map.merge(%{external_wall.id => external_wall})
 
     moved_projectiles =
-      Map.new(alive_projectiles)
+      alive_projectiles
       |> Physics.move_entities(ticks_to_move, external_wall, %{})
       |> update_collisions(
         projectiles,
         entities_to_collide_with
       )
-      |> Map.merge(Map.new(recently_exploded_projectiles))
+      |> Map.merge(recently_exploded_projectiles)
 
     %{game_state | projectiles: moved_projectiles}
   end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -65,70 +65,20 @@ defmodule Arena.GameUpdater do
 
   def handle_info(:update_game, %{game_state: game_state} = state) do
     Process.send_after(self(), :update_game, state.game_config.game.tick_rate_ms)
-
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
     ticks_to_move = (now - game_state.server_timestamp) / state.game_config.game.tick_rate_ms
 
-    entities_to_collide_projectiles =
-      Map.merge(Player.alive_players(game_state.players), game_state.obstacles)
-
-    {players, power_ups} =
-      game_state.players
-      |> Physics.move_entities(
-        ticks_to_move,
-        state.game_state.external_wall,
-        state.game_state.obstacles
-      )
-      |> update_collisions(game_state.players, game_state.power_ups)
-      |> handle_power_ups(game_state.power_ups)
-
-    # We need to send the exploded projectiles to the client at least once
-    updated_expired_projectiles =
-      game_state.projectiles
-      |> Enum.filter(fn {_projectile_id, projectile} ->
-        projectile.aditional_info.status == :EXPIRED
-      end)
-      |> Enum.reduce(%{}, fn {_projectile_id, projectile}, acc ->
-        projectile =
-          put_in(
-            projectile,
-            [:aditional_info, :status],
-            :EXPLODED
-          )
-
-        Map.put(acc, projectile.id, projectile)
-      end)
-
-    projectiles =
-      game_state.projectiles
-      |> remove_exploded_and_expired_projectiles()
-      |> Physics.move_entities(ticks_to_move, game_state.external_wall, %{})
-      |> update_collisions(
-        game_state.projectiles,
-        Map.merge(entities_to_collide_projectiles, %{
-          game_state.external_wall.id => game_state.external_wall
-        })
-      )
-      |> Map.merge(updated_expired_projectiles)
-
-    # Resolve collisions between players and projectiles
-    {projectiles, players} =
-      resolve_projectile_collisions(
-        projectiles,
-        players,
-        game_state.obstacles,
-        game_state.external_wall.id
-      )
-
-    players = apply_zone_damage(players, game_state.zone, state.game_config.game)
-
     game_state =
       game_state
-      |> Map.put(:players, players)
-      |> Map.put(:projectiles, projectiles)
-      |> Map.put(:power_ups, power_ups)
+      |> Map.put(:ticks_to_move, ticks_to_move)
+      |> move_players()
+      |> update_projectiles_status()
+      |> move_projectiles()
+      |> resolve_players_collisions_with_power_ups()
+      |> resolve_projectiles_collisions_with_players()
+      |> apply_zone_damage_to_players(state.game_config.game)
+      |> explode_projectiles()
       |> Map.put(:server_timestamp, now)
-      |> execute_on_explode_mechanics(projectiles)
 
     broadcast_game_update(game_state)
     game_state = %{game_state | killfeed: [], damage_taken: %{}, damage_done: %{}}
@@ -484,7 +434,7 @@ defmodule Arena.GameUpdater do
   ##########################
 
   ##########################
-  # Game flow
+  # Game Initialization
   ##########################
 
   # Create a new game
@@ -557,12 +507,208 @@ defmodule Arena.GameUpdater do
     end)
   end
 
+  ##########################
+  # End Game Initialization
+  ##########################
+
+  ##########################
+  # Game flow. Actions executed in every tick.
+  ##########################
+
+  defp move_players(
+         %{
+           players: players,
+           ticks_to_move: ticks_to_move,
+           external_wall: external_wall,
+           obstacles: obstacles,
+           power_ups: power_ups
+         } = game_state
+       ) do
+    moved_players =
+      players
+      |> Physics.move_entities(
+        ticks_to_move,
+        external_wall,
+        obstacles
+      )
+      |> update_collisions(players, power_ups)
+
+    %{game_state | players: moved_players}
+  end
+
+  # Remove exploded projectiles
+  # Update expired to explode status
+  defp update_projectiles_status(%{projectiles: projectiles} = game_state) do
+    updated_projectiles =
+      projectiles
+      |> Map.reject(fn {_projectile_id, projectile} ->
+        projectile.aditional_info.status == :EXPLODED
+      end)
+      |> Enum.reduce(%{}, fn {projectile_id, projectile}, acc ->
+        if projectile.aditional_info.status == :EXPIRED do
+          acc
+          |> Map.put(
+            projectile_id,
+            put_in(
+              projectile,
+              [:aditional_info, :status],
+              :EXPLODED
+            )
+          )
+        else
+          acc |> Map.put(projectile_id, projectile)
+        end
+      end)
+
+    %{game_state | projectiles: updated_projectiles}
+  end
+
+  defp move_projectiles(
+         %{
+           projectiles: projectiles,
+           players: players,
+           obstacles: obstacles,
+           external_wall: external_wall,
+           ticks_to_move: ticks_to_move
+         } = game_state
+       ) do
+    # We don't want to move recently exploded projectiles
+    {recently_exploded_projectiles, alive_projectiles} =
+      projectiles
+      |> Enum.split_with(fn {_projectile_id, projectile} ->
+        projectile.aditional_info.status == :EXPLODED
+      end)
+
+    entities_to_collide_with =
+      Player.alive_players(players)
+      |> Map.merge(obstacles)
+      |> Map.merge(%{external_wall.id => external_wall})
+
+    moved_projectiles =
+      Map.new(alive_projectiles)
+      |> Physics.move_entities(ticks_to_move, external_wall, %{})
+      |> update_collisions(
+        projectiles,
+        entities_to_collide_with
+      )
+      |> Map.merge(Map.new(recently_exploded_projectiles))
+
+    %{game_state | projectiles: moved_projectiles}
+  end
+
+  defp resolve_players_collisions_with_power_ups(
+         %{players: players, power_ups: power_ups} = game_state
+       ) do
+    {updated_players, updated_power_ups} =
+      Enum.reduce(players, {players, power_ups}, fn {_player_id, player},
+                                                    {players_acc, power_ups_acc} ->
+        case find_collided_power_up(player.collides_with, power_ups_acc) do
+          nil ->
+            {players_acc, power_ups_acc}
+
+          power_up ->
+            process_power_up(player, power_up, players_acc, power_ups_acc)
+        end
+      end)
+
+    game_state
+    |> Map.put(:players, updated_players)
+    |> Map.put(:power_ups, updated_power_ups)
+  end
+
+  # This method will decide what to do when a projectile has collided with something in the map
+  # - If collided with something with the same owner skip that collision
+  # - If collided with external wall or obstacle explode projectile
+  # - If collided with another player do the projectile's damage
+  # - Do nothing on unexpected cases
+  defp resolve_projectiles_collisions_with_players(
+         %{
+           projectiles: projectiles,
+           players: players,
+           obstacles: obstacles,
+           external_wall: external_wall
+         } = game_state
+       ) do
+    {updated_projectiles, updated_players} =
+      Enum.reduce(projectiles, {projectiles, players}, fn {_projectile_id, projectile},
+                                                          {_projectiles_acc, players_acc} = accs ->
+        # check if the projectiles is inside the walls
+        collides_with =
+          case projectile.collides_with do
+            [] -> [external_wall.id]
+            entities -> List.delete(entities, external_wall.id)
+          end
+
+        collided_entity =
+          decide_collided_entity(projectile, collides_with, external_wall.id, players_acc)
+
+        process_projectile_collision(
+          projectile,
+          Map.get(players, collided_entity),
+          Map.get(obstacles, collided_entity),
+          collided_entity == external_wall.id,
+          accs
+        )
+      end)
+
+    game_state
+    |> Map.put(:projectiles, updated_projectiles)
+    |> Map.put(:players, updated_players)
+  end
+
+  defp explode_projectiles(%{projectiles: projectiles} = game_state) do
+    Enum.reduce(projectiles, game_state, fn {_projectile_id, projectile}, game_state ->
+      if projectile.aditional_info.status == :EXPLODED &&
+           Map.get(projectile.aditional_info, :on_explode_mechanics) do
+        Skill.do_mechanic(
+          game_state,
+          projectile,
+          projectile.aditional_info.on_explode_mechanics,
+          %{}
+        )
+      else
+        game_state
+      end
+    end)
+  end
+
+  defp apply_zone_damage_to_players(%{players: players, zone: zone} = game_state, %{
+         zone_damage_interval_ms: zone_interval,
+         zone_damage: zone_damage
+       }) do
+    safe_zone = Entities.make_circular_area(0, %{x: 0.0, y: 0.0}, zone.radius)
+    safe_ids = Physics.check_collisions(safe_zone, players)
+    to_damage_ids = Map.keys(players) -- safe_ids
+    now = System.monotonic_time(:millisecond)
+
+    updated_players =
+      Enum.reduce(to_damage_ids, players, fn player_id, players_acc ->
+        player = Map.get(players_acc, player_id)
+        last_damage = player |> get_in([:aditional_info, :last_damage_received])
+        elapse_time = now - last_damage
+
+        player = player |> maybe_receive_zone_damage(elapse_time, zone_interval, zone_damage)
+
+        Map.put(players_acc, player_id, player)
+      end)
+
+    %{game_state | players: updated_players}
+  end
+
+  ##########################
+  # End Game Flow
+  ##########################
+
+  ##########################
+  # Helpers
+  ##########################
+
   defp get_next_position([pos | rest]) do
     positions = rest ++ [pos]
     {pos, positions}
   end
 
-  # Check entities collisiona
+  # Check entities collisions
   defp update_collisions(new_entities, old_entities, entities_to_collide) do
     Enum.reduce(new_entities, %{}, fn {key, value}, acc ->
       entity =
@@ -598,36 +744,6 @@ defmodule Arena.GameUpdater do
     end
   end
 
-  def remove_exploded_and_expired_projectiles(projectiles) do
-    Map.reject(projectiles, fn {_key, projectile} ->
-      projectile.aditional_info.status in [:EXPLODED, :EXPIRED]
-    end)
-  end
-
-  ##########################
-  # End game flow
-  ##########################
-
-  defp apply_zone_damage(players, zone, %{
-         zone_damage_interval_ms: zone_interval,
-         zone_damage: zone_damage
-       }) do
-    safe_zone = Entities.make_circular_area(0, %{x: 0.0, y: 0.0}, zone.radius)
-    safe_ids = Physics.check_collisions(safe_zone, players)
-    to_damage_ids = Map.keys(players) -- safe_ids
-    now = System.monotonic_time(:millisecond)
-
-    Enum.reduce(to_damage_ids, players, fn player_id, players_acc ->
-      player = Map.get(players_acc, player_id)
-      last_damage = player |> get_in([:aditional_info, :last_damage_received])
-      elapse_time = now - last_damage
-
-      player = player |> maybe_receive_zone_damage(elapse_time, zone_interval, zone_damage)
-
-      Map.put(players_acc, player_id, player)
-    end)
-  end
-
   defp maybe_receive_zone_damage(player, elapse_time, zone_damage_interval, zone_damage)
        when elapse_time > zone_damage_interval do
     Player.take_damage(player, zone_damage)
@@ -636,40 +752,17 @@ defmodule Arena.GameUpdater do
   defp maybe_receive_zone_damage(player, _elaptime, _zone_damage_interval, _zone_damage),
     do: player
 
-  # This method will decide what to do when a projectile has collided with something in the map
-  # - If collided with something with the same owner skip that collision
-  # - If collided with external wall or obstacle explode projectile
-  # - If collided with another player do the projectile's damage
-  # - Do nothing on unexpected cases
-  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id)
-
-  defp resolve_projectile_collisions(projectiles, players, obstacles, external_wall_id) do
-    Enum.reduce(projectiles, {projectiles, players}, fn {_projectile_id, projectile},
-                                                        {_projectiles_acc, players_acc} = accs ->
-      # check if the projectiles is inside the walls
-      collides_with =
-        case projectile.collides_with do
-          [] -> [external_wall_id]
-          entities -> List.delete(entities, external_wall_id)
-        end
-
-      collided_entity =
-        decide_collided_entity(projectile, collides_with, external_wall_id, players_acc)
-
-      apply_collision_updates(
-        projectile,
-        Map.get(players, collided_entity),
-        Map.get(obstacles, collided_entity),
-        collided_entity == external_wall_id,
-        accs
-      )
-    end)
-  end
-
-  defp apply_collision_updates(projectile, player, obstacle, collided_with_external_wall?, accs)
+  # Function to process the projectile collision with other entities
+  defp process_projectile_collision(
+         projectile,
+         player,
+         obstacle,
+         collided_with_external_wall?,
+         accs
+       )
 
   # Projectile collided an obstacle or went outside of the arena
-  defp apply_collision_updates(
+  defp process_projectile_collision(
          projectile,
          nil,
          obstacle,
@@ -686,7 +779,7 @@ defmodule Arena.GameUpdater do
   end
 
   # Projectile collided a player
-  defp apply_collision_updates(projectile, player, _, _, {projectiles_acc, players_acc})
+  defp process_projectile_collision(projectile, player, _, _, {projectiles_acc, players_acc})
        when not is_nil(player) do
     attacking_player = Map.get(players_acc, projectile.aditional_info.owner_id)
     real_damage = Player.calculate_real_damage(attacking_player, projectile.aditional_info.damage)
@@ -709,8 +802,8 @@ defmodule Arena.GameUpdater do
     }
   end
 
-  # Projectile didn't collide
-  defp apply_collision_updates(_, _, _, _, accs), do: accs
+  # Projectile didn't collide at all
+  defp process_projectile_collision(_, _, _, _, accs), do: accs
 
   defp decide_collided_entity(_projectile, [], _external_wall_id, _players), do: nil
 
@@ -780,48 +873,27 @@ defmodule Arena.GameUpdater do
     end
   end
 
-  defp handle_power_ups(players, power_ups) do
-    power_ups =
-      Map.reject(power_ups, fn {_power_up_id, power_up} ->
-        power_up.aditional_info.status == :TAKEN
-      end)
-
-    Enum.reduce(players, {players, power_ups}, fn {_player_id, player},
-                                                  {players_acc, power_ups_acc} = accs ->
-      power_up_collided_id =
-        Enum.find(player.collides_with, nil, fn collided_entity_id ->
-          Map.has_key?(power_ups_acc, collided_entity_id)
-        end)
-
-      power_up = Map.get(power_ups, power_up_collided_id)
-
-      if power_up && power_up.aditional_info.status == :AVAILABLE && Player.alive?(player) do
-        power_up = put_in(power_up, [:aditional_info, :status], :TAKEN)
-
-        player =
-          player
-          |> update_in([:aditional_info, :power_ups], fn amount -> amount + 1 end)
-
-        {Map.put(players_acc, player.id, player), Map.put(power_ups_acc, power_up.id, power_up)}
-      else
-        accs
-      end
+  defp find_collided_power_up(collides_with, power_ups) do
+    Enum.find(collides_with, fn collided_entity_id ->
+      Map.has_key?(power_ups, collided_entity_id)
     end)
   end
 
-  defp execute_on_explode_mechanics(game_state, projectiles) do
-    Enum.reduce(projectiles, game_state, fn {_projectile_id, projectile}, game_state ->
-      if projectile.aditional_info.status == :EXPLODED &&
-           Map.get(projectile.aditional_info, :on_explode_mechanics) do
-        Skill.do_mechanic(
-          game_state,
-          projectile,
-          projectile.aditional_info.on_explode_mechanics,
-          %{}
-        )
-      else
-        game_state
-      end
-    end)
+  defp process_power_up(player, power_up, players_acc, power_ups_acc) do
+    if power_up.aditional_info.status == :AVAILABLE && Player.alive?(player) do
+      updated_power_up = put_in(power_up, [:aditional_info, :status], :TAKEN)
+
+      updated_player =
+        update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
+
+      {Map.put(players_acc, player.id, updated_player),
+       Map.put(power_ups_acc, power_up.id, updated_power_up)}
+    else
+      {players_acc, power_ups_acc}
+    end
   end
+
+  ##########################
+  # End Helpers
+  ##########################
 end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -469,6 +469,9 @@ defmodule Arena.GameUpdater do
       |> Map.put(:player_timestamps, %{})
       |> Map.put(:server_timestamp, 0)
       |> Map.put(:client_to_player_map, %{})
+      |> Map.put(:killfeed, [])
+      |> Map.put(:damage_taken, %{})
+      |> Map.put(:damage_done, %{})
       |> Map.put(:external_wall, Entities.new_external_wall(0, config.map.radius))
       |> Map.put(:zone, %{
         radius: config.map.radius,
@@ -497,9 +500,6 @@ defmodule Arena.GameUpdater do
           new_game
           |> Map.put(:last_id, last_id)
           |> Map.put(:players, players)
-          |> Map.put(:killfeed, [])
-          |> Map.put(:damage_taken, %{})
-          |> Map.put(:damage_done, %{})
           |> put_in([:client_to_player_map, client_id], last_id)
           |> put_in([:player_timestamps, last_id], 0)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -5,10 +5,8 @@ defmodule Arena.GameUpdater do
   """
 
   use GenServer
-  alias Arena.Configuration
-  alias Arena.Entities
-  alias Arena.Game.Player
-  alias Arena.Game.Skill
+  alias Arena.{Configuration, Entities}
+  alias Arena.Game.{Player, Skill}
   alias Arena.Serialization.{GameEvent, GameState, GameFinished}
   alias Phoenix.PubSub
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -881,9 +881,9 @@ defmodule Arena.GameUpdater do
   end
 
   defp get_amount_of_power_ups(%{aditional_info: %{power_ups: power_ups}}, power_ups_per_kill) do
-    Enum.sort_by(power_ups_per_kill, fn %{minimun_amount: minimun} -> minimun end, :desc)
-    |> Enum.find(fn %{minimun_amount: minimun} ->
-      minimun <= power_ups
+    Enum.sort_by(power_ups_per_kill, fn %{minimum_amount: minimum} -> minimum end, :desc)
+    |> Enum.find(fn %{minimum_amount: minimum} ->
+      minimum <= power_ups
     end)
     |> case do
       %{amount_of_drops: amount} -> amount

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -538,23 +538,16 @@ defmodule Arena.GameUpdater do
   # Update expired to explode status
   defp update_projectiles_status(%{projectiles: projectiles} = game_state) do
     updated_projectiles =
-      projectiles
-      |> Map.reject(fn {_projectile_id, projectile} ->
-        projectile.aditional_info.status == :EXPLODED
-      end)
-      |> Enum.reduce(%{}, fn {projectile_id, projectile}, acc ->
-        if projectile.aditional_info.status == :EXPIRED do
-          acc
-          |> Map.put(
-            projectile_id,
-            put_in(
-              projectile,
-              [:aditional_info, :status],
-              :EXPLODED
-            )
-          )
-        else
-          acc |> Map.put(projectile_id, projectile)
+      Enum.reduce(projectiles, projectiles, fn {projectile_id, projectile}, acc ->
+        case projectile.aditional_info.status do
+          :EXPLODED ->
+            Map.delete(acc, projectile_id)
+
+          :EXPIRED ->
+            Map.put(acc, projectile_id, put_in(projectile, [:aditional_info, :status], :EXPLODED))
+
+          _ ->
+            acc
         end
       end)
 

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -376,15 +376,15 @@
   "power_ups": {
     "power_ups_per_kill": [
       {
-        "minimun_amount": 0,
+        "minimum_amount": 0,
         "amount_of_drops": 1
       },
       {
-        "minimun_amount": 2,
+        "minimum_amount": 2,
         "amount_of_drops": 2
       },
       {
-        "minimun_amount": 6,
+        "minimum_amount": 6,
         "amount_of_drops": 3
       }
     ],


### PR DESCRIPTION
1st iteration of #334 

Game update handler was messy. This PR wants to expose each action to see refactor oportunities with more clarity.

- Moves out every tick action to a separate function.
- Each of the mentioned functions have to receive and return the game state map.