### PR TITLE
Cooldown mechanisms

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -21,10 +21,23 @@ defmodule Arena.Configuration do
 
   defp parse_skills_config(skills_config) do
     Enum.reduce(skills_config, [], fn skill_config, skills ->
-      mechanics = parse_mechanics_config(skill_config.mechanics)
-      skill = %{skill_config | mechanics: mechanics}
+      skill = parse_skill_config(skill_config)
       [skill | skills]
     end)
+  end
+
+  defp parse_skill_config(%{cooldown_mechanism: "stamina", stamina_cost: cost} = skill_config) when cost >= 0 do
+    mechanics = parse_mechanics_config(skill_config.mechanics)
+    %{skill_config | mechanics: mechanics}
+  end
+
+  defp parse_skill_config(%{cooldown_mechanism: "time", cooldown_ms: cooldown} = skill_config) when cooldown >= 0 do
+    mechanics = parse_mechanics_config(skill_config.mechanics)
+    %{skill_config | mechanics: mechanics}
+  end
+
+  defp parse_skill_config(skill_config) do
+    raise "Invalid Skill config for `#{skill_config[:name]}`: cooldown_mechanism or corresponding attribute is invalid"
   end
 
   defp parse_mechanics_config(mechanics_config) do

--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -37,7 +37,16 @@ defmodule Arena.Configuration do
   end
 
   defp parse_skill_config(skill_config) do
-    raise "Invalid Skill config for `#{skill_config[:name]}`: cooldown_mechanism or corresponding attribute is invalid"
+    case skill_config.cooldown_mechanism do
+      "stamina" ->
+        raise "Invalid Skill config for `#{skill_config[:name]}` stamina_cost should be a number greater than or equal to zero"
+
+      "time" ->
+        raise "Invalid Skill config for `#{skill_config[:name]}` cooldown_ms should be a number greater than or equal to zero"
+
+      _ ->
+        raise "Invalid Skill config for `#{skill_config[:name]}` cooldown_mechanism is invalid, should be either `time` or `stamina`"
+    end
   end
 
   defp parse_mechanics_config(mechanics_config) do

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -39,7 +39,8 @@ defmodule Arena.Entities do
         power_up_damage_modifier: config.power_ups.power_up.power_up_damage_modifier,
         inventory: nil,
         damage_immunity: false,
-        effects: %{}
+        effects: %{},
+        cooldowns: %{}
       }
     }
   end

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -221,7 +221,8 @@ defmodule Arena.Entities do
        character_name: entity.aditional_info.character_name,
        effects: entity.aditional_info.effects,
        power_ups: entity.aditional_info.power_ups,
-       inventory: entity.aditional_info.inventory
+       inventory: entity.aditional_info.inventory,
+       cooldowns: entity.aditional_info.cooldowns
      }}
   end
 

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -105,10 +105,13 @@ defmodule Arena.Game.Player do
   end
 
   def get_skill_if_usable(player, skill_key) do
+    skill = get_in(player, [:aditional_info, :skills, skill_key])
+    skill_cooldown = get_in(player, [:aditional_info, :cooldowns, skill_key])
     available_stamina = player.aditional_info.available_stamina
 
-    case get_in(player, [:aditional_info, :skills, skill_key]) do
-      %{stamina_cost: cost} = skill when cost <= available_stamina -> skill
+    case skill do
+      %{cooldown_mechanism: "time"} when is_nil(skill_cooldown) -> skill
+      %{cooldown_mechanism: "stamina", stamina_cost: cost} when cost <= available_stamina -> skill
       _ -> nil
     end
   end
@@ -190,25 +193,10 @@ defmodule Arena.Game.Player do
 
         player =
           add_action(player, action_name, skill.execution_duration_ms)
-          |> change_stamina(-skill.stamina_cost)
+          |> apply_skill_cooldown(skill_key, skill)
           |> put_in([:direction], skill_direction |> Utils.normalize())
           |> put_in([:is_moving], false)
           |> put_in([:aditional_info, :last_skill_triggered], System.monotonic_time(:millisecond))
-
-        player =
-          case stamina_recharging?(player) do
-            false ->
-              Process.send_after(
-                self(),
-                {:recharge_stamina, player.id},
-                player.aditional_info.stamina_interval
-              )
-
-              put_in(player, [:aditional_info, :recharging_stamina], true)
-
-            _ ->
-              player
-          end
 
         put_in(game_state, [:players, player.id], player)
     end
