### PR TITLE
Remove unused GetUnits message

### DIFF
--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -29,7 +29,6 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
   field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
-  field(:get_units, 8, type: Gateway.Serialization.GetUnits, json_name: "getUnits", oneof: 0)
   field(:select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
 
   field(:unselect_unit, 10,
@@ -141,14 +140,6 @@ defmodule Gateway.Serialization.FightLevel do
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:level_id, 2, type: :string, json_name: "levelId")
-end
-
-defmodule Gateway.Serialization.GetUnits do
-  @moduledoc false
-
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
-
-  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -334,7 +325,7 @@ defmodule Gateway.Serialization.User do
   field(:campaign_progresses, 6,
     repeated: true,
     type: Gateway.Serialization.CampaignProgress,
-    json_name: "campaignsProgress"
+    json_name: "campaignProgresses"
   )
 
   field(:currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency)

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -9,7 +9,6 @@ syntax = "proto3";
       GetCampaign get_campaign = 5;
       GetLevel get_level = 6;
       FightLevel fight_level = 7;
-      GetUnits get_units = 8;
       SelectUnit select_unit = 9;
       UnselectUnit unselect_unit = 10;
       LevelUpUnit level_up_unit = 11;
@@ -56,10 +55,6 @@ syntax = "proto3";
   message FightLevel {
    string user_id = 1;
    string level_id = 2;
-  }
-
-  message GetUnits {
-    string user_id = 1;
   }
   
   message SelectUnit {


### PR DESCRIPTION
Remove the GetUnits message from gateway.proto, as it is unused and it was already removed in https://github.com/lambdaclass/champions_of_mirra/pull/270