### PR TITLE
Fix valtimer singularity pulling you inside obstacles

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -251,7 +251,7 @@ defmodule Arena.Game.Skill do
 
     entity =
       entity
-      |> Physics.move_entity_to_position(target_position, game_state.external_wall)
+      |> Physics.move_entity_to_position(target_position, game_state.external_wall, game_state.obstacles)
       |> Map.put(:aditional_info, entity.aditional_info)
 
     put_in(game_state, [:players, entity.id], entity)

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -366,7 +366,13 @@ defmodule Arena.Game.Skill do
         else
           direction = Physics.get_direction_from_positions(player.position, pool.position)
 
-          Physics.move_entity_to_direction(player, direction, pull_params.force)
+          Physics.move_entity_to_direction(
+            player,
+            direction,
+            pull_params.force,
+            game_state.external_wall,
+            game_state.obstacles
+          )
           |> Map.put(:aditional_info, player.aditional_info)
           |> Map.put(:collides_with, player.collides_with)
         end

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -243,16 +243,11 @@ defmodule Arena.Game.Skill do
     put_in(game_state, [:players, player.id], player)
   end
 
-  def do_mechanic(game_state, entity, {:teleport, teleport}, %{skill_direction: skill_target}) do
-    target_position = %{
-      x: entity.position.x + skill_target.x * teleport.range,
-      y: entity.position.y + skill_target.y * teleport.range
-    }
-
+  def do_mechanic(game_state, entity, {:teleport, _teleport}, %{skill_destination: skill_destination}) do
     entity =
       entity
-      |> Physics.move_entity_to_position(target_position, game_state.external_wall, game_state.obstacles)
       |> Map.put(:aditional_info, entity.aditional_info)
+      |> Map.put(:position, skill_destination)
 
     put_in(game_state, [:players, entity.id], entity)
   end

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -21,7 +21,7 @@ defmodule Physics do
 
   def move_entity_to_position(_entity, _new_position, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
 
-  def move_entity_to_direction(_entity, _direction, _amount),
+  def move_entity_to_direction(_entity, _direction, _amount, _external_wall, _obstacles),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def add_angle_to_direction(_direction, _angle), do: :erlang.nif_error(:nif_not_loaded)

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -19,7 +19,8 @@ defmodule Physics do
 
   def move_entity(_entity, _ticks_to_move, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
 
-  def move_entity_to_position(_entity, _new_position, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
+  def move_entity_to_position(_entity, _new_position, _external_wall, _obstacles),
+    do: :erlang.nif_error(:nif_not_loaded)
 
   def move_entity_to_direction(_entity, _direction, _amount, _external_wall, _obstacles),
     do: :erlang.nif_error(:nif_not_loaded)

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -19,7 +19,7 @@ defmodule Physics do
 
   def move_entity(_entity, _ticks_to_move, _external_wall), do: :erlang.nif_error(:nif_not_loaded)
 
-  def move_entity_to_position(_entity, _new_position, _external_wall, _obstacles),
+  def get_closest_available_position(_entity, _new_position, _external_wall, _obstacles),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def move_entity_to_direction(_entity, _direction, _amount, _external_wall, _obstacles),

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -77,12 +77,23 @@ fn move_entity_to_position(
     entity: Entity,
     new_position: Position,
     external_wall: Entity,
+    obstacles: HashMap<u64, Entity>,
 ) -> Entity {
     let mut entity: Entity = entity;
     entity.position = new_position;
 
     if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
         entity.move_to_next_valid_position_inside(&external_wall);
+    }
+
+    let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
+
+    if entity.category == Category::Player && !collides_with.is_empty() {
+        let collided_with: Vec<&Entity> = collides_with
+            .iter()
+            .map(|id| obstacles.get(id).unwrap())
+            .collect();
+        entity.move_to_next_valid_position_outside(collided_with);
     }
     entity
 }

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -165,8 +165,8 @@ fn move_entity_to_closest_available_position(
     external_wall: &Entity,
     obstacles: &HashMap<u64, Entity>,
 ) {
-    if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
-        entity.move_to_next_valid_position_inside(&external_wall);
+    if entity.category == Category::Player && !entity.is_inside_map(external_wall) {
+        entity.move_to_next_valid_position_inside(external_wall);
     }
 
     let collides_with = entity.collides_with(obstacles.clone().into_values().collect());

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -73,12 +73,12 @@ fn move_entity(
 }
 
 #[rustler::nif()]
-fn move_entity_to_position(
-    entity: Entity,
+fn get_closest_available_position(
     new_position: Position,
+    entity: Entity,
     external_wall: Entity,
     obstacles: HashMap<u64, Entity>,
-) -> Entity {
+) -> Position {
     let mut entity: Entity = entity;
     entity.position = new_position;
 
@@ -95,7 +95,7 @@ fn move_entity_to_position(
             .collect();
         entity.move_to_next_valid_position_outside(collided_with);
     }
-    entity
+    entity.position
 }
 
 #[rustler::nif()]
@@ -239,6 +239,6 @@ rustler::init!(
         get_direction_from_positions,
         calculate_speed,
         nearest_entity_direction,
-        move_entity_to_position
+        get_closest_available_position
     ]
 );

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -24,19 +24,7 @@ fn move_entities(
         if entity.is_moving {
             entity.move_entity(ticks_to_move);
 
-            if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
-                entity.move_to_next_valid_position_inside(&external_wall);
-            }
-
-            let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
-
-            if entity.category == Category::Player && !collides_with.is_empty() {
-                let collided_with: Vec<&Entity> = collides_with
-                    .iter()
-                    .map(|id| obstacles.get(id).unwrap())
-                    .collect();
-                entity.move_to_next_valid_position_outside(collided_with);
-            }
+            move_entity_to_closest_available_position(entity, &external_wall, &obstacles);
         }
     }
 
@@ -53,20 +41,7 @@ fn move_entity(
     let mut entity: Entity = entity;
     if entity.is_moving {
         entity.move_entity(ticks_to_move);
-
-        if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
-            entity.move_to_next_valid_position_inside(&external_wall);
-        }
-
-        let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
-
-        if entity.category == Category::Player && !collides_with.is_empty() {
-            let collided_with: Vec<&Entity> = collides_with
-                .iter()
-                .map(|id| obstacles.get(id).unwrap())
-                .collect();
-            entity.move_to_next_valid_position_outside(collided_with);
-        }
+        move_entity_to_closest_available_position(&mut entity, &external_wall, &obstacles);
     }
 
     entity
@@ -82,19 +57,7 @@ fn get_closest_available_position(
     let mut entity: Entity = entity;
     entity.position = new_position;
 
-    if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
-        entity.move_to_next_valid_position_inside(&external_wall);
-    }
-
-    let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
-
-    if entity.category == Category::Player && !collides_with.is_empty() {
-        let collided_with: Vec<&Entity> = collides_with
-            .iter()
-            .map(|id| obstacles.get(id).unwrap())
-            .collect();
-        entity.move_to_next_valid_position_outside(collided_with);
-    }
+    move_entity_to_closest_available_position(&mut entity, &external_wall, &obstacles);
     entity.position
 }
 
@@ -108,19 +71,7 @@ fn move_entity_to_direction(
 ) -> Entity {
     let mut entity: Entity = entity;
     entity.move_entity_to_direction(direction, amount);
-    if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
-        entity.move_to_next_valid_position_inside(&external_wall);
-    }
-
-    let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
-
-    if entity.category == Category::Player && !collides_with.is_empty() {
-        let collided_with: Vec<&Entity> = collides_with
-            .iter()
-            .map(|id| obstacles.get(id).unwrap())
-            .collect();
-        entity.move_to_next_valid_position_outside(collided_with);
-    }
+    move_entity_to_closest_available_position(&mut entity, &external_wall, &obstacles);
 
     entity
 }