@@ -356,5 +344,22 @@ defmodule Arena.Game.Player do
   defp apply_effect({:damage_immunity, damage_immunity}, player) do
     Process.send_after(self(), {:remove_damage_immunity, player.id}, damage_immunity.duration_ms)
     put_in(player, [:aditional_info, :damage_immunity], true)
+  end
+
+  defp apply_skill_cooldown(player, skill_key, %{cooldown_mechanism: "time", cooldown_ms: cooldown_ms}) do
+    put_in(player, [:aditional_info, :cooldowns, skill_key], cooldown_ms)
+  end
+
+  defp apply_skill_cooldown(player, _skill_key, %{cooldown_mechanism: "stamina", stamina_cost: cost}) do
+    player = change_stamina(player, -cost)
+
+    case stamina_recharging?(player) do
+      false ->
+        Process.send_after(self(), {:recharge_stamina, player.id}, player.aditional_info.stamina_interval)
+        put_in(player, [:aditional_info, :recharging_stamina], true)
+
+      _ ->
+        player
+    end
   end
 end

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -4,7 +4,7 @@ defmodule Arena.GameLauncher do
   use GenServer
 
   # Amount of clients needed to start a game
-  @clients_needed 10
+  @clients_needed 1
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
 

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -4,7 +4,7 @@ defmodule Arena.GameLauncher do
   use GenServer
 
   # Amount of clients needed to start a game
-  @clients_needed 1
+  @clients_needed 10
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
 

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -1,7 +1,7 @@
 defmodule Arena.Serialization.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -11,7 +11,7 @@ end
 defmodule Arena.Serialization.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:ACTIVE, 0)
   field(:EXPLODED, 1)
@@ -20,7 +20,7 @@ end
 defmodule Arena.Serialization.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -29,7 +29,7 @@ end
 defmodule Arena.Serialization.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -42,7 +42,7 @@ end
 defmodule Arena.Serialization.Direction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:x, 1, type: :float)
   field(:y, 2, type: :float)
@@ -51,7 +51,7 @@ end
 defmodule Arena.Serialization.Position do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:x, 1, type: :float)
   field(:y, 2, type: :float)
@@ -60,7 +60,7 @@ end
 defmodule Arena.Serialization.GameEvent do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:event, 0)
 
@@ -73,7 +73,7 @@ end
 defmodule Arena.Serialization.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -82,7 +82,7 @@ end
 defmodule Arena.Serialization.GameFinished do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:winner, 1, type: Arena.Serialization.Entity)
 
@@ -96,7 +96,7 @@ end
 defmodule Arena.Serialization.PingUpdate do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:latency, 1, type: :uint64)
 end
@@ -104,7 +104,7 @@ end
 defmodule Arena.Serialization.GameJoined do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: Arena.Serialization.Configuration)
@@ -113,7 +113,7 @@ end
 defmodule Arena.Serialization.Configuration do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:game, 1, type: Arena.Serialization.ConfigGame)
   field(:map, 2, type: Arena.Serialization.ConfigMap)
@@ -123,7 +123,7 @@ end
 defmodule Arena.Serialization.ConfigGame do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
@@ -131,7 +131,7 @@ end
 defmodule Arena.Serialization.ConfigMap do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
 end
@@ -139,7 +139,7 @@ end
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: Arena.Serialization.ConfigSkill)
@@ -148,7 +148,7 @@ end
 defmodule Arena.Serialization.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -167,7 +167,7 @@ end
 defmodule Arena.Serialization.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -181,7 +181,7 @@ end
 defmodule Arena.Serialization.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -190,7 +190,7 @@ end
 defmodule Arena.Serialization.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -199,7 +199,7 @@ end
 defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -208,7 +208,7 @@ end
 defmodule Arena.Serialization.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -217,7 +217,7 @@ end
 defmodule Arena.Serialization.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -226,7 +226,7 @@ end
 defmodule Arena.Serialization.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -235,7 +235,7 @@ end
 defmodule Arena.Serialization.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -244,7 +244,7 @@ end
 defmodule Arena.Serialization.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -253,7 +253,7 @@ end
 defmodule Arena.Serialization.GameState do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
   field(:players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true)
