### PR TITLE
Allow more time for SocketTester messages in tests

### DIFF
--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -236,7 +236,7 @@ defmodule Gateway.Test.Champions do
   end
 
   defp fetch_last_message(socket_tester) do
-    :timer.sleep(50)
+    :timer.sleep(100)
     send(socket_tester, {:last_message, self()})
   end
 


### PR DESCRIPTION
Closes https://github.com/orgs/lambdaclass/projects/18/views/7?pane=issue&itemId=56588663

Some of the Champions tests are occasionally failing because messages sometimes failed to be sent in time. For example: https://github.com/lambdaclass/mirra_backend/actions/runs/8252380274/job/22571736812. This PR doubles the timeout value to avoid this.