@@ -207,6 +158,26 @@ fn nearest_entity_direction(entity: Entity, entities: HashMap<u64, Entity>) -> D
     }
 
     direction
+}
+
+fn move_entity_to_closest_available_position(
+    entity: &mut Entity,
+    external_wall: &Entity,
+    obstacles: &HashMap<u64, Entity>,
+) {
+    if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
+        entity.move_to_next_valid_position_inside(&external_wall);
+    }
+
+    let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
+
+    if entity.category == Category::Player && !collides_with.is_empty() {
+        let collided_with: Vec<&Entity> = collides_with
+            .iter()
+            .map(|id| obstacles.get(id).unwrap())
+            .collect();
+        entity.move_to_next_valid_position_outside(collided_with);
+    }
 }
 
 fn distance_between_positions(entity_a_postion: Position, entity_b_postion: Position) -> f32 {

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -88,9 +88,28 @@ fn move_entity_to_position(
 }
 
 #[rustler::nif()]
-fn move_entity_to_direction(entity: Entity, direction: Position, amount: f32) -> Entity {
+fn move_entity_to_direction(
+    entity: Entity,
+    direction: Position,
+    amount: f32,
+    external_wall: Entity,
+    obstacles: HashMap<u64, Entity>,
+) -> Entity {
     let mut entity: Entity = entity;
     entity.move_entity_to_direction(direction, amount);
+    if entity.category == Category::Player && !entity.is_inside_map(&external_wall) {
+        entity.move_to_next_valid_position_inside(&external_wall);
+    }
+
+    let collides_with = entity.collides_with(obstacles.clone().into_values().collect());
+
+    if entity.category == Category::Player && !collides_with.is_empty() {
+        let collided_with: Vec<&Entity> = collides_with
+            .iter()
+            .map(|id| obstacles.get(id).unwrap())
+            .collect();
+        entity.move_to_next_valid_position_outside(collided_with);
+    }
 
     entity
 }


### PR DESCRIPTION
Valtimer was pulling people inside the colliders and with his tp you were able to go inside rocks


to test this add this to the config file in the "obstacles" list and check that valtimer don't go inside of the obstacle and move a player close to it and try to move it inside of the obstacle:

<details>
<summary>Emerald</summary>


``` json
     {
        "position": {
          "x": 0.0,
          "y": 0.0
        },
        "vertices": [
          {
            "x": 0.0,
            "y": 3000.0
          },
          {
            "x": 2000.0,
            "y": 1000.0
          },
          {
            "x": 2000.0,
            "y": -1000.0
          },
          {
            "x": 0.0,
            "y": -3000.0
          },
          {
            "x": -2000.0,
            "y": -1000.0
          },
          {
            "x": -2000.0,
            "y": 1000.0
          }
        ],
        "radius": 0.0,
        "shape": "polygon"
      }
```
</details>