@@ -305,7 +305,7 @@ end
 defmodule Arena.Serialization.Entity do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:aditional_info, 0)
 
@@ -331,16 +331,25 @@ end
 defmodule Arena.Serialization.Player.EffectsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Effect)
 end
 
+defmodule Arena.Serialization.Player.CooldownsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :uint64)
+end
+
 defmodule Arena.Serialization.Player do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:health, 1, type: :uint64)
   field(:kill_count, 2, type: :uint64, json_name: "killCount")
@@ -359,12 +368,13 @@ defmodule Arena.Serialization.Player do
   field(:power_ups, 9, type: :uint64, json_name: "powerUps")
   field(:effects, 10, repeated: true, type: Arena.Serialization.Player.EffectsEntry, map: true)
   field(:inventory, 11, type: Arena.Serialization.Item)
+  field(:cooldowns, 12, repeated: true, type: Arena.Serialization.Player.CooldownsEntry, map: true)
 end
 
 defmodule Arena.Serialization.Effect do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -373,7 +383,7 @@ end
 defmodule Arena.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 2, type: :string)
 end
@@ -381,7 +391,7 @@ end
 defmodule Arena.Serialization.Projectile do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:damage, 1, type: :uint64)
   field(:owner_id, 2, type: :uint64, json_name: "ownerId")
@@ -392,7 +402,7 @@ end
 defmodule Arena.Serialization.Obstacle do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:color, 1, type: :string)
 end
@@ -400,7 +410,7 @@ end
 defmodule Arena.Serialization.PowerUp do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: Arena.Serialization.PowerUpstatus, enum: true)
@@ -409,7 +419,7 @@ end
 defmodule Arena.Serialization.Pool do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
 end
@@ -417,7 +427,7 @@ end
 defmodule Arena.Serialization.PlayerAction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:action, 1, type: Arena.Serialization.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -426,7 +436,7 @@ end
 defmodule Arena.Serialization.Move do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:direction, 1, type: Arena.Serialization.Direction)
 end
@@ -434,7 +444,7 @@ end
 defmodule Arena.Serialization.Attack do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: Arena.Serialization.AttackParameters)
@@ -443,7 +453,7 @@ end
 defmodule Arena.Serialization.AttackParameters do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:target, 1, type: Arena.Serialization.Direction)
 end
@@ -451,7 +461,7 @@ end
 defmodule Arena.Serialization.UseItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -459,7 +469,7 @@ end
 defmodule Arena.Serialization.GameAction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:action_type, 0)
 
@@ -472,7 +482,7 @@ end
 defmodule Arena.Serialization.Zone do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -483,7 +493,7 @@ end
 defmodule Arena.Serialization.KillEntry do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -85,6 +85,7 @@
   "skills": [
     {
       "name": "hit",
+      "cooldown_mechanism": "stamina",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 300,
@@ -105,6 +106,7 @@
     },
     {
       "name": "singularity",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 300,
@@ -129,6 +131,7 @@
     },
     {
       "name": "leap",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 800,
       "activation_delay_ms": 200,
@@ -154,6 +157,7 @@
     },
     {
       "name": "shot",
+      "cooldown_mechanism": "stamina",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
@@ -175,6 +179,7 @@
     },
     {
       "name": "denial_of_service",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 1000,
       "activation_delay_ms": 0,
@@ -201,6 +206,7 @@
     },
     {
       "name": "slingshot",
+      "cooldown_mechanism": "stamina",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
@@ -226,6 +232,7 @@
     },
     {
       "name": "dash",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
@@ -244,6 +251,7 @@
     },
     {
       "name": "avenge",
+      "cooldown_mechanism": "stamina",
       "cooldown_ms": 2000,
       "execution_duration_ms": 1000,
       "activation_delay_ms": 0,
@@ -267,6 +275,7 @@
     },
     {
       "name": "veil_radiance",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 200,
@@ -288,6 +297,7 @@
     },
     {
       "name": "sneak",
+      "cooldown_mechanism": "time",
       "cooldown_ms": 2000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
@@ -307,6 +317,7 @@
     },
     {
       "name": "antimatter",
+      "cooldown_mechanism": "stamina",
       "cooldown_ms": 2000,
       "execution_duration_ms": 800,
       "activation_delay_ms": 500,

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -352,6 +352,15 @@ defmodule ArenaLoadTest.Serialization.Player.EffectsEntry do
   field(:value, 2, type: ArenaLoadTest.Serialization.Effect)
 end
 
+defmodule ArenaLoadTest.Serialization.Player.CooldownsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :uint64)
+end
+
 defmodule ArenaLoadTest.Serialization.Player do
   @moduledoc false
 
@@ -380,6 +389,12 @@ defmodule ArenaLoadTest.Serialization.Player do
   )
 
   field(:inventory, 11, type: ArenaLoadTest.Serialization.Item)
