### PR TITLE
Balance Valtimer

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -354,7 +354,7 @@
       "name": "valt_antimatter",
       "cooldown_mechanism": "stamina",
       "execution_duration_ms": 450,
-      "activation_delay_ms": 50,
+      "activation_delay_ms": 150,
       "is_passive": false,
       "autoaim": true,
       "stamina_cost": 1,

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -258,8 +258,8 @@
       "mechanics": [
         {
           "multi_circle_hit": {
-            "damage": 22,
-            "range": 300.0,
+            "damage": 21,
+            "range": 280.0,
             "interval_ms": 200,
             "amount": 3,
             "move_by": 200.0,
@@ -313,10 +313,10 @@
     {
       "name": "valt_warp",
       "cooldown_mechanism": "time",
-      "cooldown_ms": 2000,
-      "execution_duration_ms": 800,
+      "cooldown_ms": 6000,
+      "execution_duration_ms": 500,
       "inmune_while_executing": true,
-      "activation_delay_ms": 600,
+      "activation_delay_ms": 300,
       "is_passive": false,
       "autoaim": false,
       "can_pick_destination": true,
@@ -324,8 +324,8 @@
       "mechanics": [
         {
           "teleport": {
-            "range": 1000,
-            "duration_ms": 300
+            "range": 1200,
+            "duration_ms": 200
           }
         }
       ],
@@ -353,8 +353,8 @@
     {
       "name": "valt_antimatter",
       "cooldown_mechanism": "stamina",
-      "execution_duration_ms": 800,
-      "activation_delay_ms": 500,
+      "execution_duration_ms": 450,
+      "activation_delay_ms": 50,
       "is_passive": false,
       "autoaim": true,
       "stamina_cost": 1,
@@ -362,16 +362,16 @@
       "mechanics": [
         {
           "simple_shoot": {
-            "speed": 51.0,
-            "duration_ms": 1000,
+            "speed": 55.0,
+            "duration_ms": 1100,
             "remove_on_collision": true,
             "projectile_offset": 100,
-            "radius": 45.0,
+            "radius": 100.0,
             "damage": 0,
             "on_explode_mechanics": {
               "circle_hit": {
-                "damage": 60,
-                "range": 500.0,
+                "damage": 58,
+                "range": 250.0,
                 "offset": 0
               }
             }
@@ -522,7 +522,7 @@
           "effect_delay_ms": 0
         },
         "damage": {
-          "damage": 14,
+          "damage": 13,
           "effect_delay_ms": 400
         }
       }


### PR DESCRIPTION
Teleport: 
- faster execution
- longer teleport range
- cooldown to 6s (most char dashes are 5s) due to strong mechanic

Basic
- fat chunk projectile
- reduced splash
- adjusted damage
- faster execution

Pileta
- sliiightly reduced damage. I think it shouldn't be a lot better than h4cks ulti because both deal similar damage in total, but since Singu does it over a longer period, it's easier to dash away.