### PR TITLE
Randomize characters and skills in load tests

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -434,7 +434,7 @@
     },
     {
       "name": "valtimer",
-      "active": false,
+      "active": true,
       "base_speed": 30.0,
       "base_size": 90.0,
       "base_health": 100,

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -434,7 +434,7 @@
     },
     {
       "name": "valtimer",
-      "active": true,
+      "active": false,
       "base_speed": 30.0,
       "base_size": 90.0,
       "base_health": 100,

--- a/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
@@ -107,13 +107,10 @@ defmodule ArenaLoadTest.GameSocketHandler do
     end
   end
 
+  # This is enough for now. We will get the skills from the requested bots
+  # from the bots app. This will be done in future iterations.
   defp get_available_skills() do
-    Arena.Configuration.get_game_config()
-    |> Map.get(:characters)
-    # Taking anyone is fine since all of them have the same amount of skills
-    # and the skills are just numbers from 1 to N.
-    |> hd()
-    |> Map.get(:skills)
-    |> Map.keys()
+    ["1", "2", "3"]
+    |> Enum.random()
   end
 end

--- a/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
@@ -62,7 +62,7 @@ defmodule ArenaLoadTest.GameSocketHandler do
         action_type:
           {:attack,
            %Serialization.Attack{
-             skill: Enum.random(get_random_available_skill()),
+             skill: get_random_available_skill(),
              parameters: %Serialization.AttackParameters{
                target: %Serialization.Direction{
                  x: x,

--- a/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
@@ -107,6 +107,7 @@ defmodule ArenaLoadTest.GameSocketHandler do
 
   # This is enough for now. We will get the skills from the requested bots
   # from the bots app. This will be done in future iterations.
+  # https://github.com/lambdaclass/mirra_backend/issues/410
   defp get_random_available_skill() do
     ["1", "2", "3"]
     |> Enum.random()

--- a/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
@@ -11,13 +11,15 @@ defmodule ArenaLoadTest.GameSocketHandler do
   def start_link({client_id, game_id}) do
     Logger.info("Player INIT")
     ws_url = ws_url(client_id, game_id)
+    skills = get_available_skills()
 
     WebSockex.start_link(
       ws_url,
       __MODULE__,
       %{
         client_id: client_id,
-        game_id: game_id
+        game_id: game_id,
+        skills: skills
       }
     )
   end
@@ -62,7 +64,7 @@ defmodule ArenaLoadTest.GameSocketHandler do
         action_type:
           {:attack,
            %Serialization.Attack{
-             skill: "1",
+             skill: Enum.random(state.skills),
              parameters: %Serialization.AttackParameters{
                target: %Serialization.Direction{
                  x: x,
@@ -103,5 +105,15 @@ defmodule ArenaLoadTest.GameSocketHandler do
       _ ->
         "ws://#{host}/play/#{game_id}/#{client_id}"
     end
+  end
+
+  defp get_available_skills() do
+    Arena.Configuration.get_game_config()
+    |> Map.get(:characters)
+    # Taking anyone is fine since all of them have the same amount of skills
+    # and the skills are just numbers from 1 to N.
+    |> hd()
+    |> Map.get(:skills)
+    |> Map.keys()
   end
 end

--- a/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/game_socket_handler.ex
@@ -11,15 +11,13 @@ defmodule ArenaLoadTest.GameSocketHandler do
   def start_link({client_id, game_id}) do
     Logger.info("Player INIT")
     ws_url = ws_url(client_id, game_id)
-    skills = get_available_skills()
 
     WebSockex.start_link(
       ws_url,
       __MODULE__,
       %{
         client_id: client_id,
-        game_id: game_id,
-        skills: skills
+        game_id: game_id
       }
     )
   end
@@ -64,7 +62,7 @@ defmodule ArenaLoadTest.GameSocketHandler do
         action_type:
           {:attack,
            %Serialization.Attack{
-             skill: Enum.random(state.skills),
+             skill: Enum.random(get_random_available_skill()),
              parameters: %Serialization.AttackParameters{
                target: %Serialization.Direction{
                  x: x,
@@ -109,7 +107,7 @@ defmodule ArenaLoadTest.GameSocketHandler do
 
   # This is enough for now. We will get the skills from the requested bots
   # from the bots app. This will be done in future iterations.
-  defp get_available_skills() do
+  defp get_random_available_skill() do
     ["1", "2", "3"]
     |> Enum.random()
   end

--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -68,11 +68,9 @@ defmodule ArenaLoadTest.SocketHandler do
     end
   end
 
+  # This is enough for now. Will request bots from the bots app in future iterations.
   defp get_random_active_character() do
-    Arena.Configuration.get_game_config()
-    |> Map.get(:characters)
-    |> Enum.filter(fn character -> character.active end)
-    |> Enum.map(fn character -> character.name end)
+    ["muflus", "h4ck", "uma"]
     |> Enum.random()
   end
 end

--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -69,6 +69,7 @@ defmodule ArenaLoadTest.SocketHandler do
   end
 
   # This is enough for now. Will request bots from the bots app in future iterations.
+  # https://github.com/lambdaclass/mirra_backend/issues/410
   defp get_random_active_character() do
     ["muflus", "h4ck", "uma"]
     |> Enum.random()

--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -58,7 +58,7 @@ defmodule ArenaLoadTest.SocketHandler do
     host = SocketSupervisor.server_host()
     # TODO must replace character with a random available one.
     # TODO this will be done as part of https://github.com/lambdaclass/mirra_backend/issues/361
-    character = "h4ck"
+    character = get_random_active_character()
     player_name = "Player_#{player_id}"
 
     case System.get_env("SSL_ENABLED") do
@@ -68,5 +68,13 @@ defmodule ArenaLoadTest.SocketHandler do
       _ ->
         "ws://#{host}/join/#{player_id}/#{character}/#{player_name}"
     end
+  end
+
+  defp get_random_active_character() do
+    Arena.Configuration.get_game_config()
+    |> Map.get(:characters)
+    |> Enum.filter(fn character -> character.active end)
+    |> Enum.map(fn character -> character.name end)
+    |> Enum.random()
   end
 end

--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -56,8 +56,6 @@ defmodule ArenaLoadTest.SocketHandler do
   # Private
   defp ws_url(player_id) do
     host = SocketSupervisor.server_host()
-    # TODO must replace character with a random available one.
-    # TODO this will be done as part of https://github.com/lambdaclass/mirra_backend/issues/361
     character = get_random_active_character()
     player_name = "Player_#{player_id}"
 


### PR DESCRIPTION
## Motivation
LoadTest's mocked players were all h4cks and they were using their basic skill only (we got ulti and dash too).
Closes #397

## Changes:

- [Set random character instead of always being h4ck](https://github.com/lambdaclass/mirra_backend/commit/e9c055e84bda6c6e223fcf9ba9c5cbbaf0d2e371)
- [Make mocked players to use random skills](https://github.com/lambdaclass/mirra_backend/commit/3d455b421d5bcc080c7bacd029a10cd4229ab670)
- [Make valtimer inactive because he's not active in the main client](https://github.com/lambdaclass/mirra_backend/commit/35342c1bf393fd785bc521f41717bd9f6b98d4d8)
- [Remove TODO tag message](https://github.com/lambdaclass/mirra_backend/commit/f0adebf594f326c5653dfc1a301482d559ceaff1)

## How to test it?

I'll attach a video about it. Basically what you do is start a game and instantiate as many mocked players as you want.

https://github.com/lambdaclass/mirra_backend/assets/65268603/402cbb9a-57e3-45b6-9d3b-9dfecd7717bf