+
+  field(:cooldowns, 12,
+    repeated: true,
+    type: ArenaLoadTest.Serialization.Player.CooldownsEntry,
+    map: true
+  )
 end
 
 defmodule ArenaLoadTest.Serialization.Effect do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -4450,7 +4450,8 @@ proto.Player.toObject = function(includeInstance, msg) {
     characterName: jspb.Message.getFieldWithDefault(msg, 8, ""),
     powerUps: jspb.Message.getFieldWithDefault(msg, 9, 0),
     effectsMap: (f = msg.getEffectsMap()) ? f.toObject(includeInstance, proto.Effect.toObject) : [],
-    inventory: (f = msg.getInventory()) && proto.Item.toObject(includeInstance, f)
+    inventory: (f = msg.getInventory()) && proto.Item.toObject(includeInstance, f),
+    cooldownsMap: (f = msg.getCooldownsMap()) ? f.toObject(includeInstance, undefined) : []
   };
 
   if (includeInstance) {
@@ -4534,6 +4535,12 @@ proto.Player.deserializeBinaryFromReader = function(msg, reader) {
       var value = new proto.Item;
       reader.readMessage(value,proto.Item.deserializeBinaryFromReader);
       msg.setInventory(value);
+      break;
+    case 12:
+      var value = msg.getCooldownsMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readUint64, null, "", 0);
+         });
       break;
     default:
       reader.skipField();
@@ -4639,6 +4646,10 @@ proto.Player.serializeBinaryToWriter = function(message, writer) {
       f,
       proto.Item.serializeBinaryToWriter
     );
+  }
+  f = message.getCooldownsMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(12, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeUint64);
   }
 };
 
@@ -4882,6 +4893,29 @@ proto.Player.prototype.clearInventory = function() {
  */
 proto.Player.prototype.hasInventory = function() {
   return jspb.Message.getField(this, 11) != null;
+};
+
+
+/**
+ * map<string, uint64> cooldowns = 12;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,number>}
+ */
+proto.Player.prototype.getCooldownsMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,number>} */ (
+      jspb.Message.getMapField(this, 12, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.clearCooldownsMap = function() {
+  this.getCooldownsMap().clear();
+  return this;
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -1,7 +1,7 @@
 defmodule GameClient.Protobuf.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -11,7 +11,7 @@ end
 defmodule GameClient.Protobuf.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:ACTIVE, 0)
   field(:EXPLODED, 1)
@@ -20,7 +20,7 @@ end
 defmodule GameClient.Protobuf.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -29,7 +29,7 @@ end
 defmodule GameClient.Protobuf.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -42,7 +42,7 @@ end
 defmodule GameClient.Protobuf.Direction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:x, 1, type: :float)
   field(:y, 2, type: :float)
@@ -51,7 +51,7 @@ end
 defmodule GameClient.Protobuf.Position do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:x, 1, type: :float)
   field(:y, 2, type: :float)
@@ -60,7 +60,7 @@ end
 defmodule GameClient.Protobuf.GameEvent do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:event, 0)
 
@@ -73,7 +73,7 @@ end
 defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -82,7 +82,7 @@ end
 defmodule GameClient.Protobuf.GameFinished do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:winner, 1, type: GameClient.Protobuf.Entity)
 
@@ -96,7 +96,7 @@ end
 defmodule GameClient.Protobuf.PingUpdate do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:latency, 1, type: :uint64)
 end
@@ -104,7 +104,7 @@ end
 defmodule GameClient.Protobuf.GameJoined do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: GameClient.Protobuf.Configuration)
@@ -113,7 +113,7 @@ end
 defmodule GameClient.Protobuf.Configuration do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:game, 1, type: GameClient.Protobuf.ConfigGame)
   field(:map, 2, type: GameClient.Protobuf.ConfigMap)
