### PR TITLE
Move advance_level to Champions app and add experience reward

### DIFF
--- a/apps/champions/lib/champions/battle.ex
+++ b/apps/champions/lib/champions/battle.ex
@@ -23,7 +23,7 @@ defmodule Champions.Battle do
       units = Units.get_selected_units(user_id)
 
       if battle(units, level.units) == :team_1 do
-        case Users.advance_level(user_id, level.campaign_id) do
+        case Champions.Campaigns.advance_level(user_id, level.campaign_id) do
           # TODO: add rewards to response [CHoM-191]
           {:ok, _changes} -> :win
           _error -> {:error, :failed_to_advance}

--- a/apps/champions/lib/champions/campaigns.ex
+++ b/apps/champions/lib/champions/campaigns.ex
@@ -3,7 +3,16 @@ defmodule Champions.Campaigns do
   Campaigns logic for Champions of Mirra.
   """
 
+  alias Champions.Users
   alias GameBackend.Campaigns
+  alias GameBackend.Campaigns.CampaignProgress
+  alias GameBackend.Items.Item
+  alias GameBackend.Repo
+  alias GameBackend.Rewards
+  alias GameBackend.Transaction
+  alias GameBackend.Units.Unit
+  alias GameBackend.Users.Currencies
+  alias Ecto.Multi
 
   @doc """
   Gets all campaigns, and sorted ascendingly by campaign number.
