### PR TITLE
Add toxiproxy script to enable lag spikes

### DIFF
--- a/lag_spikes.sh
+++ b/lag_spikes.sh
@@ -11,12 +11,12 @@ do
 	for i in "${!latencies[@]}"; do
 		latency=${latencies[i]}
 		latency_duration=${latency_durations[i]}
-        # Update latency with toxiproxy-cli
-        toxiproxy-cli toxic update -n latency -a latency=$latency game_proxy
+		# Update latency with toxiproxy-cli
+		toxiproxy-cli toxic update -n latency -a latency=$latency game_proxy
 
-        echo "Applied latency: $latency ms for $latency_duration seconds"
+		echo "Applied latency: $latency ms for $latency_duration seconds"
 
-        # Sleep for the defined latency duration
-        sleep $latency_duration
+		# Sleep for the defined latency duration
+		sleep $latency_duration
 	done
 done

--- a/lag_spikes.sh
+++ b/lag_spikes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# The following lists contain the latency (in ms) and its duration (in seconds).
+# They are processed pairwise, meaning the first element of one list corresponds 
+# to the first element of the other list, and so forth.
+latencies=(100 2000 300)
+latency_durations=(15 25 20)
+
+while true
+do
+	for i in "${!latencies[@]}"; do
+		latency=${latencies[i]}
+		latency_duration=${latency_durations[i]}
+        # Update latency with toxiproxy-cli
+        toxiproxy-cli toxic update -n latency -a latency=$latency game_proxy
+
+        echo "Applied latency: $latency ms for $latency_duration seconds"
+
+        # Sleep for the defined latency duration
+        sleep $latency_duration
+	done
+done


### PR DESCRIPTION
We had the documentation but the script was missing.
We need to make the latency and its duration configurable. This script allows it.