@@ -123,7 +123,7 @@ end
 defmodule GameClient.Protobuf.ConfigGame do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
 end
@@ -131,7 +131,7 @@ end
 defmodule GameClient.Protobuf.ConfigMap do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
 end
@@ -139,7 +139,7 @@ end
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: GameClient.Protobuf.ConfigSkill)
@@ -148,7 +148,7 @@ end
 defmodule GameClient.Protobuf.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -167,7 +167,7 @@ end
 defmodule GameClient.Protobuf.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -181,7 +181,7 @@ end
 defmodule GameClient.Protobuf.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -190,7 +190,7 @@ end
 defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -199,7 +199,7 @@ end
 defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -208,7 +208,7 @@ end
 defmodule GameClient.Protobuf.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -217,7 +217,7 @@ end
 defmodule GameClient.Protobuf.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -226,7 +226,7 @@ end
 defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -235,7 +235,7 @@ end
 defmodule GameClient.Protobuf.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -244,7 +244,7 @@ end
 defmodule GameClient.Protobuf.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -253,7 +253,7 @@ end
 defmodule GameClient.Protobuf.GameState do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
   field(:players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true)
@@ -305,7 +305,7 @@ end
 defmodule GameClient.Protobuf.Entity do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:aditional_info, 0)
 
@@ -331,16 +331,25 @@ end
 defmodule GameClient.Protobuf.Player.EffectsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Effect)
 end
 
+defmodule GameClient.Protobuf.Player.CooldownsEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :uint64)
+end
+
 defmodule GameClient.Protobuf.Player do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:health, 1, type: :uint64)
   field(:kill_count, 2, type: :uint64, json_name: "killCount")
@@ -359,12 +368,13 @@ defmodule GameClient.Protobuf.Player do
   field(:power_ups, 9, type: :uint64, json_name: "powerUps")
   field(:effects, 10, repeated: true, type: GameClient.Protobuf.Player.EffectsEntry, map: true)
   field(:inventory, 11, type: GameClient.Protobuf.Item)
+  field(:cooldowns, 12, repeated: true, type: GameClient.Protobuf.Player.CooldownsEntry, map: true)
 end
 
 defmodule GameClient.Protobuf.Effect do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -373,7 +383,7 @@ end
 defmodule GameClient.Protobuf.Item do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 2, type: :string)
 end
@@ -381,7 +391,7 @@ end
 defmodule GameClient.Protobuf.Projectile do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:damage, 1, type: :uint64)
   field(:owner_id, 2, type: :uint64, json_name: "ownerId")
@@ -392,7 +402,7 @@ end
 defmodule GameClient.Protobuf.Obstacle do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:color, 1, type: :string)
 end
@@ -400,7 +410,7 @@ end
 defmodule GameClient.Protobuf.PowerUp do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: GameClient.Protobuf.PowerUpstatus, enum: true)
@@ -409,7 +419,7 @@ end
 defmodule GameClient.Protobuf.Pool do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
 end
@@ -417,7 +427,7 @@ end
 defmodule GameClient.Protobuf.PlayerAction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -426,7 +436,7 @@ end
 defmodule GameClient.Protobuf.Move do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:direction, 1, type: GameClient.Protobuf.Direction)
 end
@@ -434,7 +444,7 @@ end
 defmodule GameClient.Protobuf.Attack do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: GameClient.Protobuf.AttackParameters)
@@ -443,7 +453,7 @@ end
 defmodule GameClient.Protobuf.AttackParameters do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:target, 1, type: GameClient.Protobuf.Direction)
 end
@@ -451,7 +461,7 @@ end
 defmodule GameClient.Protobuf.UseItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -459,7 +469,7 @@ end
 defmodule GameClient.Protobuf.GameAction do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:action_type, 0)
 
@@ -472,7 +482,7 @@ end
 defmodule GameClient.Protobuf.Zone do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -483,7 +493,7 @@ end
 defmodule GameClient.Protobuf.KillEntry do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -1,7 +1,7 @@
 defmodule Gateway.Serialization.WebSocketRequest do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:request_type, 0)
 
@@ -75,7 +75,7 @@ end
 defmodule Gateway.Serialization.GetUser do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -83,7 +83,7 @@ end
 defmodule Gateway.Serialization.GetUserByUsername do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:username, 1, type: :string)
 end
