### PR TITLE
Add prod configs

### DIFF
--- a/apps/champions/config/prod.exs
+++ b/apps/champions/config/prod.exs
@@ -1,0 +1,1 @@
+import Config

--- a/apps/game_backend/config/prod.exs
+++ b/apps/game_backend/config/prod.exs
@@ -1,0 +1,1 @@
+import Config

--- a/apps/gateway/config/prod.exs
+++ b/apps/gateway/config/prod.exs
@@ -1,0 +1,1 @@
+import Config


### PR DESCRIPTION
After PR #350, [arena deploy is not working](https://github.com/lambdaclass/mirra_backend/actions/runs/8192618076) because of missing prod.exs config files in some apps. This PR adds them even if only empty, in order to [fix arena deploys](https://github.com/lambdaclass/mirra_backend/actions/runs/8194927724).