### PR TITLE
Make bot get request async to fix server timeout

### DIFF
--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -87,7 +87,7 @@ defmodule Arena.GameLauncher do
 
   def handle_info({:spawn_bot_for_player, bot_client, game_pid}, state) do
     Finch.build(:get, build_bot_url(game_pid, bot_client))
-    |> Finch.request(Arena.Finch)
+    |> Finch.async_request(Arena.Finch)
 
     {:noreply, state}
   end

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -94,8 +94,7 @@ defmodule Arena.GameLauncher do
   end
 
   # This is a handler to the async bot request
-  def handle_info({{Finch.HTTP1.Pool, _}, result}, state) do
-    Logger.info("Bot request result #{result}")
+  def handle_info({{Finch.HTTP1.Pool, _}, _}, state) do
     {:noreply, state}
   end
 

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -1,6 +1,5 @@
 defmodule Arena.GameLauncher do
   @moduledoc false
-  require Logger
   alias Ecto.UUID
 
   use GenServer

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -1,5 +1,6 @@
 defmodule Arena.GameLauncher do
   @moduledoc false
+  require Logger
   alias Ecto.UUID
 
   use GenServer
@@ -89,6 +90,12 @@ defmodule Arena.GameLauncher do
     Finch.build(:get, build_bot_url(game_pid, bot_client))
     |> Finch.async_request(Arena.Finch)
 
+    {:noreply, state}
+  end
+
+  # This is a handler to the async bot request
+  def handle_info({{Finch.HTTP1.Pool, _}, result}, state) do
+    Logger.info("Bot request result #{result}")
     {:noreply, state}
   end
 


### PR DESCRIPTION

### Error
the join messages from the clients were timouting

### Cause
the game_launcher genserver was stuck every time we tried to spawn a bot because we did a GET request, and if the bot server is down or it took it a while to answer the game_launcher didn't answer to the client messages

### Solution
Make the bot request to the bot server async