@@ -91,7 +91,7 @@ end
 defmodule Gateway.Serialization.CreateUser do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:username, 1, type: :string)
 end
@@ -99,7 +99,7 @@ end
 defmodule Gateway.Serialization.GetCampaigns do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -107,7 +107,7 @@ end
 defmodule Gateway.Serialization.GetCampaign do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -116,7 +116,7 @@ end
 defmodule Gateway.Serialization.GetLevel do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:level_id, 2, type: :string, json_name: "levelId")
@@ -125,7 +125,7 @@ end
 defmodule Gateway.Serialization.FightLevel do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:level_id, 2, type: :string, json_name: "levelId")
@@ -142,7 +142,7 @@ end
 defmodule Gateway.Serialization.SelectUnit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -152,7 +152,7 @@ end
 defmodule Gateway.Serialization.UnselectUnit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -161,7 +161,7 @@ end
 defmodule Gateway.Serialization.LevelUpUnit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -170,7 +170,7 @@ end
 defmodule Gateway.Serialization.TierUpUnit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -179,7 +179,7 @@ end
 defmodule Gateway.Serialization.FuseUnit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -189,7 +189,7 @@ end
 defmodule Gateway.Serialization.EquipItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -199,7 +199,7 @@ end
 defmodule Gateway.Serialization.UnequipItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -208,7 +208,7 @@ end
 defmodule Gateway.Serialization.GetItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -217,7 +217,7 @@ end
 defmodule Gateway.Serialization.LevelUpItem do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -251,7 +251,7 @@ end
 defmodule Gateway.Serialization.WebSocketResponse do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof(:response_type, 0)
 
@@ -290,7 +290,7 @@ end
 defmodule Gateway.Serialization.User do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:username, 2, type: :string)
@@ -311,7 +311,7 @@ end
 defmodule Gateway.Serialization.CampaignProgress do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -321,7 +321,7 @@ end
 defmodule Gateway.Serialization.UserCurrency do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 2, type: :uint32)
@@ -330,7 +330,7 @@ end
 defmodule Gateway.Serialization.Currency do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:name, 1, type: :string)
 end
@@ -338,7 +338,7 @@ end
 defmodule Gateway.Serialization.Unit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint32)
@@ -363,7 +363,7 @@ end
 defmodule Gateway.Serialization.UnitAndCurrencies do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:unit, 1, type: Gateway.Serialization.Unit)
 
@@ -377,7 +377,7 @@ end
 defmodule Gateway.Serialization.Character do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:active, 1, type: :bool)
   field(:name, 2, type: :string)
@@ -388,7 +388,7 @@ end
 defmodule Gateway.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint32)
@@ -400,7 +400,7 @@ end
 defmodule Gateway.Serialization.ItemTemplate do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:name, 2, type: :string)
@@ -410,7 +410,7 @@ end
 defmodule Gateway.Serialization.Campaigns do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
 end
@@ -418,7 +418,7 @@ end
 defmodule Gateway.Serialization.Campaign do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:super_campaign_id, 2, type: :string, json_name: "superCampaignId")
@@ -429,7 +429,7 @@ end
 defmodule Gateway.Serialization.Level do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:id, 1, type: :string)
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -440,7 +440,7 @@ end
 defmodule Gateway.Serialization.BattleResult do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:result, 1, type: :string)
 end
@@ -448,7 +448,7 @@ end
 defmodule Gateway.Serialization.Error do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:reason, 1, type: :string)
 end

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -152,6 +152,7 @@ message Player {
   uint64 power_ups = 9;
   map<uint64, Effect> effects = 10;
   Item inventory = 11;
+  map<string, uint64> cooldowns = 12;
 }
 
 message Effect {


### PR DESCRIPTION
We introduce a new field for skills called `cooldown_mechanism` which (for now) can be one of two values
- `time` the cooldown is based on time since last execution, this time is read from `cooldown_ms` field. When a skill has this mechanism it will not use stamina or anything related to that
- `stamina` their is no real cooldown rather the skill can be used as long as you have enough stamina. Skills using this won't ever be added to the cooldowns list

You can use https://github.com/lambdaclass/curse_of_mirra/pull/1595 to test or `main`, either thing should work