### PR TITLE
Normalize direction after using it to the skill

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -174,7 +174,7 @@ defmodule Arena.Game.Player do
         player =
           add_action(player, action_name, skill.execution_duration_ms)
           |> change_stamina(-skill.stamina_cost)
-          |> put_in([:direction], skill_direction)
+          |> put_in([:direction], skill_direction |> Utils.normalize())
           |> put_in([:is_moving], false)
           |> put_in([:aditional_info, :last_skill_triggered], System.monotonic_time(:millisecond))
 

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -100,7 +100,7 @@
     {
       "name": "leap",
       "cooldown_ms": 2000,
-      "execution_duration_ms": 1000,
+      "execution_duration_ms": 800,
       "activation_delay_ms": 200,
       "is_passive": false,
       "autoaim": true,
@@ -110,7 +110,7 @@
         {
           "leap": {
             "range": 1000.0,
-            "duration_ms": 800,
+            "duration_ms": 600,
             "on_arrival_mechanic": {
               "circle_hit": {
                 "damage": 22,


### PR DESCRIPTION
The problem here was that we were using the direction selected by the player to move the player during the leap, without normalizing it.
So you feel that your leap didn't arrive at the selected destination.
