### PR TITLE
Fix get_characters functions

### DIFF
--- a/apps/game_backend/lib/game_backend/units/characters.ex
+++ b/apps/game_backend/lib/game_backend/units/characters.ex
@@ -17,9 +17,9 @@ defmodule GameBackend.Units.Characters do
     |> Repo.insert()
   end
 
-  def get_character(id), do: Repo.get(Character, id) |> Repo.preload(:skills)
+  def get_character(id), do: Repo.get(Character, id) |> Repo.preload([:basic_skill, :ultimate_skill])
 
-  def get_characters(), do: Repo.all(Character) |> Repo.preload(:skills)
+  def get_characters(), do: Repo.all(Character) |> Repo.preload([:basic_skill, :ultimate_skill])
 
   def get_character_by_name(name), do: Repo.one(from(c in Character, where: c.name == ^name))
 


### PR DESCRIPTION
The preload was left based on an outdated implementation of skills.

# To test

Make sure you have some characters in your db (seeds should be creating some) and then run these functions to get them.