### PR TITLE
Sort units by level

### DIFF
--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -19,7 +19,7 @@ defmodule GameBackend.Users.User do
     field(:last_afk_reward_claim, :utc_datetime)
 
     has_many(:currencies, UserCurrency)
-    has_many(:units, Unit)
+    has_many(:units, Unit, preload_order: [desc: :level])
     has_many(:items, Item)
     has_many(:afk_reward_rates, AfkRewardRate)
     has_many(:campaign_progresses, CampaignProgress)


### PR DESCRIPTION
Closes https://github.com/lambdaclass/champions_of_mirra/issues/306

Sets the default order of the units association in users. Doesn't need any changes in the front end

# To test

Open the client and check that units are sorted by level in Barracks and LineUp (right before a battle) screens