### PR TITLE
Integrate battles and levels

### DIFF
--- a/apps/champions/lib/champions/battle.ex
+++ b/apps/champions/lib/champions/battle.ex
@@ -5,6 +5,7 @@ defmodule Champions.Battle do
   Fight outcomes are decided randomly, favoring the team with the higher aggregate level.
   """
 
+  alias Champions.Battle.Simulator
   alias GameBackend.Campaigns
   alias GameBackend.Campaigns.SuperCampaignProgress
   alias GameBackend.Units
@@ -22,14 +23,16 @@ defmodule Champions.Battle do
          {:level_valid, true} <- {:level_valid, current_level_id == level_id} do
       units = Units.get_selected_units(user_id)
 
-      if battle(units, level.units) == :team_1 do
-        case Champions.Campaigns.advance_level(user_id, level.campaign.super_campaign_id) do
+      case Simulator.run_battle(units, level.units) do
+        %{result: "team_1"} = result ->
           # TODO: add rewards to response [CHoM-191]
-          {:ok, _changes} -> :win
-          _error -> {:error, :failed_to_advance}
-        end
-      else
-        :loss
+          case Champions.Campaigns.advance_level(user_id, level.campaign.super_campaign_id) do
+            {:ok, _changes} -> result
+            _error -> {:error, :failed_to_advance}
+          end
+
+        result ->
+          result
       end
     else
       {:user_exists, false} -> {:error, :user_not_found}
@@ -37,29 +40,5 @@ defmodule Champions.Battle do
       {:super_campaign_progress, {:error, :not_found}} -> {:error, :super_campaign_progress_not_found}
       {:level_valid, false} -> {:error, :level_invalid}
     end
-  end
-
-  @doc """
-  Run a battle between two teams. The outcome is decided randomly, favoring the team
-  with the higher aggregate level of their selected units. Returns `:team_1` or `:team_2`.
-  """
-  def battle(team_1, team_2) do
-    team_1_agg_level =
-      Enum.reduce(team_1, 0, fn unit, acc ->
-        unit.level + item_level_agg(unit.items) + acc
-      end)
-
-    team_2_agg_level =
-      Enum.reduce(team_2, 0, fn unit, acc ->
-        unit.level + item_level_agg(unit.items) + acc
-      end)
-
-    total_level = team_1_agg_level + team_2_agg_level
-
-    if Enum.random(1..total_level) <= team_1_agg_level, do: :team_1, else: :team_2
-  end
-
-  defp item_level_agg(items) do
-    Enum.reduce(items, 0, fn item, acc -> item.level + acc end)
   end
 end

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -74,6 +74,7 @@ defmodule Champions.Battle.Simulator do
     seed = options[:seed] || @default_seed
 
     :rand.seed(:default, seed)
+    Logger.info("Running battle with seed: #{seed}")
 
     team_1 = Enum.into(team_1, %{}, fn unit -> create_unit_map(unit, 1) end)
     team_2 = Enum.into(team_2, %{}, fn unit -> create_unit_map(unit, 2) end)

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -584,6 +584,17 @@ defmodule Champions.Battle.Simulator do
     {new_target, new_history}
   end
 
+  defp process_execution(
+         _,
+         target,
+         caster,
+         history,
+         _skill_id
+       ) do
+    Logger.warning("#{format_unit_name(caster)} tried to apply an unknown execution to #{format_unit_name(caster)}")
+    {target, history}
+  end
+
   # Calculate the current amount of the given attribute that the unit has, based on its modifiers.
   defp calculate_unit_stat(unit, attribute) do
     overrides = Enum.filter(unit.modifiers.overrides, &(&1.attribute == Atom.to_string(attribute)))

--- a/apps/champions/priv/skills.json
+++ b/apps/champions/priv/skills.json
@@ -853,7 +853,7 @@
         "components": [],
         "modifiers": [
           {
-            "attribute": "armor",
+            "attribute": "defense",
             "modifier_operation": "Multiply",
             "magnitude_calc_type": "Float",
             "float_magnitude": 0.85
@@ -868,7 +868,7 @@
           }
         ],
         "target_strategy": {
-          "highest": "Armor"
+          "highest": "defense"
         },
         "target_count": 2,
         "target_allies": false

--- a/apps/game_backend/lib/game_backend/campaigns.ex
+++ b/apps/game_backend/lib/game_backend/campaigns.ex
@@ -81,7 +81,10 @@ defmodule GameBackend.Campaigns do
   Returns `{:error, :not_found}` if no level is found.
   """
   def get_level(level_id) do
