### PR TITLE
Fix consumed units not owned on fuse

### DIFF
--- a/apps/champions/lib/champions/units.ex
+++ b/apps/champions/lib/champions/units.ex
@@ -269,6 +269,9 @@ defmodule Champions.Units do
       {:unit_not_in_consumed_units, false} ->
         {:error, :consumed_units_invalid}
 
+      {:consumed_units_owned, false} ->
+        {:error, :consumed_units_not_found}
+
       {:consumed_units_count, false} ->
         {:error, :consumed_units_not_found}
 


### PR DESCRIPTION
Closes: https://github.com/lambdaclass/champions_of_mirra/issues/302

We were missing a clause in the fuse `with` failure path

# To Test

Run a fusion:

```
{:ok, user} = Champions.Users.register("User")
character = GameBackend.Units.Characters.get_character_by_name("Muflus")
```
Create 6 rank 5 muflus
```
{:ok, unit_n} = GameBackend.Units.insert_unit(%{character_id: character.id, user_id: user.id, level: 1, tier: 1, selected: false, slot: nil, rank: 5})
```
Fusing 5 of them to the first one
```
{:ok, new_unit} = Champions.Units.fuse(user.id, unit_1.id, [unit_2.id, unit_3.id, unit_4.id, unit_5.id, unit_6.id])
```



Now let's do it again but passing in a unit that exists but is not owned by the user:
Create a new user and get one of its units
```
{:ok, another_user} = Champions.Users.register("AnotherUser")
[random_unit | _] = another_user.units
```
Create 5 rank 5 Muflus
```
{:ok, unit_n} = GameBackend.Units.insert_unit(%{character_id: character.id, user_id: user.id, level: 1, tier: 1, selected: false, slot: nil, rank: 5})
```
Try fusing
```
{:error, :consumed_units_not_found} = Champions.Units.fuse(user.id, unit_1.id, [random_unit.id, unit_2.id, unit_3.id, unit_4.id, unit_5.id])
```