### PR TITLE
Testing balance changes

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -295,7 +295,7 @@
     {
       "name": "veil_radiance",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 1800,
+      "cooldown_ms": 4000,
       "execution_duration_ms": 500,
       "activation_delay_ms": 200,
       "is_passive": false,
@@ -493,7 +493,7 @@
   "effects": [
     {
       "name": "invisible",
-      "duration_ms": 4000,
+      "duration_ms": 3000,
       "remove_on_action": true,
       "effect_mechanics": {}
     },

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -142,12 +142,12 @@
       "mechanics": [
         {
           "leap": {
-            "range": 1000.0,
-            "duration_ms": 600,
+            "range": 1250.0,
+            "duration_ms": 400,
             "radius": 600,
             "on_arrival_mechanic": {
               "circle_hit": {
-                "damage": 40,
+                "damage": 48,
                 "range": 600.0
               }
             }
@@ -193,7 +193,7 @@
             "interval_ms": 100,
             "amount": 10,
             "speed": 65.0,
-            "duration_ms": 1000,
+            "duration_ms": 500,
             "remove_on_collision": true,
             "projectile_offset": 100,
             "angle": 80.0,
@@ -252,7 +252,7 @@
     {
       "name": "h4ck_dash",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 2000,
+      "cooldown_ms": 2600,
       "execution_duration_ms": 500,
       "activation_delay_ms": 0,
       "is_passive": false,
@@ -281,9 +281,9 @@
       "mechanics": [
         {
           "multi_cone_hit": {
-            "damage": 7,
+            "damage": 11,
             "range": 800.0,
-            "angle": 45.0,
+            "angle": 25.0,
             "interval_ms": 250,
             "amount": 3,
             "move_by": 150.0
@@ -443,7 +443,7 @@
       "base_stamina": 3,
       "stamina_interval": 1800,
       "max_inventory_size": 1,
-      "natural_healing_interval": 300,
+      "natural_healing_interval": 400,
       "natural_healing_damage_interval": 1600,
       "skills": {
         "1": "avenge",

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -132,7 +132,7 @@
     {
       "name": "leap",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 2000,
+      "cooldown_ms": 3000,
       "execution_duration_ms": 800,
       "activation_delay_ms": 200,
       "is_passive": false,
@@ -147,7 +147,7 @@
             "radius": 600,
             "on_arrival_mechanic": {
               "circle_hit": {
-                "damage": 22,
+                "damage": 30,
                 "range": 600.0
               }
             }
@@ -180,7 +180,7 @@
     {
       "name": "denial_of_service",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 2000,
+      "cooldown_ms": 1800,
       "execution_duration_ms": 1000,
       "activation_delay_ms": 0,
       "is_passive": false,
@@ -197,7 +197,7 @@
             "remove_on_collision": true,
             "projectile_offset": 100,
             "angle": 80.0,
-            "damage": 9,
+            "damage": 11,
             "radius": 12.0
           }
         }
@@ -276,7 +276,7 @@
     {
       "name": "veil_radiance",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 2000,
+      "cooldown_ms": 1800,
       "execution_duration_ms": 500,
       "activation_delay_ms": 200,
       "is_passive": false,
@@ -286,7 +286,7 @@
       "mechanics": [
         {
           "circle_hit": {
-            "damage": 14,
+            "damage": 18,
             "range": 800.0
           }
         }
@@ -384,13 +384,13 @@
     {
       "name": "muflus",
       "active": true,
-      "base_speed": 30.0,
+      "base_speed": 25.0,
       "base_size": 100.0,
-      "base_health": 110,
-      "base_stamina": 3,
-      "stamina_interval": 2000,
+      "base_health": 130,
+      "base_stamina": 2,
+      "stamina_interval": 2500,
       "max_inventory_size": 1,
-      "natural_healing_interval": 1000,
+      "natural_healing_interval": 1500,
       "natural_healing_damage_interval": 5000,
       "skills": {
         "1": "hit",
@@ -401,11 +401,11 @@
     {
       "name": "h4ck",
       "active": true,
-      "base_speed": 30.0,
+      "base_speed": 35.0,
       "base_size": 80.0,
       "base_health": 100,
-      "base_stamina": 3,
-      "stamina_interval": 2000,
+      "base_stamina": 4,
+      "stamina_interval": 1500,
       "max_inventory_size": 1,
       "natural_healing_interval": 1000,
       "natural_healing_damage_interval": 5000,
@@ -418,11 +418,11 @@
     {
       "name": "uma",
       "active": true,
-      "base_speed": 30.0,
+      "base_speed": 32.0,
       "base_size": 85.0,
-      "base_health": 100,
+      "base_health": 90,
       "base_stamina": 3,
-      "stamina_interval": 2000,
+      "stamina_interval": 1800,
       "max_inventory_size": 1,
       "natural_healing_interval": 1000,
       "natural_healing_damage_interval": 5000,

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -132,7 +132,7 @@
     {
       "name": "leap",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 3000,
+      "cooldown_ms": 4000,
       "execution_duration_ms": 800,
       "activation_delay_ms": 200,
       "is_passive": false,
@@ -147,7 +147,7 @@
             "radius": 600,
             "on_arrival_mechanic": {
               "circle_hit": {
-                "damage": 30,
+                "damage": 40,
                 "range": 600.0
               }
             }
@@ -220,10 +220,10 @@
             "angle_between": 14.0,
             "amount": 3,
             "speed": 58.0,
-            "duration_ms": 1000,
+            "duration_ms": 750,
             "remove_on_collision": true,
             "projectile_offset": 100,
-            "damage": 9,
+            "damage": 12,
             "radius": 12.0
           }
         }
@@ -244,6 +244,25 @@
         {
           "dash": {
             "speed": 60.0,
+            "duration": 500
+          }
+        }
+      ]
+    },
+    {
+      "name": "h4ck_dash",
+      "cooldown_mechanism": "time",
+      "cooldown_ms": 2000,
+      "execution_duration_ms": 500,
+      "activation_delay_ms": 0,
+      "is_passive": false,
+      "autoaim": false,
+      "stamina_cost": 1,
+      "can_pick_destination": false,
+      "mechanics": [
+        {
+          "dash": {
+            "speed": 80.0,
             "duration": 500
           }
         }
@@ -412,7 +431,7 @@
       "skills": {
         "1": "slingshot",
         "2": "denial_of_service",
-        "3": "dash"
+        "3": "h4ck_dash"
       }
     },
     {
@@ -424,8 +443,8 @@
       "base_stamina": 3,
       "stamina_interval": 1800,
       "max_inventory_size": 1,
-      "natural_healing_interval": 1000,
-      "natural_healing_damage_interval": 5000,
+      "natural_healing_interval": 300,
+      "natural_healing_damage_interval": 1600,
       "skills": {
         "1": "avenge",
         "2": "veil_radiance",


### PR DESCRIPTION
MUFLUS (SLOW and STRONG)
Base Health: Increase to 130 to emphasize durability.
Base Stamina: Decrease to 2 to reflect slower, more powerful actions.
Stamina Interval: Increase to 2500 ms to slow down stamina recovery, fitting the slower character design.
Leap Damage: Increase to 30 to make the ultimate more devastating.
Base Speed: Decrease to 25 to emphasize the character's slowness.

H4CK (FAST and RANGED DPS)
Base Health: Keep at 100 to maintain balance with high mobility.
Base Stamina: Increase to 4 to allow for more frequent attacks.
Stamina Interval: Decrease to 1500 ms for faster stamina recovery, supporting rapid movement and attacks.
Denial of Service Damage: Increase to 11 per shot to boost DPS capability.
Base Speed: Increase to 35 to emphasize agility.

UMA (TRICKY and STEALTHY)
Base Health: Decrease to 90 to reflect the character's elusive nature.
Base Stamina: Keep at 3, suitable for a stealthy assassin.
Stamina Interval: Set to 1800 ms to balance between MUFLUS and H4CK.
Veil Radiance Damage: Increase to 18 to make surprise attacks more lethal.
Base Speed: Increase to 32 to aid in stealth and quick strikes.


Skills Adjustments
Leap (MUFLUS): Increase cooldown to 3000 ms to prevent overuse of the powerful ultimate.
Denial of Service (H4CK): Decrease cooldown to 1800 ms to enhance the DPS role.
Veil Radiance (UMA): Decrease cooldown to 1800 ms to allow for more frequent stealth attacks.
Healing and Natural Recovery
MUFLUS: Increase natural healing interval to 1500 ms due to higher health, reflecting the tankier nature.
H4CK and UMA: Keep natural healing interval at 1000 ms, suitable for their more agile and risk-taking playstyles.