### PR TITLE
Fix `not an already existing atom` error

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -279,9 +279,9 @@ defmodule Arena.Game.Player do
   ####################
   # Internal helpers #
   ####################
-  defp skill_key_execution_action(skill_key) do
-    "EXECUTING_SKILL_#{String.upcase(skill_key)}" |> String.to_existing_atom()
-  end
+  defp skill_key_execution_action("1"), do: :EXECUTING_SKILL_1
+  defp skill_key_execution_action("2"), do: :EXECUTING_SKILL_2
+  defp skill_key_execution_action("3"), do: :EXECUTING_SKILL_3
 
   defp maybe_trigger_natural_heal(player, true) do
     now = System.monotonic_time(:millisecond)


### PR DESCRIPTION
Closes #358 

Replace the dynamic atom creation for the protobuf enum to a static return, although the dynamic part was nice since it converts to an enum it makes little sense, better to crash and remember to add the additional line here

Sadly I wasn't able to reproduce the issue so this fixes it by removing the cause, but the underlying reason remains sort of a mystery (although we have theories)