@@ -30,4 +39,98 @@ defmodule Champions.Campaigns do
   Get a level by id.
   """
   def get_level(level_id), do: Campaigns.get_level(level_id)
+
+  @doc """
+  Increments a user's level and apply the level's rewards.
+  If it was the last level in the campaign, increments the campaign number and sets the level number to 1.
+  """
+  def advance_level(user_id, campaign_id) do
+    with {:campaign_progress, {:ok, campaign_progress}} <-
+           {:campaign_progress, Campaigns.get_campaign_progress(user_id, campaign_id)},
+         {:next_level, {next_campaign_id, next_level_id}} <-
+           {:next_level, Campaigns.get_next_level(campaign_progress.level)} do
+      level = campaign_progress.level
+
+      Multi.new()
+      |> apply_experience_reward(user_id, level.experience_reward)
+      |> apply_currency_rewards(user_id, level.currency_rewards)
+      |> apply_afk_rewards_increments(user_id, level.afk_rewards_increments)
+      |> Multi.insert_all(:item_rewards, Item, fn _ ->
+        build_item_rewards_params(user_id, level.item_rewards)
+      end)
+      |> Multi.insert_all(:unit_rewards, Unit, fn _ ->
+        build_unit_rewards_params(user_id, level.unit_rewards)
+      end)
+      |> Multi.run(:update_campaign_progress, fn _, _ ->
+        if next_level_id == level.id,
+          do: {:ok, nil},
+          else: update_campaign_progress(campaign_progress, next_campaign_id, next_level_id)
+      end)
+      |> Transaction.run()
+    else
+      {:campaign_progress, _transaction_error} -> {:error, :campaign_progress_not_found}
+      {:next_level, _transaction_error} -> {:campaign_progress_error}
+    end
+  end
+
+  defp update_campaign_progress(campaign_progress, next_campaign_id, next_level_id) do
+    campaign_progress
+    |> CampaignProgress.advance_level_changeset(%{
+      campaign_id: next_campaign_id,
+      level_id: next_level_id
+    })
+    |> Repo.update()
+  end
+
+  defp build_item_rewards_params(user_id, item_rewards) do
+    Enum.map(item_rewards, fn item_reward ->
+      Enum.map(1..item_reward.amount, fn _ ->
+        %{
+          user_id: user_id,
+          template_id: item_reward.item_template_id,
+          level: 1,
+          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        }
+      end)
+    end)
+    |> List.flatten()
+  end
+
+  defp build_unit_rewards_params(user_id, unit_rewards) do
+    Enum.map(unit_rewards, fn unit_reward ->
+      Enum.map(1..unit_reward.amount, fn _ ->
+        %{
+          user_id: user_id,
+          character_id: unit_reward.character_id,
+          level: 1,
+          tier: 1,
+          rank: unit_reward.rank,
+          selected: false,
+          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        }
+      end)
+    end)
+    |> List.flatten()
+  end
+
+  defp apply_currency_rewards(multi, user_id, currency_rewards) do
+    Enum.reduce(currency_rewards, multi, fn currency_reward, multi ->
+      Multi.run(multi, {:add_currency, currency_reward.currency_id}, fn _, _ ->
+        Currencies.add_currency(user_id, currency_reward.currency_id, currency_reward.amount)
+      end)
+    end)
+  end
+
+  defp apply_afk_rewards_increments(multi, user_id, afk_rewards_increments) do
+    Enum.reduce(afk_rewards_increments, multi, fn increment, multi ->
+      Multi.run(multi, {:add_afk_reward_increment, increment.currency_id}, fn _, _ ->
+        Rewards.increment_afk_reward_rate(user_id, increment.currency_id, increment.amount)
+      end)
+    end)
+  end
+
+  def apply_experience_reward(multi, user_id, experience_reward),
+    do: Multi.run(multi, :add_experience, fn _, _ -> Users.add_experience(user_id, experience_reward) end)
 end

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -11,13 +11,6 @@ defmodule GameBackend.Users do
 
   import Ecto.Query, warn: false
 
-  alias Ecto.Multi
-  alias GameBackend.Units.Unit
-  alias GameBackend.Items.Item
-  alias GameBackend.Rewards
-  alias GameBackend.Users.Currencies
-  alias GameBackend.Campaigns.CampaignProgress
-  alias GameBackend.Campaigns
   alias GameBackend.Repo
   alias GameBackend.Users.User
 
@@ -88,39 +81,6 @@ defmodule GameBackend.Users do
       |> User.experience_changeset(params)
       |> Repo.update()
 
-  @doc """
-  Increments a user's level and apply the level's rewards.
-  If it was the last level in the campaign, increments the campaign number and sets the level number to 1.
-  """
-  def advance_level(user_id, campaign_id) do
-    with {:campaign_progress, {:ok, campaign_progress}} <-
-           {:campaign_progress, Campaigns.get_campaign_progress(user_id, campaign_id)},
-         {:next_level, {next_campaign_id, next_level_id}} <-
-           {:next_level, Campaigns.get_next_level(campaign_progress.level)} do
-      level = campaign_progress.level
-
-      # TODO: Implement experience rewards [CHoM-#216]
-      Multi.new()
-      |> apply_currency_rewards(user_id, level.currency_rewards)
-      |> apply_afk_rewards_increments(user_id, level.afk_rewards_increments)
-      |> Multi.insert_all(:item_rewards, Item, fn _ ->
-        build_item_rewards_params(user_id, level.item_rewards)
-      end)
-      |> Multi.insert_all(:unit_rewards, Unit, fn _ ->
-        build_unit_rewards_params(user_id, level.unit_rewards)
-      end)
-      |> Multi.run(:update_campaign_progress, fn _, _ ->
-        if next_level_id == level.id,
-          do: {:ok, nil},
-          else: update_campaign_progress(campaign_progress, next_campaign_id, next_level_id)
-      end)
-      |> Repo.transaction()
-    else
-      {:campaign_progress, _transaction_error} -> {:error, :campaign_progress_not_found}
-      {:next_level, _transaction_error} -> {:campaign_progress_error}
-    end
-  end
-
   def reset_afk_rewards_claim(user_id) do
     {:ok, user} = get_user(user_id)
 
@@ -141,62 +101,4 @@ defmodule GameBackend.Users do
           currencies: :currency
         ]
       )
-
-  defp update_campaign_progress(campaign_progress, next_campaign_id, next_level_id) do
-    campaign_progress
-    |> CampaignProgress.advance_level_changeset(%{
-      campaign_id: next_campaign_id,
-      level_id: next_level_id
-    })
-    |> Repo.update()
-  end
-
-  defp build_item_rewards_params(user_id, item_rewards) do
-    Enum.map(item_rewards, fn item_reward ->
-      Enum.map(1..item_reward.amount, fn _ ->
-        %{
-          user_id: user_id,
-          template_id: item_reward.item_template_id,
-          level: 1,
-          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-        }
-      end)
-    end)
-    |> List.flatten()
-  end
-
-  defp build_unit_rewards_params(user_id, unit_rewards) do
-    Enum.map(unit_rewards, fn unit_reward ->
-      Enum.map(1..unit_reward.amount, fn _ ->
-        %{
-          user_id: user_id,
-          character_id: unit_reward.character_id,
-          level: 1,
-          tier: 1,
-          rank: unit_reward.rank,
-          selected: false,
-          inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-          updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-        }
-      end)
-    end)
-    |> List.flatten()
-  end
-
-  defp apply_currency_rewards(multi, user_id, currency_rewards) do
-    Enum.reduce(currency_rewards, multi, fn currency_reward, multi ->
-      Multi.run(multi, {:add_currency, currency_reward.currency_id}, fn _, _ ->
-        Currencies.add_currency(user_id, currency_reward.currency_id, currency_reward.amount)
-      end)
-    end)
-  end
-
-  defp apply_afk_rewards_increments(multi, user_id, afk_rewards_increments) do
-    Enum.reduce(afk_rewards_increments, multi, fn increment, multi ->
-      Multi.run(multi, {:add_afk_reward_increment, increment.currency_id}, fn _, _ ->
-        Rewards.increment_afk_reward_rate(user_id, increment.currency_id, increment.amount)
-      end)
-    end)
-  end
 end


### PR DESCRIPTION
Fixes https://github.com/lambdaclass/champions_of_mirra/issues/216

Adds experience rewads to levels. These are applied automatically to a user on level win.

We had to move advance_level from GameBackend to Champions since we needed a Champions function (add_experience) to make it work, which means that we were putting Champions logic inside GameBackend.


# To Test

Start the client so that the test user gets created, then run in iex:
`{:ok, user} = Champions.Users.get_user_by_username("testUser")`
Check your level and xp by running:
`Champions.Users.get_user("d53d6129-d69f-4762-8077-9d84ab25b13b") |> elem(1) |> Map.take([:experience, :level])`
Now win a level in the campaign and then check your xp again. It should have grown.