### PR TITLE
Fix amount of spawned bots

### DIFF
--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -101,7 +101,7 @@ defmodule Arena.GameLauncher do
   end
 
   defp get_bot_clients(missing_clients) do
-    Enum.map(0..missing_clients, fn i ->
+    Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
       {client_id, "h4ck", Enum.at(@bot_names, i), nil}


### PR DESCRIPTION
The amount of bots spawned in matches are wrong since we're spawning one more bots than we should, this is due to how ranges in elixir work, if we do 0..0 we still doing a cicle and spawning a bot, to fix this we'll take the same approach as the power ups changing it to `1..missing_clients//1`