### PR TITLE
[gh-433] Fix killfeed not displaying names

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1071,7 +1071,8 @@ defmodule Arena.GameUpdater do
       speed: 0.0,
       category: :obstacle,
       direction: %{x: 0.0, y: 0.0},
-      is_moving: false
+      is_moving: false,
+      name: "Point 1"
     }
 
     case Physics.check_collisions(point, %{0 => external_wall}) do

--- a/apps/arena/native/physics/src/map.rs
+++ b/apps/arena/native/physics/src/map.rs
@@ -95,7 +95,7 @@ impl Entity {
             category: Category::Obstacle,
             direction: Direction { x: 0.0, y: 0.0 },
             is_moving: false,
-            name: String::from(format!("{}{}", "Point ", id)),
+            name: format!("{}{}", "Point ", id),
         }
     }
 
@@ -110,7 +110,7 @@ impl Entity {
             category: Category::Obstacle,
             direction: Direction { x: 0.0, y: 0.0 },
             is_moving: false,
-            name: String::from(format!("{}{}", "Line ", id)),
+            name: format!("{}{}", "Line ", id),
         }
     }
 

--- a/apps/arena/native/physics/src/map.rs
+++ b/apps/arena/native/physics/src/map.rs
@@ -35,6 +35,7 @@ pub struct Entity {
     pub category: Category,
     pub direction: Direction,
     pub is_moving: bool,
+    pub name: String,
 }
 
 #[derive(Deserialize, NifTaggedEnum, Clone, PartialEq)]
@@ -94,6 +95,7 @@ impl Entity {
             category: Category::Obstacle,
             direction: Direction { x: 0.0, y: 0.0 },
             is_moving: false,
+            name: String::from(format!("{}{}", "Point ", id)),
         }
     }
 
@@ -108,6 +110,7 @@ impl Entity {
             category: Category::Obstacle,
             direction: Direction { x: 0.0, y: 0.0 },
             is_moving: false,
+            name: String::from(format!("{}{}", "Line ", id)),
         }
     }
 


### PR DESCRIPTION
Closes #433 

The killfeed were not displaying character names sometimes, this was caused bu the rust `Entity` structure not containing this field thus causing it to be lost when you called the `physics` module to process an entity calculation 

Fixed added the name to the rust entity