### PR TITLE
Fix deployment bug

### DIFF
--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -51,8 +51,9 @@ defmodule Arena.MixProject do
       {:exbase58, "~> 1.0.2"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:plug_cowboy, "~> 2.5"},
-      {:toxiproxy_ex, "~> 1.1.1"},
-      {:configurator, in_umbrella: true}
+      {:toxiproxy_ex, "~> 1.1.1"}
+      # TODO We will find a way to solve this dependency.
+      # {:configurator, in_umbrella: true}
     ]
   end
 

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -52,8 +52,6 @@ defmodule Arena.MixProject do
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:plug_cowboy, "~> 2.5"},
       {:toxiproxy_ex, "~> 1.1.1"}
-      # TODO We will find a way to solve this dependency.
-      # {:configurator, in_umbrella: true}
     ]
   end
 


### PR DESCRIPTION
## Motivation
Deployment was being executed successfully but the service kept restaring because the configurator app was being launched alongside arena (we don't want this).

## Changes
Remove configurator as arena dependency