### PR TITLE
Block tier ups by level

### DIFF
--- a/apps/champions/lib/champions/units.ex
+++ b/apps/champions/lib/champions/units.ex
@@ -190,9 +190,8 @@ defmodule Champions.Units do
   @doc """
   Returns whether a unit can tier up. tier is blocked by rank.
   """
-  def can_tier_up(unit), do: can_tier_up(unit.rank, unit.tier)
+  def can_tier_up(unit), do: can_tier_up(unit.rank, unit.tier) and not can_level_up(unit)
 
-  # TODO: Don't allow units with a level lower than the tier's max to tier up [#CHoM-227]
   defp can_tier_up(@star1, tier) when tier < 1, do: true
   defp can_tier_up(@star2, tier) when tier < 2, do: true
   defp can_tier_up(@star3, tier) when tier < 3, do: true


### PR DESCRIPTION
Closes [#208](https://github.com/lambdaclass/champions_of_mirra/issues/208)

Don't allow units to be tiered up unless they cannot be leveled up further