### PR TITLE
Implement Tags for Champions Battle

### DIFF
--- a/apps/champions/priv/skills.json
+++ b/apps/champions/priv/skills.json
@@ -784,7 +784,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Burn"
+            "tags": [
+              "Burn"
+            ]
           }
         ],
         "modifiers": [],
@@ -853,7 +855,7 @@
         "components": [],
         "modifiers": [
           {
-            "attribute": "armor",
+            "attribute": "defense",
             "modifier_operation": "Multiply",
             "magnitude_calc_type": "Float",
             "float_magnitude": 0.85
@@ -868,7 +870,7 @@
           }
         ],
         "target_strategy": {
-          "highest": "Armor"
+          "highest": "defense"
         },
         "target_count": 2,
         "target_allies": false
@@ -918,7 +920,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Stun"
+            "tags": [
+              "Stun"
+            ]
           }
         ],
         "modifiers": [
@@ -1477,7 +1481,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Stun"
+            "tags": [
+              "Stun"
+            ]
           }
         ],
         "modifiers": [],
@@ -1538,7 +1544,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Burn"
+            "tags": [
+              "Burn"
+            ]
           }
         ],
         "modifiers": [],
@@ -1701,7 +1709,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Silence"
+            "tags": [
+              "Silence"
+            ]
           }
         ],
         "modifiers": [],
@@ -1886,7 +1896,9 @@
         "components": [
           {
             "type": "ApplyTags",
-            "tag": "Paralyzed"
+            "tags": [
+              "Paralyzed"
+            ]
           }
         ],
         "modifiers": [],

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -100,7 +100,13 @@ defmodule GameBackend.Units.Skills.Effect do
 
       %{
         type: "ApplyTags",
-        tags: _effect
+        tags: [_some_tag | _other_tags]
+      } ->
+        true
+
+      %{
+        type: "TargetTagRequirements",
+        tags: [_some_tag | _other_tags]
       } ->
         true
 

--- a/apps/game_backend/lib/game_backend/units/skills/effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/effect.ex
@@ -100,7 +100,7 @@ defmodule GameBackend.Units.Skills.Effect do
 
       %{
         type: "ApplyTags",
-        tag: _effect
+        tags: _effect
       } ->
         true
 


### PR DESCRIPTION
- Implements tags behaviour with `ApplyTags` components
- Implements "Stun" tag custom behavior (unit won't be able to attack)
- Implements `TargetTagRequirements` component, that determines whether a skill hits or not based on if the target has a skill

Tests haven't been added in this PR so as to not generate conflicts with #464 . Issue is [here](https://github.com/lambdaclass/champions_of_mirra/issues/356).

# To Test

Battle in battle.md should work. Additionally, you should see many `Applying tag "Stun" to unit Muflus-e76` logs, which render units unable to cast skills.

If you want to do more in-depth testing, something you can do is play around with `ApplyTags` and `TargetTagRequirements`. For example, you can give Muflus' ultimate a TargetTagRequirement of a random tag that obviously won't exist. If you do so, then no one will get stunned during battle. However, if you make his basic apply the tag you set (remember to turn the effect into a "Duration" type) then stuns will happen because the tag is found now.

Feel free to find your own ways to experiment with this!