### PR TITLE
[gh-400] Change muflus hit to circle hit

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -12,7 +12,8 @@ defmodule Arena.Game.Skill do
   end
 
   def do_mechanic(game_state, entity, {:circle_hit, circle_hit}, _skill_params) do
-    circular_damage_area = Entities.make_circular_area(entity.id, entity.position, circle_hit.range)
+    circle_center_position = get_position_with_offset(entity.position, entity.direction, circle_hit.offset)
+    circular_damage_area = Entities.make_circular_area(entity.id, circle_center_position, circle_hit.range)
 
     entity_player_owner = get_entity_player_owner(game_state, entity)
 
@@ -130,7 +131,11 @@ defmodule Arena.Game.Skill do
     projectile =
       Entities.new_projectile(
         last_id,
-        get_real_projectile_spawn_position(entity_player_owner, repeated_shot),
+        get_position_with_offset(
+          entity_player_owner.position,
+          entity_player_owner.direction,
+          repeated_shot.projectile_offset
+        ),
         randomize_direction_in_angle(entity.direction, repeated_shot.angle),
         entity_player_owner.id,
         skill_params.skill_key,
@@ -154,7 +159,11 @@ defmodule Arena.Game.Skill do
       projectile =
         Entities.new_projectile(
           last_id,
-          get_real_projectile_spawn_position(entity_player_owner, multishot),
+          get_position_with_offset(
+            entity_player_owner.position,
+            entity_player_owner.direction,
+            multishot.projectile_offset
+          ),
           direction,
           entity_player_owner.id,
           skill_params.skill_key,
@@ -176,7 +185,11 @@ defmodule Arena.Game.Skill do
     projectile =
       Entities.new_projectile(
         last_id,
-        get_real_projectile_spawn_position(entity_player_owner, simple_shoot),
+        get_position_with_offset(
+          entity_player_owner.position,
+          entity_player_owner.directio,
+          simple_shoot.projectile_offset
+        ),
         entity.direction,
         entity_player_owner.id,
         skill_params.skill_key,
@@ -373,9 +386,9 @@ defmodule Arena.Game.Skill do
     Enum.concat([add_side, middle, sub_side])
   end
 
-  defp get_real_projectile_spawn_position(spawner, specs) do
-    real_position_x = spawner.position.x + specs.projectile_offset * spawner.direction.x
-    real_position_y = spawner.position.y + specs.projectile_offset * spawner.direction.y
+  defp get_position_with_offset(position, direction, offset) do
+    real_position_x = position.x + offset * direction.x
+    real_position_y = position.y + offset * direction.y
 
     %{x: real_position_x, y: real_position_y}
   end

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -95,10 +95,10 @@
       "can_pick_destination": false,
       "mechanics": [
         {
-          "cone_hit": {
+          "circle_hit": {
             "damage": 16,
-            "range": 1100.0,
-            "angle": 50.0
+            "range": 150.0,
+            "offset": 500
           }
         }
       ],
@@ -148,7 +148,8 @@
             "on_arrival_mechanic": {
               "circle_hit": {
                 "damage": 22,
-                "range": 600.0
+                "range": 600.0,
+                "offset": 0
               }
             }
           }
@@ -287,7 +288,8 @@
         {
           "circle_hit": {
             "damage": 14,
-            "range": 800.0
+            "range": 800.0,
+            "offset": 0
           }
         }
       ],
@@ -337,7 +339,8 @@
             "on_explode_mechanics": {
               "circle_hit": {
                 "damage": 15,
-                "range": 500.0
+                "range": 500.0,
+                "offset": 0
               }
             }
           }


### PR DESCRIPTION
Closes #400 

Replaced muflus "hit" skill with a circle hit instead of a cone hit

Added offset to the circle generated with the circle hit mechanic same as the projectile spawning

Hit that damaged the enemy
<img width="1246" alt="Screenshot 2024-03-22 at 11 37 03" src="https://github.com/lambdaclass/mirra_backend/assets/106101218/a2076ec4-9402-4e92-a6dd-db7f33f42629">

Missed hit
<img width="606" alt="Screenshot 2024-03-22 at 11 38 17" src="https://github.com/lambdaclass/mirra_backend/assets/106101218/d1a3185b-21df-4e94-9252-22aebcdd4497">