-    level = Repo.get(Level, level_id) |> Repo.preload([:campaign, :currency_rewards, units: :items, units: :character])
+    level =
+      Repo.get(Level, level_id)
+      |> Repo.preload([:campaign, :currency_rewards, units: [:items, character: [:ultimate_skill, :basic_skill]]])
+
     if level, do: {:ok, level}, else: {:error, :not_found}
   end
 

--- a/apps/game_backend/lib/game_backend/units.ex
+++ b/apps/game_backend/lib/game_backend/units.ex
@@ -114,7 +114,7 @@ defmodule GameBackend.Units do
     do:
       from(unit in user_units_query(user_id), where: unit.selected)
       |> Repo.all()
-      |> Repo.preload([:character, :user, :items])
+      |> Repo.preload([:user, :items, character: [:basic_skill, :ultimate_skill]])
 
   @doc """
   Get a user's unit associated to the given character.

--- a/apps/gateway/lib/gateway/champions_socket_handler.ex
+++ b/apps/gateway/lib/gateway/champions_socket_handler.ex
@@ -40,8 +40,7 @@ defmodule Gateway.ChampionsSocketHandler do
     GetBoxes,
     GetBox,
     Summon,
-    GetUserSuperCampaignProgresses,
-    BattleTest
+    GetUserSuperCampaignProgresses
   }
 
   @behaviour :cowboy_websocket
@@ -115,8 +114,15 @@ defmodule Gateway.ChampionsSocketHandler do
 
   defp handle(%FightLevel{user_id: user_id, level_id: level_id}) do
     case Battle.fight_level(user_id, level_id) do
-      {:error, reason} -> prepare_response({:error, reason}, nil)
-      battle_result -> prepare_response(%{result: Atom.to_string(battle_result)}, :battle_result)
+      {:error, reason} ->
+        prepare_response({:error, reason}, nil)
+
+      battle_result ->
+        battle_result
+        |> update_in([:steps], fn steps ->
+          Enum.map(steps, &prepare_step/1)
+        end)
+        |> prepare_response(:battle_result)
     end
   end
 
@@ -206,45 +212,6 @@ defmodule Gateway.ChampionsSocketHandler do
       end)
 
     prepare_response(%{super_campaign_progresses: super_campaign_progresses}, :super_campaign_progresses)
-  end
-
-  # Temporary endpoint to test the sending of battle replays to the client
-  defp handle(%BattleTest{user_id: _user_id}) do
-    team1 =
-      Enum.map(1..6, fn slot ->
-        GameBackend.Units.insert_unit(%{
-          character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id,
-          level: 1,
-          tier: 1,
-          rank: 1,
-          selected: true,
-          user_id: nil,
-          slot: slot
-        })
-        |> elem(1)
-        |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill])
-      end)
-
-    team2 =
-      Enum.map(1..6, fn slot ->
-        GameBackend.Units.insert_unit(%{
-          character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id,
-          level: 1,
-          tier: 1,
-          rank: 1,
-          selected: true,
-          user_id: nil,
-          slot: slot
-        })
-        |> elem(1)
-        |> GameBackend.Repo.preload(character: [:basic_skill, :ultimate_skill])
-      end)
-
-    Champions.Battle.Simulator.run_battle(team1, team2)
-    |> update_in([:steps], fn steps ->
-      Enum.map(steps, &prepare_step/1)
-    end)
-    |> prepare_response(:battle_replay)
   end
 
   defp handle(unknown_request),

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -18,6 +18,8 @@ defmodule Gateway.Serialization.Stat do
   field(:ENERGY, 1)
   field(:DAMAGE, 2)
   field(:DEFENSE, 3)
+  field(:DAMAGE_REDUCTION, 4)
+  field(:SPEED, 5)
 end
 
 defmodule Gateway.Serialization.WebSocketRequest do

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -109,20 +109,6 @@ defmodule Gateway.Serialization.WebSocketRequest do
     json_name: "getUserSuperCampaignProgresses",
     oneof: 0
   )
-
-  field(:battle_test, 24,
-    type: Gateway.Serialization.BattleTest,
-    json_name: "battleTest",
-    oneof: 0
-  )
-end
-
-defmodule Gateway.Serialization.BattleTest do
-  @moduledoc false
-
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
-
-  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -366,12 +352,6 @@ defmodule Gateway.Serialization.WebSocketResponse do
     json_name: "superCampaignProgresses",
     oneof: 0
   )
-
-  field(:battle_replay, 16,
-    type: Gateway.Serialization.BattleReplay,
-    json_name: "battleReplay",
-    oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.User do
@@ -561,14 +541,6 @@ defmodule Gateway.Serialization.CurrencyReward do
   field(:amount, 3, type: :uint64)
 end
 
-defmodule Gateway.Serialization.BattleResult do
-  @moduledoc false
-
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
-
-  field(:result, 1, type: :string)
-end
-
 defmodule Gateway.Serialization.AfkRewards do
   @moduledoc false
 
@@ -652,7 +624,7 @@ defmodule Gateway.Serialization.UserAndUnit do
   field(:unit, 2, type: Gateway.Serialization.Unit)
 end
 
-defmodule Gateway.Serialization.BattleReplay do
+defmodule Gateway.Serialization.BattleResult do
   @moduledoc false
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -16,7 +16,7 @@ defmodule Gateway.Serialization.Stat do
 
   field(:HEALTH, 0)
   field(:ENERGY, 1)
-  field(:DAMAGE, 2)
+  field(:ATTACK, 2)
   field(:DEFENSE, 3)
   field(:DAMAGE_REDUCTION, 4)
   field(:SPEED, 5)

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -339,11 +339,11 @@ defmodule Gateway.Test.Champions do
       fetch_last_message(socket_tester)
 
       assert_receive %WebSocketResponse{
-        response_type: {:battle_result, _ = battle_result}
+        response_type: {:battle_result, battle_result}
       }
 
       # Battle result should be either win or loss
-      assert battle_result.result == "win" or battle_result.result == "loss"
+      assert battle_result.result in ["team_1", "team_2", "draw", "timeout"]
 
       # TODO: check rewards [#CHoM-341]
     end
@@ -372,7 +372,7 @@ defmodule Gateway.Test.Champions do
         response_type: {:battle_result, _ = battle_result}
       }
 
-      assert battle_result.result == "win"
+      assert battle_result.result == "team_1"
 
       {:ok, advanced_user} = Users.get_user(user.id)
 
@@ -447,7 +447,7 @@ defmodule Gateway.Test.Champions do
         response_type: {:battle_result, _ = battle_result}
       }
 
-      assert battle_result.result == "win"
+      assert battle_result.result == "team_1"
 
       # Get advanced user
       SocketTester.get_user(socket_tester, user.id)
@@ -528,7 +528,7 @@ defmodule Gateway.Test.Champions do
         response_type: {:battle_result, _ = battle_result}
       }
 
-      assert battle_result.result == "win"
+      assert battle_result.result == "team_1"
 
       # Get new user
       SocketTester.get_user(socket_tester, user.id)

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -342,7 +342,7 @@ defmodule Gateway.Test.Champions do
         response_type: {:battle_result, battle_result}
       }
 
-      # Battle result should be either win or loss
+      # Battle result should be either team_1, team_2, draw or timeout
       assert battle_result.result in ["team_1", "team_2", "draw", "timeout"]
 
       # TODO: check rewards [#CHoM-341]

--- a/apps/gateway/test/support/socket_tester.ex
+++ b/apps/gateway/test/support/socket_tester.ex
@@ -39,8 +39,7 @@ defmodule Gateway.SocketTester do
     GetBox,
     GetBoxes,
     Summon,
-    GetUserSuperCampaignProgresses,
-    BattleTest
+    GetUserSuperCampaignProgresses
   }
 
   def start_link() do
@@ -270,16 +269,6 @@ defmodule Gateway.SocketTester do
         {:binary,
          WebSocketRequest.encode(%WebSocketRequest{
            request_type: {:get_user_super_campaign_progresses, %GetUserSuperCampaignProgresses{user_id: user_id}}
-         })}
-      )
-
-  def battle_test(pid, user_id),
-    do:
-      WebSockex.send_frame(
-        pid,
-        {:binary,
-         WebSocketRequest.encode(%WebSocketRequest{
-           request_type: {:battle_test, %BattleTest{user_id: user_id}}
          })}
       )
 

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -312,6 +312,8 @@ syntax = "proto3";
     ENERGY = 1;
     DAMAGE = 2;
     DEFENSE = 3;
+    DAMAGE_REDUCTION = 4;
+    SPEED = 5;
   }
 
   message BattleResult {

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -24,12 +24,7 @@ syntax = "proto3";
       GetAfkRewards get_afk_rewards = 21;
       ClaimAfkRewards claim_afk_rewards = 22;
       GetUserSuperCampaignProgresses get_user_super_campaign_progresses = 23;
-      BattleTest battle_test = 24;
     }
-  }
-
-  message BattleTest {
-    string user_id = 1;
   }
 
  message GetUser {
@@ -155,7 +150,6 @@ syntax = "proto3";
       UserAndUnit user_and_unit = 13;
       AfkRewards afk_rewards = 14;
       SuperCampaignProgresses super_campaign_progresses = 15;
-      BattleReplay battle_replay = 16;
     }
   }
   
@@ -263,10 +257,6 @@ syntax = "proto3";
     uint64 amount = 3;
   }
 
-  message BattleResult {
-    string result = 1;
-  }
-
   message AfkRewards {
     repeated AfkReward afk_rewards = 1;
   }
@@ -308,7 +298,7 @@ syntax = "proto3";
     Unit unit = 2;
   }
 
-// BATTLE REPLAY
+// BATTLE RESULT
 
   enum SkillActionType {
     ANIMATION_START = 0;
@@ -324,7 +314,7 @@ syntax = "proto3";
     DEFENSE = 3;
   }
 
-  message BattleReplay {
+  message BattleResult {
     State initial_state = 1;
     repeated Step steps = 2;
     string result = 3;
@@ -368,7 +358,6 @@ syntax = "proto3";
     repeated string target_ids = 2;
     string skill_id = 3;
     SkillActionType skill_action_type = 4;
-    // Stat should only be "health" or "energy" when in SkillAction
     repeated StatAffected stats_affected = 5;
   }
 

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -310,7 +310,7 @@ syntax = "proto3";
   enum Stat {
     HEALTH = 0;
     ENERGY = 1;
-    DAMAGE = 2;
+    ATTACK = 2;
     DEFENSE = 3;
     DAMAGE_REDUCTION = 4;
     SPEED = 5;


### PR DESCRIPTION
Frontend PR: https://github.com/lambdaclass/champions_of_mirra/pull/324 (Waiting on)

Closes https://github.com/lambdaclass/champions_of_mirra/issues/351

- Get rid of the BattleTest endpoint
- Use Simulator.battle() in fights
- Add handler for unimplemented executions
  - Unimplemented stats Modifiers (`damage_reduction`) and Components (`AddTags`) don't need any extra handling because of how we implemented them :D
  - Edit: Unimplemented stat modifiers don't need extra handling _on Simulator_, but they do require it in the Stat enum for the Protobuf message :c

# To test
In the frontend, go to the campaign and fight some levels! any level you fight should be playable without errors. Pro tip: If you're struggling with a level, try leveling up your units ;) or even get lucky and roll a Muflus in Summon