### PR TITLE
Fix protobuf message names for tags and modifiers

### DIFF
--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -106,7 +106,6 @@ defmodule Champions.Battle.Simulator do
         end
       )
 
-    IO.inspect(Enum.reverse(history), limit: :infinity)
     %{initial_state: transform_initial_state_for_replay(initial_state), steps: Enum.reverse(history), result: result}
   end
 

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -106,6 +106,7 @@ defmodule Champions.Battle.Simulator do
         end
       )
 
+    IO.inspect(Enum.reverse(history), limit: :infinity)
     %{initial_state: transform_initial_state_for_replay(initial_state), steps: Enum.reverse(history), result: result}
   end
 

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -278,7 +278,7 @@ defmodule Champions.Battle.Simulator do
              history,
              %{
                skill_id: modifier.skill_id,
-               target_ids: [unit.id],
+               target_id: unit.id,
                stat_affected: %{
                  stat: modifier.attribute |> String.upcase() |> String.to_atom(),
                  amount: modifier.float_magnitude
@@ -316,7 +316,7 @@ defmodule Champions.Battle.Simulator do
              history,
              %{
                skill_id: tag.skill_id,
-               unit_id: unit.id,
+               target_id: unit.id,
                tag: tag.tag
              },
              :tag_expired
@@ -530,7 +530,7 @@ defmodule Champions.Battle.Simulator do
             history,
             %{
               skill_id: modifier.skill_id,
-              target_ids: [target.id],
+              target_id: target.id,
               stat_affected: %{
                 stat: modifier.attribute |> String.upcase() |> String.to_atom(),
                 amount: modifier.float_magnitude
@@ -631,7 +631,7 @@ defmodule Champions.Battle.Simulator do
             history,
             %{
               skill_id: effect.skill_id,
-              unit_id: target.id,
+              target_id: target.id,
               tag: tag
             },
             :tag_received

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -3,10 +3,10 @@ defmodule Gateway.Serialization.SkillActionType do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ANIMATION_START, 0)
-  field(:EFFECT_TRIGGER, 1)
-  field(:EFFECT_HIT, 2)
-  field(:EFFECT_MISS, 3)
+  field :ANIMATION_START, 0
+  field :EFFECT_TRIGGER, 1
+  field :EFFECT_HIT, 2
+  field :EFFECT_MISS, 3
 end
 
 defmodule Gateway.Serialization.Stat do
@@ -14,12 +14,12 @@ defmodule Gateway.Serialization.Stat do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:HEALTH, 0)
-  field(:ENERGY, 1)
-  field(:ATTACK, 2)
-  field(:DEFENSE, 3)
-  field(:DAMAGE_REDUCTION, 4)
-  field(:SPEED, 5)
+  field :HEALTH, 0
+  field :ENERGY, 1
+  field :ATTACK, 2
+  field :DEFENSE, 3
+  field :DAMAGE_REDUCTION, 4
+  field :SPEED, 5
 end
 
 defmodule Gateway.Serialization.WebSocketRequest do
@@ -27,90 +27,79 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:request_type, 0)
+  oneof :request_type, 0
 
-  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
+  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
 
-  field(:get_user_by_username, 2,
+  field :get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
-  )
 
-  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
+  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
 
-  field(:get_campaigns, 4,
+  field :get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
-  )
 
-  field(:get_campaign, 5,
+  field :get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
-  )
 
-  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
-  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
-  field(:select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
+  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
+  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
+  field :select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
 
-  field(:unselect_unit, 10,
+  field :unselect_unit, 10,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
-  )
 
-  field(:level_up_unit, 11,
+  field :level_up_unit, 11,
     type: Gateway.Serialization.LevelUpUnit,
     json_name: "levelUpUnit",
     oneof: 0
-  )
 
-  field(:tier_up_unit, 12,
+  field :tier_up_unit, 12,
     type: Gateway.Serialization.TierUpUnit,
     json_name: "tierUpUnit",
     oneof: 0
-  )
 
-  field(:fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0)
-  field(:equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
+  field :fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0
+  field :equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
 
-  field(:unequip_item, 15,
+  field :unequip_item, 15,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
-  )
 
-  field(:get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
+  field :get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
 
-  field(:level_up_item, 17,
+  field :level_up_item, 17,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
-  )
 
-  field(:get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0)
-  field(:get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0)
-  field(:summon, 20, type: Gateway.Serialization.Summon, oneof: 0)
+  field :get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0
+  field :get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0
+  field :summon, 20, type: Gateway.Serialization.Summon, oneof: 0
 
-  field(:get_afk_rewards, 21,
+  field :get_afk_rewards, 21,
     type: Gateway.Serialization.GetAfkRewards,
     json_name: "getAfkRewards",
     oneof: 0
-  )
 
-  field(:claim_afk_rewards, 22,
+  field :claim_afk_rewards, 22,
     type: Gateway.Serialization.ClaimAfkRewards,
     json_name: "claimAfkRewards",
     oneof: 0
-  )
 
-  field(:get_user_super_campaign_progresses, 23,
+  field :get_user_super_campaign_progresses, 23,
     type: Gateway.Serialization.GetUserSuperCampaignProgresses,
     json_name: "getUserSuperCampaignProgresses",
     oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -118,7 +107,7 @@ defmodule Gateway.Serialization.GetUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
@@ -126,7 +115,7 @@ defmodule Gateway.Serialization.GetUserByUsername do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.CreateUser do
@@ -134,7 +123,7 @@ defmodule Gateway.Serialization.CreateUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
@@ -142,7 +131,7 @@ defmodule Gateway.Serialization.GetCampaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetCampaign do
@@ -150,8 +139,8 @@ defmodule Gateway.Serialization.GetCampaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
 end
 
 defmodule Gateway.Serialization.GetLevel do
@@ -159,8 +148,8 @@ defmodule Gateway.Serialization.GetLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.FightLevel do
@@ -168,8 +157,8 @@ defmodule Gateway.Serialization.FightLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -177,9 +166,9 @@ defmodule Gateway.Serialization.SelectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
-  field(:slot, 3, type: :uint32)
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
+  field :slot, 3, type: :uint32
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
@@ -187,8 +176,8 @@ defmodule Gateway.Serialization.UnselectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.LevelUpUnit do
@@ -196,8 +185,8 @@ defmodule Gateway.Serialization.LevelUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.TierUpUnit do
@@ -205,8 +194,8 @@ defmodule Gateway.Serialization.TierUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.FuseUnit do
@@ -214,9 +203,9 @@ defmodule Gateway.Serialization.FuseUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
-  field(:consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
+  field :consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds"
 end
 
 defmodule Gateway.Serialization.EquipItem do
@@ -224,9 +213,9 @@ defmodule Gateway.Serialization.EquipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
-  field(:unit_id, 3, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
+  field :unit_id, 3, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.UnequipItem do
@@ -234,8 +223,8 @@ defmodule Gateway.Serialization.UnequipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.GetItem do
@@ -243,8 +232,8 @@ defmodule Gateway.Serialization.GetItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
@@ -252,8 +241,8 @@ defmodule Gateway.Serialization.LevelUpItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.GetAfkRewards do
@@ -261,7 +250,7 @@ defmodule Gateway.Serialization.GetAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.ClaimAfkRewards do
@@ -269,7 +258,7 @@ defmodule Gateway.Serialization.ClaimAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetBoxes do
@@ -277,7 +266,7 @@ defmodule Gateway.Serialization.GetBoxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetBox do
@@ -285,7 +274,7 @@ defmodule Gateway.Serialization.GetBox do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:box_id, 1, type: :string, json_name: "boxId")
+  field :box_id, 1, type: :string, json_name: "boxId"
 end
 
 defmodule Gateway.Serialization.Summon do
@@ -293,8 +282,8 @@ defmodule Gateway.Serialization.Summon do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:box_id, 2, type: :string, json_name: "boxId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :box_id, 2, type: :string, json_name: "boxId"
 end
 
 defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
@@ -302,7 +291,7 @@ defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
@@ -310,50 +299,45 @@ defmodule Gateway.Serialization.WebSocketResponse do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:response_type, 0)
+  oneof :response_type, 0
 
-  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
-  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
-  field(:units, 3, type: Gateway.Serialization.Units, oneof: 0)
+  field :user, 1, type: Gateway.Serialization.User, oneof: 0
+  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
+  field :units, 3, type: Gateway.Serialization.Units, oneof: 0
 
-  field(:unit_and_currencies, 4,
+  field :unit_and_currencies, 4,
     type: Gateway.Serialization.UnitAndCurrencies,
     json_name: "unitAndCurrencies",
     oneof: 0
-  )
 
-  field(:item, 5, type: Gateway.Serialization.Item, oneof: 0)
-  field(:campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0)
-  field(:campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0)
-  field(:level, 8, type: Gateway.Serialization.Level, oneof: 0)
+  field :item, 5, type: Gateway.Serialization.Item, oneof: 0
+  field :campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0
+  field :campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0
+  field :level, 8, type: Gateway.Serialization.Level, oneof: 0
 
-  field(:battle_result, 9,
+  field :battle_result, 9,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
-  )
 
-  field(:error, 10, type: Gateway.Serialization.Error, oneof: 0)
-  field(:boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0)
-  field(:box, 12, type: Gateway.Serialization.Box, oneof: 0)
+  field :error, 10, type: Gateway.Serialization.Error, oneof: 0
+  field :boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0
+  field :box, 12, type: Gateway.Serialization.Box, oneof: 0
 
-  field(:user_and_unit, 13,
+  field :user_and_unit, 13,
     type: Gateway.Serialization.UserAndUnit,
     json_name: "userAndUnit",
     oneof: 0
-  )
 
-  field(:afk_rewards, 14,
+  field :afk_rewards, 14,
     type: Gateway.Serialization.AfkRewards,
     json_name: "afkRewards",
     oneof: 0
-  )
 
-  field(:super_campaign_progresses, 15,
+  field :super_campaign_progresses, 15,
     type: Gateway.Serialization.SuperCampaignProgresses,
     json_name: "superCampaignProgresses",
     oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.User do
@@ -361,19 +345,18 @@ defmodule Gateway.Serialization.User do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:username, 2, type: :string)
-  field(:level, 3, type: :uint64)
-  field(:experience, 4, type: :uint64)
-  field(:currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency)
-  field(:units, 8, repeated: true, type: Gateway.Serialization.Unit)
-  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :username, 2, type: :string
+  field :level, 3, type: :uint64
+  field :experience, 4, type: :uint64
+  field :currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency
+  field :units, 8, repeated: true, type: Gateway.Serialization.Unit
+  field :items, 9, repeated: true, type: Gateway.Serialization.Item
 
-  field(:afk_reward_rates, 10,
+  field :afk_reward_rates, 10,
     repeated: true,
     type: Gateway.Serialization.AfkRewardRate,
     json_name: "afkRewardRates"
-  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgresses do
@@ -381,11 +364,10 @@ defmodule Gateway.Serialization.SuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:super_campaign_progresses, 1,
+  field :super_campaign_progresses, 1,
     repeated: true,
     type: Gateway.Serialization.SuperCampaignProgress,
     json_name: "superCampaignProgresses"
-  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgress do
@@ -393,10 +375,10 @@ defmodule Gateway.Serialization.SuperCampaignProgress do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
-  field(:level_id, 3, type: :string, json_name: "levelId")
-  field(:super_campaign_id, 4, type: :string, json_name: "superCampaignId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field :level_id, 3, type: :string, json_name: "levelId"
+  field :super_campaign_id, 4, type: :string, json_name: "superCampaignId"
 end
 
 defmodule Gateway.Serialization.AfkRewardRate do
@@ -404,9 +386,9 @@ defmodule Gateway.Serialization.AfkRewardRate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:currency_id, 2, type: :string, json_name: "currencyId")
-  field(:rate, 3, type: :float)
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :currency_id, 2, type: :string, json_name: "currencyId"
+  field :rate, 3, type: :float
 end
 
 defmodule Gateway.Serialization.UserCurrency do
@@ -414,8 +396,8 @@ defmodule Gateway.Serialization.UserCurrency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :uint32)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :uint32
 end
 
 defmodule Gateway.Serialization.Currency do
@@ -423,7 +405,7 @@ defmodule Gateway.Serialization.Currency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:name, 1, type: :string)
+  field :name, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Unit do
@@ -431,16 +413,16 @@ defmodule Gateway.Serialization.Unit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:level, 2, type: :uint32)
-  field(:tier, 3, type: :uint32)
-  field(:rank, 4, type: :uint32)
-  field(:selected, 5, type: :bool)
-  field(:slot, 6, type: :uint32)
-  field(:campaign_level_id, 7, type: :string, json_name: "campaignLevelId")
-  field(:user_id, 8, type: :string, json_name: "userId")
-  field(:character, 9, type: Gateway.Serialization.Character)
-  field(:items, 10, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :level, 2, type: :uint32
+  field :tier, 3, type: :uint32
+  field :rank, 4, type: :uint32
+  field :selected, 5, type: :bool
+  field :slot, 6, type: :uint32
+  field :campaign_level_id, 7, type: :string, json_name: "campaignLevelId"
+  field :user_id, 8, type: :string, json_name: "userId"
+  field :character, 9, type: Gateway.Serialization.Character
+  field :items, 10, repeated: true, type: Gateway.Serialization.Item
 end
 
 defmodule Gateway.Serialization.Units do
@@ -448,7 +430,7 @@ defmodule Gateway.Serialization.Units do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:units, 1, repeated: true, type: Gateway.Serialization.Unit)
+  field :units, 1, repeated: true, type: Gateway.Serialization.Unit
 end
 
 defmodule Gateway.Serialization.UnitAndCurrencies do
@@ -456,13 +438,12 @@ defmodule Gateway.Serialization.UnitAndCurrencies do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:unit, 1, type: Gateway.Serialization.Unit)
+  field :unit, 1, type: Gateway.Serialization.Unit
 
-  field(:user_currency, 2,
+  field :user_currency, 2,
     repeated: true,
     type: Gateway.Serialization.UserCurrency,
     json_name: "userCurrency"
-  )
 end
 
 defmodule Gateway.Serialization.Character do
@@ -470,10 +451,10 @@ defmodule Gateway.Serialization.Character do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:active, 1, type: :bool)
-  field(:name, 2, type: :string)
-  field(:faction, 3, type: :string)
-  field(:quality, 4, type: :uint32)
+  field :active, 1, type: :bool
+  field :name, 2, type: :string
+  field :faction, 3, type: :string
+  field :quality, 4, type: :uint32
 end
 
 defmodule Gateway.Serialization.Item do
@@ -481,11 +462,11 @@ defmodule Gateway.Serialization.Item do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:level, 2, type: :uint32)
-  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
-  field(:user_id, 4, type: :string, json_name: "userId")
-  field(:unit_id, 5, type: :string, json_name: "unitId")
+  field :id, 1, type: :string
+  field :level, 2, type: :uint32
+  field :template, 3, type: Gateway.Serialization.ItemTemplate
+  field :user_id, 4, type: :string, json_name: "userId"
+  field :unit_id, 5, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
@@ -493,9 +474,9 @@ defmodule Gateway.Serialization.ItemTemplate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:name, 2, type: :string)
-  field(:type, 3, type: :string)
+  field :id, 1, type: :string
+  field :name, 2, type: :string
+  field :type, 3, type: :string
 end
 
 defmodule Gateway.Serialization.Campaigns do
@@ -503,7 +484,7 @@ defmodule Gateway.Serialization.Campaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
+  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
 end
 
 defmodule Gateway.Serialization.Campaign do
@@ -511,10 +492,10 @@ defmodule Gateway.Serialization.Campaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:super_campaign_id, 2, type: :string, json_name: "superCampaignId")
-  field(:campaign_number, 3, type: :uint32, json_name: "campaignNumber")
-  field(:levels, 4, repeated: true, type: Gateway.Serialization.Level)
+  field :id, 1, type: :string
+  field :super_campaign_id, 2, type: :string, json_name: "superCampaignId"
+  field :campaign_number, 3, type: :uint32, json_name: "campaignNumber"
+  field :levels, 4, repeated: true, type: Gateway.Serialization.Level
 end
 
 defmodule Gateway.Serialization.Level do
@@ -522,16 +503,15 @@ defmodule Gateway.Serialization.Level do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
-  field(:level_number, 3, type: :uint32, json_name: "levelNumber")
-  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
+  field :id, 1, type: :string
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field :level_number, 3, type: :uint32, json_name: "levelNumber"
+  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
 
-  field(:currency_rewards, 5,
+  field :currency_rewards, 5,
     repeated: true,
     type: Gateway.Serialization.CurrencyReward,
     json_name: "currencyRewards"
-  )
 end
 
 defmodule Gateway.Serialization.CurrencyReward do
@@ -539,8 +519,8 @@ defmodule Gateway.Serialization.CurrencyReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 3, type: :uint64)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 3, type: :uint64
 end
 
 defmodule Gateway.Serialization.AfkRewards do
@@ -548,11 +528,10 @@ defmodule Gateway.Serialization.AfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:afk_rewards, 1,
+  field :afk_rewards, 1,
     repeated: true,
     type: Gateway.Serialization.AfkReward,
     json_name: "afkRewards"
-  )
 end
 
 defmodule Gateway.Serialization.AfkReward do
@@ -560,8 +539,8 @@ defmodule Gateway.Serialization.AfkReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :uint64)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :uint64
 end
 
 defmodule Gateway.Serialization.Error do
@@ -569,7 +548,7 @@ defmodule Gateway.Serialization.Error do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:reason, 1, type: :string)
+  field :reason, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Boxes do
@@ -577,7 +556,7 @@ defmodule Gateway.Serialization.Boxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:boxes, 1, repeated: true, type: Gateway.Serialization.Box)
+  field :boxes, 1, repeated: true, type: Gateway.Serialization.Box
 end
 
 defmodule Gateway.Serialization.Box do
@@ -585,18 +564,17 @@ defmodule Gateway.Serialization.Box do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:name, 2, type: :string)
-  field(:description, 3, type: :string)
-  field(:factions, 4, repeated: true, type: :string)
+  field :id, 1, type: :string
+  field :name, 2, type: :string
+  field :description, 3, type: :string
+  field :factions, 4, repeated: true, type: :string
 
-  field(:rank_weights, 5,
+  field :rank_weights, 5,
     repeated: true,
     type: Gateway.Serialization.RankWeights,
     json_name: "rankWeights"
-  )
 
-  field(:cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost)
+  field :cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost
 end
 
 defmodule Gateway.Serialization.RankWeights do
@@ -604,8 +582,8 @@ defmodule Gateway.Serialization.RankWeights do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:rank, 1, type: :int32)
-  field(:weight, 2, type: :int32)
+  field :rank, 1, type: :int32
+  field :weight, 2, type: :int32
 end
 
 defmodule Gateway.Serialization.CurrencyCost do
@@ -613,8 +591,8 @@ defmodule Gateway.Serialization.CurrencyCost do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :int32)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :int32
 end
 
 defmodule Gateway.Serialization.UserAndUnit do
@@ -622,8 +600,8 @@ defmodule Gateway.Serialization.UserAndUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user, 1, type: Gateway.Serialization.User)
-  field(:unit, 2, type: Gateway.Serialization.Unit)
+  field :user, 1, type: Gateway.Serialization.User
+  field :unit, 2, type: Gateway.Serialization.Unit
 end
 
 defmodule Gateway.Serialization.BattleResult do
@@ -631,9 +609,9 @@ defmodule Gateway.Serialization.BattleResult do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState")
-  field(:steps, 2, repeated: true, type: Gateway.Serialization.Step)
-  field(:result, 3, type: :string)
+  field :initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState"
+  field :steps, 2, repeated: true, type: Gateway.Serialization.Step
+  field :result, 3, type: :string
 end
 
 defmodule Gateway.Serialization.State do
@@ -641,7 +619,7 @@ defmodule Gateway.Serialization.State do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:units, 1, repeated: true, type: Gateway.Serialization.BattleUnit)
+  field :units, 1, repeated: true, type: Gateway.Serialization.BattleUnit
 end
 
 defmodule Gateway.Serialization.BattleUnit do
@@ -649,11 +627,11 @@ defmodule Gateway.Serialization.BattleUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:health, 2, type: :int32)
-  field(:slot, 3, type: :int32)
-  field(:character_id, 4, type: :string, json_name: "characterId")
-  field(:team, 5, type: :int32)
+  field :id, 1, type: :string
+  field :health, 2, type: :int32
+  field :slot, 3, type: :int32
+  field :character_id, 4, type: :string, json_name: "characterId"
+  field :team, 5, type: :int32
 end
 
 defmodule Gateway.Serialization.Step do
@@ -661,8 +639,8 @@ defmodule Gateway.Serialization.Step do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:step_number, 1, type: :int32, json_name: "stepNumber")
-  field(:actions, 2, repeated: true, type: Gateway.Serialization.Action)
+  field :step_number, 1, type: :int32, json_name: "stepNumber"
+  field :actions, 2, repeated: true, type: Gateway.Serialization.Action
 end
 
 defmodule Gateway.Serialization.Action do
@@ -670,34 +648,30 @@ defmodule Gateway.Serialization.Action do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:action_type, 0)
+  oneof :action_type, 0
 
-  field(:skill_action, 1,
+  field :skill_action, 1,
     type: Gateway.Serialization.SkillAction,
     json_name: "skillAction",
     oneof: 0
-  )
 
-  field(:modifier_received, 2,
+  field :modifier_received, 2,
     type: Gateway.Serialization.ModifierReceived,
     json_name: "modifierReceived",
     oneof: 0
-  )
 
-  field(:tag_received, 3,
+  field :tag_received, 3,
     type: Gateway.Serialization.TagReceived,
     json_name: "tagReceived",
     oneof: 0
-  )
 
-  field(:modifier_expired, 4,
+  field :modifier_expired, 4,
     type: Gateway.Serialization.ModifierExpired,
     json_name: "modifierExpired",
     oneof: 0
-  )
 
-  field(:tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0)
-  field(:death, 6, type: Gateway.Serialization.Death, oneof: 0)
+  field :tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0
+  field :death, 6, type: Gateway.Serialization.Death, oneof: 0
 end
 
 defmodule Gateway.Serialization.StatAffected do
@@ -705,8 +679,8 @@ defmodule Gateway.Serialization.StatAffected do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:stat, 1, type: Gateway.Serialization.Stat, enum: true)
-  field(:amount, 2, type: :float)
+  field :stat, 1, type: Gateway.Serialization.Stat, enum: true
+  field :amount, 2, type: :float
 end
 
 defmodule Gateway.Serialization.SkillAction do
@@ -714,21 +688,19 @@ defmodule Gateway.Serialization.SkillAction do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:caster_id, 1, type: :string, json_name: "casterId")
-  field(:target_ids, 2, repeated: true, type: :string, json_name: "targetIds")
-  field(:skill_id, 3, type: :string, json_name: "skillId")
+  field :caster_id, 1, type: :string, json_name: "casterId"
+  field :target_ids, 2, repeated: true, type: :string, json_name: "targetIds"
+  field :skill_id, 3, type: :string, json_name: "skillId"
 
-  field(:skill_action_type, 4,
+  field :skill_action_type, 4,
     type: Gateway.Serialization.SkillActionType,
     json_name: "skillActionType",
     enum: true
-  )
 
-  field(:stats_affected, 5,
+  field :stats_affected, 5,
     repeated: true,
     type: Gateway.Serialization.StatAffected,
     json_name: "statsAffected"
-  )
 end
 
 defmodule Gateway.Serialization.ModifierReceived do
@@ -736,9 +708,9 @@ defmodule Gateway.Serialization.ModifierReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
 end
 
 defmodule Gateway.Serialization.TagReceived do
@@ -746,9 +718,9 @@ defmodule Gateway.Serialization.TagReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:tag, 3, type: :string)
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :tag, 3, type: :string
 end
 
 defmodule Gateway.Serialization.ModifierExpired do
@@ -756,9 +728,9 @@ defmodule Gateway.Serialization.ModifierExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
 end
 
 defmodule Gateway.Serialization.TagExpired do
@@ -766,9 +738,9 @@ defmodule Gateway.Serialization.TagExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:tag_name, 3, type: :string, json_name: "tagName")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :tag, 3, type: :string
 end
 
 defmodule Gateway.Serialization.Death do
@@ -776,5 +748,5 @@ defmodule Gateway.Serialization.Death do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:unit_id, 1, type: :string, json_name: "unitId")
+  field :unit_id, 1, type: :string, json_name: "unitId"
 end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -3,10 +3,10 @@ defmodule Gateway.Serialization.SkillActionType do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :ANIMATION_START, 0
-  field :EFFECT_TRIGGER, 1
-  field :EFFECT_HIT, 2
-  field :EFFECT_MISS, 3
+  field(:ANIMATION_START, 0)
+  field(:EFFECT_TRIGGER, 1)
+  field(:EFFECT_HIT, 2)
+  field(:EFFECT_MISS, 3)
 end
 
 defmodule Gateway.Serialization.Stat do
@@ -14,12 +14,12 @@ defmodule Gateway.Serialization.Stat do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :HEALTH, 0
-  field :ENERGY, 1
-  field :ATTACK, 2
-  field :DEFENSE, 3
-  field :DAMAGE_REDUCTION, 4
-  field :SPEED, 5
+  field(:HEALTH, 0)
+  field(:ENERGY, 1)
+  field(:ATTACK, 2)
+  field(:DEFENSE, 3)
+  field(:DAMAGE_REDUCTION, 4)
+  field(:SPEED, 5)
 end
 
 defmodule Gateway.Serialization.WebSocketRequest do
@@ -27,79 +27,90 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :request_type, 0
+  oneof(:request_type, 0)
 
-  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
+  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
 
-  field :get_user_by_username, 2,
+  field(:get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
+  )
 
-  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
+  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
 
-  field :get_campaigns, 4,
+  field(:get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
+  )
 
-  field :get_campaign, 5,
+  field(:get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
+  )
 
-  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
-  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
-  field :select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
+  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
+  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
+  field(:select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
 
-  field :unselect_unit, 10,
+  field(:unselect_unit, 10,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
+  )
 
-  field :level_up_unit, 11,
+  field(:level_up_unit, 11,
     type: Gateway.Serialization.LevelUpUnit,
     json_name: "levelUpUnit",
     oneof: 0
+  )
 
-  field :tier_up_unit, 12,
+  field(:tier_up_unit, 12,
     type: Gateway.Serialization.TierUpUnit,
     json_name: "tierUpUnit",
     oneof: 0
+  )
 
-  field :fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0
-  field :equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
+  field(:fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0)
+  field(:equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
 
-  field :unequip_item, 15,
+  field(:unequip_item, 15,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
+  )
 
-  field :get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
+  field(:get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
 
-  field :level_up_item, 17,
+  field(:level_up_item, 17,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
+  )
 
-  field :get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0
-  field :get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0
-  field :summon, 20, type: Gateway.Serialization.Summon, oneof: 0
+  field(:get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0)
+  field(:get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0)
+  field(:summon, 20, type: Gateway.Serialization.Summon, oneof: 0)
 
-  field :get_afk_rewards, 21,
+  field(:get_afk_rewards, 21,
     type: Gateway.Serialization.GetAfkRewards,
     json_name: "getAfkRewards",
     oneof: 0
+  )
 
-  field :claim_afk_rewards, 22,
+  field(:claim_afk_rewards, 22,
     type: Gateway.Serialization.ClaimAfkRewards,
     json_name: "claimAfkRewards",
     oneof: 0
+  )
 
-  field :get_user_super_campaign_progresses, 23,
+  field(:get_user_super_campaign_progresses, 23,
     type: Gateway.Serialization.GetUserSuperCampaignProgresses,
     json_name: "getUserSuperCampaignProgresses",
     oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -107,7 +118,7 @@ defmodule Gateway.Serialization.GetUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
@@ -115,7 +126,7 @@ defmodule Gateway.Serialization.GetUserByUsername do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.CreateUser do
@@ -123,7 +134,7 @@ defmodule Gateway.Serialization.CreateUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
@@ -131,7 +142,7 @@ defmodule Gateway.Serialization.GetCampaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetCampaign do
@@ -139,8 +150,8 @@ defmodule Gateway.Serialization.GetCampaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
 end
 
 defmodule Gateway.Serialization.GetLevel do
@@ -148,8 +159,8 @@ defmodule Gateway.Serialization.GetLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.FightLevel do
@@ -157,8 +168,8 @@ defmodule Gateway.Serialization.FightLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -166,9 +177,9 @@ defmodule Gateway.Serialization.SelectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
-  field :slot, 3, type: :uint32
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field(:slot, 3, type: :uint32)
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
@@ -176,8 +187,8 @@ defmodule Gateway.Serialization.UnselectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.LevelUpUnit do
@@ -185,8 +196,8 @@ defmodule Gateway.Serialization.LevelUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.TierUpUnit do
@@ -194,8 +205,8 @@ defmodule Gateway.Serialization.TierUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.FuseUnit do
@@ -203,9 +214,9 @@ defmodule Gateway.Serialization.FuseUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
-  field :consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field(:consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds")
 end
 
 defmodule Gateway.Serialization.EquipItem do
@@ -213,9 +224,9 @@ defmodule Gateway.Serialization.EquipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
-  field :unit_id, 3, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
+  field(:unit_id, 3, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.UnequipItem do
@@ -223,8 +234,8 @@ defmodule Gateway.Serialization.UnequipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.GetItem do
@@ -232,8 +243,8 @@ defmodule Gateway.Serialization.GetItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
@@ -241,8 +252,8 @@ defmodule Gateway.Serialization.LevelUpItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.GetAfkRewards do
@@ -250,7 +261,7 @@ defmodule Gateway.Serialization.GetAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.ClaimAfkRewards do
@@ -258,7 +269,7 @@ defmodule Gateway.Serialization.ClaimAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetBoxes do
@@ -266,7 +277,7 @@ defmodule Gateway.Serialization.GetBoxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetBox do
@@ -274,7 +285,7 @@ defmodule Gateway.Serialization.GetBox do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :box_id, 1, type: :string, json_name: "boxId"
+  field(:box_id, 1, type: :string, json_name: "boxId")
 end
 
 defmodule Gateway.Serialization.Summon do
@@ -282,8 +293,8 @@ defmodule Gateway.Serialization.Summon do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :box_id, 2, type: :string, json_name: "boxId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:box_id, 2, type: :string, json_name: "boxId")
 end
 
 defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
@@ -291,7 +302,7 @@ defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
@@ -299,45 +310,50 @@ defmodule Gateway.Serialization.WebSocketResponse do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :response_type, 0
+  oneof(:response_type, 0)
 
-  field :user, 1, type: Gateway.Serialization.User, oneof: 0
-  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
-  field :units, 3, type: Gateway.Serialization.Units, oneof: 0
+  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
+  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
+  field(:units, 3, type: Gateway.Serialization.Units, oneof: 0)
 
-  field :unit_and_currencies, 4,
+  field(:unit_and_currencies, 4,
     type: Gateway.Serialization.UnitAndCurrencies,
     json_name: "unitAndCurrencies",
     oneof: 0
+  )
 
-  field :item, 5, type: Gateway.Serialization.Item, oneof: 0
-  field :campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0
-  field :campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0
-  field :level, 8, type: Gateway.Serialization.Level, oneof: 0
+  field(:item, 5, type: Gateway.Serialization.Item, oneof: 0)
+  field(:campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0)
+  field(:campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0)
+  field(:level, 8, type: Gateway.Serialization.Level, oneof: 0)
 
-  field :battle_result, 9,
+  field(:battle_result, 9,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
+  )
 
-  field :error, 10, type: Gateway.Serialization.Error, oneof: 0
-  field :boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0
-  field :box, 12, type: Gateway.Serialization.Box, oneof: 0
+  field(:error, 10, type: Gateway.Serialization.Error, oneof: 0)
+  field(:boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0)
+  field(:box, 12, type: Gateway.Serialization.Box, oneof: 0)
 
-  field :user_and_unit, 13,
+  field(:user_and_unit, 13,
     type: Gateway.Serialization.UserAndUnit,
     json_name: "userAndUnit",
     oneof: 0
+  )
 
-  field :afk_rewards, 14,
+  field(:afk_rewards, 14,
     type: Gateway.Serialization.AfkRewards,
     json_name: "afkRewards",
     oneof: 0
+  )
 
-  field :super_campaign_progresses, 15,
+  field(:super_campaign_progresses, 15,
     type: Gateway.Serialization.SuperCampaignProgresses,
     json_name: "superCampaignProgresses",
     oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.User do
@@ -345,18 +361,19 @@ defmodule Gateway.Serialization.User do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :username, 2, type: :string
-  field :level, 3, type: :uint64
-  field :experience, 4, type: :uint64
-  field :currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency
-  field :units, 8, repeated: true, type: Gateway.Serialization.Unit
-  field :items, 9, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:username, 2, type: :string)
+  field(:level, 3, type: :uint64)
+  field(:experience, 4, type: :uint64)
+  field(:currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency)
+  field(:units, 8, repeated: true, type: Gateway.Serialization.Unit)
+  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
 
-  field :afk_reward_rates, 10,
+  field(:afk_reward_rates, 10,
     repeated: true,
     type: Gateway.Serialization.AfkRewardRate,
     json_name: "afkRewardRates"
+  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgresses do
@@ -364,10 +381,11 @@ defmodule Gateway.Serialization.SuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :super_campaign_progresses, 1,
+  field(:super_campaign_progresses, 1,
     repeated: true,
     type: Gateway.Serialization.SuperCampaignProgress,
     json_name: "superCampaignProgresses"
+  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgress do
@@ -375,10 +393,10 @@ defmodule Gateway.Serialization.SuperCampaignProgress do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
-  field :level_id, 3, type: :string, json_name: "levelId"
-  field :super_campaign_id, 4, type: :string, json_name: "superCampaignId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field(:level_id, 3, type: :string, json_name: "levelId")
+  field(:super_campaign_id, 4, type: :string, json_name: "superCampaignId")
 end
 
 defmodule Gateway.Serialization.AfkRewardRate do
@@ -386,9 +404,9 @@ defmodule Gateway.Serialization.AfkRewardRate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :currency_id, 2, type: :string, json_name: "currencyId"
-  field :rate, 3, type: :float
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:currency_id, 2, type: :string, json_name: "currencyId")
+  field(:rate, 3, type: :float)
 end
 
 defmodule Gateway.Serialization.UserCurrency do
@@ -396,8 +414,8 @@ defmodule Gateway.Serialization.UserCurrency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :uint32
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :uint32)
 end
 
 defmodule Gateway.Serialization.Currency do
@@ -405,7 +423,7 @@ defmodule Gateway.Serialization.Currency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :name, 1, type: :string
+  field(:name, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Unit do
@@ -413,16 +431,16 @@ defmodule Gateway.Serialization.Unit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :level, 2, type: :uint32
-  field :tier, 3, type: :uint32
-  field :rank, 4, type: :uint32
-  field :selected, 5, type: :bool
-  field :slot, 6, type: :uint32
-  field :campaign_level_id, 7, type: :string, json_name: "campaignLevelId"
-  field :user_id, 8, type: :string, json_name: "userId"
-  field :character, 9, type: Gateway.Serialization.Character
-  field :items, 10, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:level, 2, type: :uint32)
+  field(:tier, 3, type: :uint32)
+  field(:rank, 4, type: :uint32)
+  field(:selected, 5, type: :bool)
+  field(:slot, 6, type: :uint32)
+  field(:campaign_level_id, 7, type: :string, json_name: "campaignLevelId")
+  field(:user_id, 8, type: :string, json_name: "userId")
+  field(:character, 9, type: Gateway.Serialization.Character)
+  field(:items, 10, repeated: true, type: Gateway.Serialization.Item)
 end
 
 defmodule Gateway.Serialization.Units do
@@ -430,7 +448,7 @@ defmodule Gateway.Serialization.Units do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :units, 1, repeated: true, type: Gateway.Serialization.Unit
+  field(:units, 1, repeated: true, type: Gateway.Serialization.Unit)
 end
 
 defmodule Gateway.Serialization.UnitAndCurrencies do
@@ -438,12 +456,13 @@ defmodule Gateway.Serialization.UnitAndCurrencies do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :unit, 1, type: Gateway.Serialization.Unit
+  field(:unit, 1, type: Gateway.Serialization.Unit)
 
-  field :user_currency, 2,
+  field(:user_currency, 2,
     repeated: true,
     type: Gateway.Serialization.UserCurrency,
     json_name: "userCurrency"
+  )
 end
 
 defmodule Gateway.Serialization.Character do
@@ -451,10 +470,10 @@ defmodule Gateway.Serialization.Character do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :active, 1, type: :bool
-  field :name, 2, type: :string
-  field :faction, 3, type: :string
-  field :quality, 4, type: :uint32
+  field(:active, 1, type: :bool)
+  field(:name, 2, type: :string)
+  field(:faction, 3, type: :string)
+  field(:quality, 4, type: :uint32)
 end
 
 defmodule Gateway.Serialization.Item do
@@ -462,11 +481,11 @@ defmodule Gateway.Serialization.Item do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :level, 2, type: :uint32
-  field :template, 3, type: Gateway.Serialization.ItemTemplate
-  field :user_id, 4, type: :string, json_name: "userId"
-  field :unit_id, 5, type: :string, json_name: "unitId"
+  field(:id, 1, type: :string)
+  field(:level, 2, type: :uint32)
+  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
+  field(:user_id, 4, type: :string, json_name: "userId")
+  field(:unit_id, 5, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
@@ -474,9 +493,9 @@ defmodule Gateway.Serialization.ItemTemplate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :name, 2, type: :string
-  field :type, 3, type: :string
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:type, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.Campaigns do
@@ -484,7 +503,7 @@ defmodule Gateway.Serialization.Campaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
+  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
 end
 
 defmodule Gateway.Serialization.Campaign do
@@ -492,10 +511,10 @@ defmodule Gateway.Serialization.Campaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :super_campaign_id, 2, type: :string, json_name: "superCampaignId"
-  field :campaign_number, 3, type: :uint32, json_name: "campaignNumber"
-  field :levels, 4, repeated: true, type: Gateway.Serialization.Level
+  field(:id, 1, type: :string)
+  field(:super_campaign_id, 2, type: :string, json_name: "superCampaignId")
+  field(:campaign_number, 3, type: :uint32, json_name: "campaignNumber")
+  field(:levels, 4, repeated: true, type: Gateway.Serialization.Level)
 end
 
 defmodule Gateway.Serialization.Level do
@@ -503,15 +522,16 @@ defmodule Gateway.Serialization.Level do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
-  field :level_number, 3, type: :uint32, json_name: "levelNumber"
-  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
+  field(:id, 1, type: :string)
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field(:level_number, 3, type: :uint32, json_name: "levelNumber")
+  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
 
-  field :currency_rewards, 5,
+  field(:currency_rewards, 5,
     repeated: true,
     type: Gateway.Serialization.CurrencyReward,
     json_name: "currencyRewards"
+  )
 end
 
 defmodule Gateway.Serialization.CurrencyReward do
@@ -519,8 +539,8 @@ defmodule Gateway.Serialization.CurrencyReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 3, type: :uint64
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 3, type: :uint64)
 end
 
 defmodule Gateway.Serialization.AfkRewards do
@@ -528,10 +548,11 @@ defmodule Gateway.Serialization.AfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :afk_rewards, 1,
+  field(:afk_rewards, 1,
     repeated: true,
     type: Gateway.Serialization.AfkReward,
     json_name: "afkRewards"
+  )
 end
 
 defmodule Gateway.Serialization.AfkReward do
@@ -539,8 +560,8 @@ defmodule Gateway.Serialization.AfkReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :uint64
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :uint64)
 end
 
 defmodule Gateway.Serialization.Error do
@@ -548,7 +569,7 @@ defmodule Gateway.Serialization.Error do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :reason, 1, type: :string
+  field(:reason, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Boxes do
@@ -556,7 +577,7 @@ defmodule Gateway.Serialization.Boxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :boxes, 1, repeated: true, type: Gateway.Serialization.Box
+  field(:boxes, 1, repeated: true, type: Gateway.Serialization.Box)
 end
 
 defmodule Gateway.Serialization.Box do
@@ -564,17 +585,18 @@ defmodule Gateway.Serialization.Box do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :name, 2, type: :string
-  field :description, 3, type: :string
-  field :factions, 4, repeated: true, type: :string
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:description, 3, type: :string)
+  field(:factions, 4, repeated: true, type: :string)
 
-  field :rank_weights, 5,
+  field(:rank_weights, 5,
     repeated: true,
     type: Gateway.Serialization.RankWeights,
     json_name: "rankWeights"
+  )
 
-  field :cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost
+  field(:cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost)
 end
 
 defmodule Gateway.Serialization.RankWeights do
@@ -582,8 +604,8 @@ defmodule Gateway.Serialization.RankWeights do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :rank, 1, type: :int32
-  field :weight, 2, type: :int32
+  field(:rank, 1, type: :int32)
+  field(:weight, 2, type: :int32)
 end
 
 defmodule Gateway.Serialization.CurrencyCost do
@@ -591,8 +613,8 @@ defmodule Gateway.Serialization.CurrencyCost do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :int32
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :int32)
 end
 
 defmodule Gateway.Serialization.UserAndUnit do
@@ -600,8 +622,8 @@ defmodule Gateway.Serialization.UserAndUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user, 1, type: Gateway.Serialization.User
-  field :unit, 2, type: Gateway.Serialization.Unit
+  field(:user, 1, type: Gateway.Serialization.User)
+  field(:unit, 2, type: Gateway.Serialization.Unit)
 end
 
 defmodule Gateway.Serialization.BattleResult do
@@ -609,9 +631,9 @@ defmodule Gateway.Serialization.BattleResult do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState"
-  field :steps, 2, repeated: true, type: Gateway.Serialization.Step
-  field :result, 3, type: :string
+  field(:initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState")
+  field(:steps, 2, repeated: true, type: Gateway.Serialization.Step)
+  field(:result, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.State do
@@ -619,7 +641,7 @@ defmodule Gateway.Serialization.State do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :units, 1, repeated: true, type: Gateway.Serialization.BattleUnit
+  field(:units, 1, repeated: true, type: Gateway.Serialization.BattleUnit)
 end
 
 defmodule Gateway.Serialization.BattleUnit do
@@ -627,11 +649,11 @@ defmodule Gateway.Serialization.BattleUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :health, 2, type: :int32
-  field :slot, 3, type: :int32
-  field :character_id, 4, type: :string, json_name: "characterId"
-  field :team, 5, type: :int32
+  field(:id, 1, type: :string)
+  field(:health, 2, type: :int32)
+  field(:slot, 3, type: :int32)
+  field(:character_id, 4, type: :string, json_name: "characterId")
+  field(:team, 5, type: :int32)
 end
 
 defmodule Gateway.Serialization.Step do
@@ -639,8 +661,8 @@ defmodule Gateway.Serialization.Step do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :step_number, 1, type: :int32, json_name: "stepNumber"
-  field :actions, 2, repeated: true, type: Gateway.Serialization.Action
+  field(:step_number, 1, type: :int32, json_name: "stepNumber")
+  field(:actions, 2, repeated: true, type: Gateway.Serialization.Action)
 end
 
 defmodule Gateway.Serialization.Action do
@@ -648,30 +670,34 @@ defmodule Gateway.Serialization.Action do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :skill_action, 1,
+  field(:skill_action, 1,
     type: Gateway.Serialization.SkillAction,
     json_name: "skillAction",
     oneof: 0
+  )
 
-  field :modifier_received, 2,
+  field(:modifier_received, 2,
     type: Gateway.Serialization.ModifierReceived,
     json_name: "modifierReceived",
     oneof: 0
+  )
 
-  field :tag_received, 3,
+  field(:tag_received, 3,
     type: Gateway.Serialization.TagReceived,
     json_name: "tagReceived",
     oneof: 0
+  )
 
-  field :modifier_expired, 4,
+  field(:modifier_expired, 4,
     type: Gateway.Serialization.ModifierExpired,
     json_name: "modifierExpired",
     oneof: 0
+  )
 
-  field :tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0
-  field :death, 6, type: Gateway.Serialization.Death, oneof: 0
+  field(:tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0)
+  field(:death, 6, type: Gateway.Serialization.Death, oneof: 0)
 end
 
 defmodule Gateway.Serialization.StatAffected do
@@ -679,8 +705,8 @@ defmodule Gateway.Serialization.StatAffected do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :stat, 1, type: Gateway.Serialization.Stat, enum: true
-  field :amount, 2, type: :float
+  field(:stat, 1, type: Gateway.Serialization.Stat, enum: true)
+  field(:amount, 2, type: :float)
 end
 
 defmodule Gateway.Serialization.SkillAction do
@@ -688,19 +714,21 @@ defmodule Gateway.Serialization.SkillAction do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :caster_id, 1, type: :string, json_name: "casterId"
-  field :target_ids, 2, repeated: true, type: :string, json_name: "targetIds"
-  field :skill_id, 3, type: :string, json_name: "skillId"
+  field(:caster_id, 1, type: :string, json_name: "casterId")
+  field(:target_ids, 2, repeated: true, type: :string, json_name: "targetIds")
+  field(:skill_id, 3, type: :string, json_name: "skillId")
 
-  field :skill_action_type, 4,
+  field(:skill_action_type, 4,
     type: Gateway.Serialization.SkillActionType,
     json_name: "skillActionType",
     enum: true
+  )
 
-  field :stats_affected, 5,
+  field(:stats_affected, 5,
     repeated: true,
     type: Gateway.Serialization.StatAffected,
     json_name: "statsAffected"
+  )
 end
 
 defmodule Gateway.Serialization.ModifierReceived do
@@ -708,9 +736,9 @@ defmodule Gateway.Serialization.ModifierReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
 end
 
 defmodule Gateway.Serialization.TagReceived do
@@ -718,9 +746,9 @@ defmodule Gateway.Serialization.TagReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :tag, 3, type: :string
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:tag, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.ModifierExpired do
@@ -728,9 +756,9 @@ defmodule Gateway.Serialization.ModifierExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
 end
 
 defmodule Gateway.Serialization.TagExpired do
@@ -738,9 +766,9 @@ defmodule Gateway.Serialization.TagExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :tag_name, 3, type: :string, json_name: "tagName"
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:tag_name, 3, type: :string, json_name: "tagName")
 end
 
 defmodule Gateway.Serialization.Death do
@@ -748,5 +776,5 @@ defmodule Gateway.Serialization.Death do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :unit_id, 1, type: :string, json_name: "unitId"
+  field(:unit_id, 1, type: :string, json_name: "unitId")
 end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -3,10 +3,10 @@ defmodule Gateway.Serialization.SkillActionType do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ANIMATION_START, 0)
-  field(:EFFECT_TRIGGER, 1)
-  field(:EFFECT_HIT, 2)
-  field(:EFFECT_MISS, 3)
+  field :ANIMATION_START, 0
+  field :EFFECT_TRIGGER, 1
+  field :EFFECT_HIT, 2
+  field :EFFECT_MISS, 3
 end
 
 defmodule Gateway.Serialization.Stat do
@@ -14,12 +14,12 @@ defmodule Gateway.Serialization.Stat do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:HEALTH, 0)
-  field(:ENERGY, 1)
-  field(:ATTACK, 2)
-  field(:DEFENSE, 3)
-  field(:DAMAGE_REDUCTION, 4)
-  field(:SPEED, 5)
+  field :HEALTH, 0
+  field :ENERGY, 1
+  field :ATTACK, 2
+  field :DEFENSE, 3
+  field :DAMAGE_REDUCTION, 4
+  field :SPEED, 5
 end
 
 defmodule Gateway.Serialization.WebSocketRequest do
@@ -27,90 +27,79 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:request_type, 0)
+  oneof :request_type, 0
 
-  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
+  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
 
-  field(:get_user_by_username, 2,
+  field :get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
-  )
 
-  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
+  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
 
-  field(:get_campaigns, 4,
+  field :get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
-  )
 
-  field(:get_campaign, 5,
+  field :get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
-  )
 
-  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
-  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
-  field(:select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
+  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
+  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
+  field :select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
 
-  field(:unselect_unit, 10,
+  field :unselect_unit, 10,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
-  )
 
-  field(:level_up_unit, 11,
+  field :level_up_unit, 11,
     type: Gateway.Serialization.LevelUpUnit,
     json_name: "levelUpUnit",
     oneof: 0
-  )
 
-  field(:tier_up_unit, 12,
+  field :tier_up_unit, 12,
     type: Gateway.Serialization.TierUpUnit,
     json_name: "tierUpUnit",
     oneof: 0
-  )
 
-  field(:fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0)
-  field(:equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
+  field :fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0
+  field :equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
 
-  field(:unequip_item, 15,
+  field :unequip_item, 15,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
-  )
 
-  field(:get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
+  field :get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
 
-  field(:level_up_item, 17,
+  field :level_up_item, 17,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
-  )
 
-  field(:get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0)
-  field(:get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0)
-  field(:summon, 20, type: Gateway.Serialization.Summon, oneof: 0)
+  field :get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0
+  field :get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0
+  field :summon, 20, type: Gateway.Serialization.Summon, oneof: 0
 
-  field(:get_afk_rewards, 21,
+  field :get_afk_rewards, 21,
     type: Gateway.Serialization.GetAfkRewards,
     json_name: "getAfkRewards",
     oneof: 0
-  )
 
-  field(:claim_afk_rewards, 22,
+  field :claim_afk_rewards, 22,
     type: Gateway.Serialization.ClaimAfkRewards,
     json_name: "claimAfkRewards",
     oneof: 0
-  )
 
-  field(:get_user_super_campaign_progresses, 23,
+  field :get_user_super_campaign_progresses, 23,
     type: Gateway.Serialization.GetUserSuperCampaignProgresses,
     json_name: "getUserSuperCampaignProgresses",
     oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -118,7 +107,7 @@ defmodule Gateway.Serialization.GetUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
@@ -126,7 +115,7 @@ defmodule Gateway.Serialization.GetUserByUsername do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.CreateUser do
@@ -134,7 +123,7 @@ defmodule Gateway.Serialization.CreateUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:username, 1, type: :string)
+  field :username, 1, type: :string
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
@@ -142,7 +131,7 @@ defmodule Gateway.Serialization.GetCampaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetCampaign do
@@ -150,8 +139,8 @@ defmodule Gateway.Serialization.GetCampaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
 end
 
 defmodule Gateway.Serialization.GetLevel do
@@ -159,8 +148,8 @@ defmodule Gateway.Serialization.GetLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.FightLevel do
@@ -168,8 +157,8 @@ defmodule Gateway.Serialization.FightLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:level_id, 2, type: :string, json_name: "levelId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :level_id, 2, type: :string, json_name: "levelId"
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -177,9 +166,9 @@ defmodule Gateway.Serialization.SelectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
-  field(:slot, 3, type: :uint32)
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
+  field :slot, 3, type: :uint32
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
@@ -187,8 +176,8 @@ defmodule Gateway.Serialization.UnselectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.LevelUpUnit do
@@ -196,8 +185,8 @@ defmodule Gateway.Serialization.LevelUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.TierUpUnit do
@@ -205,8 +194,8 @@ defmodule Gateway.Serialization.TierUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.FuseUnit do
@@ -214,9 +203,9 @@ defmodule Gateway.Serialization.FuseUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:unit_id, 2, type: :string, json_name: "unitId")
-  field(:consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :unit_id, 2, type: :string, json_name: "unitId"
+  field :consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds"
 end
 
 defmodule Gateway.Serialization.EquipItem do
@@ -224,9 +213,9 @@ defmodule Gateway.Serialization.EquipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
-  field(:unit_id, 3, type: :string, json_name: "unitId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
+  field :unit_id, 3, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.UnequipItem do
@@ -234,8 +223,8 @@ defmodule Gateway.Serialization.UnequipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.GetItem do
@@ -243,8 +232,8 @@ defmodule Gateway.Serialization.GetItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
@@ -252,8 +241,8 @@ defmodule Gateway.Serialization.LevelUpItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:item_id, 2, type: :string, json_name: "itemId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :item_id, 2, type: :string, json_name: "itemId"
 end
 
 defmodule Gateway.Serialization.GetAfkRewards do
@@ -261,7 +250,7 @@ defmodule Gateway.Serialization.GetAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.ClaimAfkRewards do
@@ -269,7 +258,7 @@ defmodule Gateway.Serialization.ClaimAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetBoxes do
@@ -277,7 +266,7 @@ defmodule Gateway.Serialization.GetBoxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.GetBox do
@@ -285,7 +274,7 @@ defmodule Gateway.Serialization.GetBox do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:box_id, 1, type: :string, json_name: "boxId")
+  field :box_id, 1, type: :string, json_name: "boxId"
 end
 
 defmodule Gateway.Serialization.Summon do
@@ -293,8 +282,8 @@ defmodule Gateway.Serialization.Summon do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:box_id, 2, type: :string, json_name: "boxId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :box_id, 2, type: :string, json_name: "boxId"
 end
 
 defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
@@ -302,7 +291,7 @@ defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
+  field :user_id, 1, type: :string, json_name: "userId"
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
@@ -310,50 +299,45 @@ defmodule Gateway.Serialization.WebSocketResponse do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:response_type, 0)
+  oneof :response_type, 0
 
-  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
-  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
-  field(:units, 3, type: Gateway.Serialization.Units, oneof: 0)
+  field :user, 1, type: Gateway.Serialization.User, oneof: 0
+  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
+  field :units, 3, type: Gateway.Serialization.Units, oneof: 0
 
-  field(:unit_and_currencies, 4,
+  field :unit_and_currencies, 4,
     type: Gateway.Serialization.UnitAndCurrencies,
     json_name: "unitAndCurrencies",
     oneof: 0
-  )
 
-  field(:item, 5, type: Gateway.Serialization.Item, oneof: 0)
-  field(:campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0)
-  field(:campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0)
-  field(:level, 8, type: Gateway.Serialization.Level, oneof: 0)
+  field :item, 5, type: Gateway.Serialization.Item, oneof: 0
+  field :campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0
+  field :campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0
+  field :level, 8, type: Gateway.Serialization.Level, oneof: 0
 
-  field(:battle_result, 9,
+  field :battle_result, 9,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
-  )
 
-  field(:error, 10, type: Gateway.Serialization.Error, oneof: 0)
-  field(:boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0)
-  field(:box, 12, type: Gateway.Serialization.Box, oneof: 0)
+  field :error, 10, type: Gateway.Serialization.Error, oneof: 0
+  field :boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0
+  field :box, 12, type: Gateway.Serialization.Box, oneof: 0
 
-  field(:user_and_unit, 13,
+  field :user_and_unit, 13,
     type: Gateway.Serialization.UserAndUnit,
     json_name: "userAndUnit",
     oneof: 0
-  )
 
-  field(:afk_rewards, 14,
+  field :afk_rewards, 14,
     type: Gateway.Serialization.AfkRewards,
     json_name: "afkRewards",
     oneof: 0
-  )
 
-  field(:super_campaign_progresses, 15,
+  field :super_campaign_progresses, 15,
     type: Gateway.Serialization.SuperCampaignProgresses,
     json_name: "superCampaignProgresses",
     oneof: 0
-  )
 end
 
 defmodule Gateway.Serialization.User do
@@ -361,19 +345,18 @@ defmodule Gateway.Serialization.User do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:username, 2, type: :string)
-  field(:level, 3, type: :uint64)
-  field(:experience, 4, type: :uint64)
-  field(:currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency)
-  field(:units, 8, repeated: true, type: Gateway.Serialization.Unit)
-  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :username, 2, type: :string
+  field :level, 3, type: :uint64
+  field :experience, 4, type: :uint64
+  field :currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency
+  field :units, 8, repeated: true, type: Gateway.Serialization.Unit
+  field :items, 9, repeated: true, type: Gateway.Serialization.Item
 
-  field(:afk_reward_rates, 10,
+  field :afk_reward_rates, 10,
     repeated: true,
     type: Gateway.Serialization.AfkRewardRate,
     json_name: "afkRewardRates"
-  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgresses do
@@ -381,11 +364,10 @@ defmodule Gateway.Serialization.SuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:super_campaign_progresses, 1,
+  field :super_campaign_progresses, 1,
     repeated: true,
     type: Gateway.Serialization.SuperCampaignProgress,
     json_name: "superCampaignProgresses"
-  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgress do
@@ -393,10 +375,10 @@ defmodule Gateway.Serialization.SuperCampaignProgress do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
-  field(:level_id, 3, type: :string, json_name: "levelId")
-  field(:super_campaign_id, 4, type: :string, json_name: "superCampaignId")
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field :level_id, 3, type: :string, json_name: "levelId"
+  field :super_campaign_id, 4, type: :string, json_name: "superCampaignId"
 end
 
 defmodule Gateway.Serialization.AfkRewardRate do
@@ -404,9 +386,9 @@ defmodule Gateway.Serialization.AfkRewardRate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user_id, 1, type: :string, json_name: "userId")
-  field(:currency_id, 2, type: :string, json_name: "currencyId")
-  field(:rate, 3, type: :float)
+  field :user_id, 1, type: :string, json_name: "userId"
+  field :currency_id, 2, type: :string, json_name: "currencyId"
+  field :rate, 3, type: :float
 end
 
 defmodule Gateway.Serialization.UserCurrency do
@@ -414,8 +396,8 @@ defmodule Gateway.Serialization.UserCurrency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :uint32)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :uint32
 end
 
 defmodule Gateway.Serialization.Currency do
@@ -423,7 +405,7 @@ defmodule Gateway.Serialization.Currency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:name, 1, type: :string)
+  field :name, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Unit do
@@ -431,16 +413,16 @@ defmodule Gateway.Serialization.Unit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:level, 2, type: :uint32)
-  field(:tier, 3, type: :uint32)
-  field(:rank, 4, type: :uint32)
-  field(:selected, 5, type: :bool)
-  field(:slot, 6, type: :uint32)
-  field(:campaign_level_id, 7, type: :string, json_name: "campaignLevelId")
-  field(:user_id, 8, type: :string, json_name: "userId")
-  field(:character, 9, type: Gateway.Serialization.Character)
-  field(:items, 10, repeated: true, type: Gateway.Serialization.Item)
+  field :id, 1, type: :string
+  field :level, 2, type: :uint32
+  field :tier, 3, type: :uint32
+  field :rank, 4, type: :uint32
+  field :selected, 5, type: :bool
+  field :slot, 6, type: :uint32
+  field :campaign_level_id, 7, type: :string, json_name: "campaignLevelId"
+  field :user_id, 8, type: :string, json_name: "userId"
+  field :character, 9, type: Gateway.Serialization.Character
+  field :items, 10, repeated: true, type: Gateway.Serialization.Item
 end
 
 defmodule Gateway.Serialization.Units do
@@ -448,7 +430,7 @@ defmodule Gateway.Serialization.Units do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:units, 1, repeated: true, type: Gateway.Serialization.Unit)
+  field :units, 1, repeated: true, type: Gateway.Serialization.Unit
 end
 
 defmodule Gateway.Serialization.UnitAndCurrencies do
@@ -456,13 +438,12 @@ defmodule Gateway.Serialization.UnitAndCurrencies do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:unit, 1, type: Gateway.Serialization.Unit)
+  field :unit, 1, type: Gateway.Serialization.Unit
 
-  field(:user_currency, 2,
+  field :user_currency, 2,
     repeated: true,
     type: Gateway.Serialization.UserCurrency,
     json_name: "userCurrency"
-  )
 end
 
 defmodule Gateway.Serialization.Character do
@@ -470,10 +451,10 @@ defmodule Gateway.Serialization.Character do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:active, 1, type: :bool)
-  field(:name, 2, type: :string)
-  field(:faction, 3, type: :string)
-  field(:quality, 4, type: :uint32)
+  field :active, 1, type: :bool
+  field :name, 2, type: :string
+  field :faction, 3, type: :string
+  field :quality, 4, type: :uint32
 end
 
 defmodule Gateway.Serialization.Item do
@@ -481,11 +462,11 @@ defmodule Gateway.Serialization.Item do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:level, 2, type: :uint32)
-  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
-  field(:user_id, 4, type: :string, json_name: "userId")
-  field(:unit_id, 5, type: :string, json_name: "unitId")
+  field :id, 1, type: :string
+  field :level, 2, type: :uint32
+  field :template, 3, type: Gateway.Serialization.ItemTemplate
+  field :user_id, 4, type: :string, json_name: "userId"
+  field :unit_id, 5, type: :string, json_name: "unitId"
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
@@ -493,9 +474,9 @@ defmodule Gateway.Serialization.ItemTemplate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:name, 2, type: :string)
-  field(:type, 3, type: :string)
+  field :id, 1, type: :string
+  field :name, 2, type: :string
+  field :type, 3, type: :string
 end
 
 defmodule Gateway.Serialization.Campaigns do
@@ -503,7 +484,7 @@ defmodule Gateway.Serialization.Campaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
+  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
 end
 
 defmodule Gateway.Serialization.Campaign do
@@ -511,10 +492,10 @@ defmodule Gateway.Serialization.Campaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:super_campaign_id, 2, type: :string, json_name: "superCampaignId")
-  field(:campaign_number, 3, type: :uint32, json_name: "campaignNumber")
-  field(:levels, 4, repeated: true, type: Gateway.Serialization.Level)
+  field :id, 1, type: :string
+  field :super_campaign_id, 2, type: :string, json_name: "superCampaignId"
+  field :campaign_number, 3, type: :uint32, json_name: "campaignNumber"
+  field :levels, 4, repeated: true, type: Gateway.Serialization.Level
 end
 
 defmodule Gateway.Serialization.Level do
@@ -522,16 +503,15 @@ defmodule Gateway.Serialization.Level do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:campaign_id, 2, type: :string, json_name: "campaignId")
-  field(:level_number, 3, type: :uint32, json_name: "levelNumber")
-  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
+  field :id, 1, type: :string
+  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field :level_number, 3, type: :uint32, json_name: "levelNumber"
+  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
 
-  field(:currency_rewards, 5,
+  field :currency_rewards, 5,
     repeated: true,
     type: Gateway.Serialization.CurrencyReward,
     json_name: "currencyRewards"
-  )
 end
 
 defmodule Gateway.Serialization.CurrencyReward do
@@ -539,8 +519,8 @@ defmodule Gateway.Serialization.CurrencyReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 3, type: :uint64)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 3, type: :uint64
 end
 
 defmodule Gateway.Serialization.AfkRewards do
@@ -548,11 +528,10 @@ defmodule Gateway.Serialization.AfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:afk_rewards, 1,
+  field :afk_rewards, 1,
     repeated: true,
     type: Gateway.Serialization.AfkReward,
     json_name: "afkRewards"
-  )
 end
 
 defmodule Gateway.Serialization.AfkReward do
@@ -560,8 +539,8 @@ defmodule Gateway.Serialization.AfkReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :uint64)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :uint64
 end
 
 defmodule Gateway.Serialization.Error do
@@ -569,7 +548,7 @@ defmodule Gateway.Serialization.Error do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:reason, 1, type: :string)
+  field :reason, 1, type: :string
 end
 
 defmodule Gateway.Serialization.Boxes do
@@ -577,7 +556,7 @@ defmodule Gateway.Serialization.Boxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:boxes, 1, repeated: true, type: Gateway.Serialization.Box)
+  field :boxes, 1, repeated: true, type: Gateway.Serialization.Box
 end
 
 defmodule Gateway.Serialization.Box do
@@ -585,18 +564,17 @@ defmodule Gateway.Serialization.Box do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:name, 2, type: :string)
-  field(:description, 3, type: :string)
-  field(:factions, 4, repeated: true, type: :string)
+  field :id, 1, type: :string
+  field :name, 2, type: :string
+  field :description, 3, type: :string
+  field :factions, 4, repeated: true, type: :string
 
-  field(:rank_weights, 5,
+  field :rank_weights, 5,
     repeated: true,
     type: Gateway.Serialization.RankWeights,
     json_name: "rankWeights"
-  )
 
-  field(:cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost)
+  field :cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost
 end
 
 defmodule Gateway.Serialization.RankWeights do
@@ -604,8 +582,8 @@ defmodule Gateway.Serialization.RankWeights do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:rank, 1, type: :int32)
-  field(:weight, 2, type: :int32)
+  field :rank, 1, type: :int32
+  field :weight, 2, type: :int32
 end
 
 defmodule Gateway.Serialization.CurrencyCost do
@@ -613,8 +591,8 @@ defmodule Gateway.Serialization.CurrencyCost do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 2, type: :int32)
+  field :currency, 1, type: Gateway.Serialization.Currency
+  field :amount, 2, type: :int32
 end
 
 defmodule Gateway.Serialization.UserAndUnit do
@@ -622,8 +600,8 @@ defmodule Gateway.Serialization.UserAndUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:user, 1, type: Gateway.Serialization.User)
-  field(:unit, 2, type: Gateway.Serialization.Unit)
+  field :user, 1, type: Gateway.Serialization.User
+  field :unit, 2, type: Gateway.Serialization.Unit
 end
 
 defmodule Gateway.Serialization.BattleResult do
@@ -631,9 +609,9 @@ defmodule Gateway.Serialization.BattleResult do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState")
-  field(:steps, 2, repeated: true, type: Gateway.Serialization.Step)
-  field(:result, 3, type: :string)
+  field :initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState"
+  field :steps, 2, repeated: true, type: Gateway.Serialization.Step
+  field :result, 3, type: :string
 end
 
 defmodule Gateway.Serialization.State do
@@ -641,7 +619,7 @@ defmodule Gateway.Serialization.State do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:units, 1, repeated: true, type: Gateway.Serialization.BattleUnit)
+  field :units, 1, repeated: true, type: Gateway.Serialization.BattleUnit
 end
 
 defmodule Gateway.Serialization.BattleUnit do
@@ -649,11 +627,11 @@ defmodule Gateway.Serialization.BattleUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:id, 1, type: :string)
-  field(:health, 2, type: :int32)
-  field(:slot, 3, type: :int32)
-  field(:character_id, 4, type: :string, json_name: "characterId")
-  field(:team, 5, type: :int32)
+  field :id, 1, type: :string
+  field :health, 2, type: :int32
+  field :slot, 3, type: :int32
+  field :character_id, 4, type: :string, json_name: "characterId"
+  field :team, 5, type: :int32
 end
 
 defmodule Gateway.Serialization.Step do
@@ -661,8 +639,8 @@ defmodule Gateway.Serialization.Step do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:step_number, 1, type: :int32, json_name: "stepNumber")
-  field(:actions, 2, repeated: true, type: Gateway.Serialization.Action)
+  field :step_number, 1, type: :int32, json_name: "stepNumber"
+  field :actions, 2, repeated: true, type: Gateway.Serialization.Action
 end
 
 defmodule Gateway.Serialization.Action do
@@ -670,34 +648,30 @@ defmodule Gateway.Serialization.Action do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof(:action_type, 0)
+  oneof :action_type, 0
 
-  field(:skill_action, 1,
+  field :skill_action, 1,
     type: Gateway.Serialization.SkillAction,
     json_name: "skillAction",
     oneof: 0
-  )
 
-  field(:modifier_received, 2,
+  field :modifier_received, 2,
     type: Gateway.Serialization.ModifierReceived,
     json_name: "modifierReceived",
     oneof: 0
-  )
 
-  field(:tag_received, 3,
+  field :tag_received, 3,
     type: Gateway.Serialization.TagReceived,
     json_name: "tagReceived",
     oneof: 0
-  )
 
-  field(:modifier_expired, 4,
+  field :modifier_expired, 4,
     type: Gateway.Serialization.ModifierExpired,
     json_name: "modifierExpired",
     oneof: 0
-  )
 
-  field(:tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0)
-  field(:death, 6, type: Gateway.Serialization.Death, oneof: 0)
+  field :tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0
+  field :death, 6, type: Gateway.Serialization.Death, oneof: 0
 end
 
 defmodule Gateway.Serialization.StatAffected do
@@ -705,8 +679,8 @@ defmodule Gateway.Serialization.StatAffected do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:stat, 1, type: Gateway.Serialization.Stat, enum: true)
-  field(:amount, 2, type: :float)
+  field :stat, 1, type: Gateway.Serialization.Stat, enum: true
+  field :amount, 2, type: :float
 end
 
 defmodule Gateway.Serialization.SkillAction do
@@ -714,21 +688,19 @@ defmodule Gateway.Serialization.SkillAction do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:caster_id, 1, type: :string, json_name: "casterId")
-  field(:target_ids, 2, repeated: true, type: :string, json_name: "targetIds")
-  field(:skill_id, 3, type: :string, json_name: "skillId")
+  field :caster_id, 1, type: :string, json_name: "casterId"
+  field :target_ids, 2, repeated: true, type: :string, json_name: "targetIds"
+  field :skill_id, 3, type: :string, json_name: "skillId"
 
-  field(:skill_action_type, 4,
+  field :skill_action_type, 4,
     type: Gateway.Serialization.SkillActionType,
     json_name: "skillActionType",
     enum: true
-  )
 
-  field(:stats_affected, 5,
+  field :stats_affected, 5,
     repeated: true,
     type: Gateway.Serialization.StatAffected,
     json_name: "statsAffected"
-  )
 end
 
 defmodule Gateway.Serialization.ModifierReceived do
@@ -736,9 +708,9 @@ defmodule Gateway.Serialization.ModifierReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
 end
 
 defmodule Gateway.Serialization.TagReceived do
@@ -746,9 +718,9 @@ defmodule Gateway.Serialization.TagReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:tag_name, 3, type: :string, json_name: "tagName")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :tag, 3, type: :string
 end
 
 defmodule Gateway.Serialization.ModifierExpired do
@@ -756,9 +728,9 @@ defmodule Gateway.Serialization.ModifierExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
 end
 
 defmodule Gateway.Serialization.TagExpired do
@@ -766,9 +738,9 @@ defmodule Gateway.Serialization.TagExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:skill_id, 1, type: :string, json_name: "skillId")
-  field(:target_id, 2, type: :string, json_name: "targetId")
-  field(:tag_name, 3, type: :string, json_name: "tagName")
+  field :skill_id, 1, type: :string, json_name: "skillId"
+  field :target_id, 2, type: :string, json_name: "targetId"
+  field :tag_name, 3, type: :string, json_name: "tagName"
 end
 
 defmodule Gateway.Serialization.Death do
@@ -776,5 +748,5 @@ defmodule Gateway.Serialization.Death do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:unit_id, 1, type: :string, json_name: "unitId")
+  field :unit_id, 1, type: :string, json_name: "unitId"
 end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -3,10 +3,10 @@ defmodule Gateway.Serialization.SkillActionType do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :ANIMATION_START, 0
-  field :EFFECT_TRIGGER, 1
-  field :EFFECT_HIT, 2
-  field :EFFECT_MISS, 3
+  field(:ANIMATION_START, 0)
+  field(:EFFECT_TRIGGER, 1)
+  field(:EFFECT_HIT, 2)
+  field(:EFFECT_MISS, 3)
 end
 
 defmodule Gateway.Serialization.Stat do
@@ -14,12 +14,12 @@ defmodule Gateway.Serialization.Stat do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :HEALTH, 0
-  field :ENERGY, 1
-  field :ATTACK, 2
-  field :DEFENSE, 3
-  field :DAMAGE_REDUCTION, 4
-  field :SPEED, 5
+  field(:HEALTH, 0)
+  field(:ENERGY, 1)
+  field(:ATTACK, 2)
+  field(:DEFENSE, 3)
+  field(:DAMAGE_REDUCTION, 4)
+  field(:SPEED, 5)
 end
 
 defmodule Gateway.Serialization.WebSocketRequest do
@@ -27,79 +27,90 @@ defmodule Gateway.Serialization.WebSocketRequest do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :request_type, 0
+  oneof(:request_type, 0)
 
-  field :get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0
+  field(:get_user, 1, type: Gateway.Serialization.GetUser, json_name: "getUser", oneof: 0)
 
-  field :get_user_by_username, 2,
+  field(:get_user_by_username, 2,
     type: Gateway.Serialization.GetUserByUsername,
     json_name: "getUserByUsername",
     oneof: 0
+  )
 
-  field :create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0
+  field(:create_user, 3, type: Gateway.Serialization.CreateUser, json_name: "createUser", oneof: 0)
 
-  field :get_campaigns, 4,
+  field(:get_campaigns, 4,
     type: Gateway.Serialization.GetCampaigns,
     json_name: "getCampaigns",
     oneof: 0
+  )
 
-  field :get_campaign, 5,
+  field(:get_campaign, 5,
     type: Gateway.Serialization.GetCampaign,
     json_name: "getCampaign",
     oneof: 0
+  )
 
-  field :get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0
-  field :fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0
-  field :select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0
+  field(:get_level, 6, type: Gateway.Serialization.GetLevel, json_name: "getLevel", oneof: 0)
+  field(:fight_level, 7, type: Gateway.Serialization.FightLevel, json_name: "fightLevel", oneof: 0)
+  field(:select_unit, 9, type: Gateway.Serialization.SelectUnit, json_name: "selectUnit", oneof: 0)
 
-  field :unselect_unit, 10,
+  field(:unselect_unit, 10,
     type: Gateway.Serialization.UnselectUnit,
     json_name: "unselectUnit",
     oneof: 0
+  )
 
-  field :level_up_unit, 11,
+  field(:level_up_unit, 11,
     type: Gateway.Serialization.LevelUpUnit,
     json_name: "levelUpUnit",
     oneof: 0
+  )
 
-  field :tier_up_unit, 12,
+  field(:tier_up_unit, 12,
     type: Gateway.Serialization.TierUpUnit,
     json_name: "tierUpUnit",
     oneof: 0
+  )
 
-  field :fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0
-  field :equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0
+  field(:fuse_unit, 13, type: Gateway.Serialization.FuseUnit, json_name: "fuseUnit", oneof: 0)
+  field(:equip_item, 14, type: Gateway.Serialization.EquipItem, json_name: "equipItem", oneof: 0)
 
-  field :unequip_item, 15,
+  field(:unequip_item, 15,
     type: Gateway.Serialization.UnequipItem,
     json_name: "unequipItem",
     oneof: 0
+  )
 
-  field :get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0
+  field(:get_item, 16, type: Gateway.Serialization.GetItem, json_name: "getItem", oneof: 0)
 
-  field :level_up_item, 17,
+  field(:level_up_item, 17,
     type: Gateway.Serialization.LevelUpItem,
     json_name: "levelUpItem",
     oneof: 0
+  )
 
-  field :get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0
-  field :get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0
-  field :summon, 20, type: Gateway.Serialization.Summon, oneof: 0
+  field(:get_boxes, 18, type: Gateway.Serialization.GetBoxes, json_name: "getBoxes", oneof: 0)
+  field(:get_box, 19, type: Gateway.Serialization.GetBox, json_name: "getBox", oneof: 0)
+  field(:summon, 20, type: Gateway.Serialization.Summon, oneof: 0)
 
-  field :get_afk_rewards, 21,
+  field(:get_afk_rewards, 21,
     type: Gateway.Serialization.GetAfkRewards,
     json_name: "getAfkRewards",
     oneof: 0
+  )
 
-  field :claim_afk_rewards, 22,
+  field(:claim_afk_rewards, 22,
     type: Gateway.Serialization.ClaimAfkRewards,
     json_name: "claimAfkRewards",
     oneof: 0
+  )
 
-  field :get_user_super_campaign_progresses, 23,
+  field(:get_user_super_campaign_progresses, 23,
     type: Gateway.Serialization.GetUserSuperCampaignProgresses,
     json_name: "getUserSuperCampaignProgresses",
     oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -107,7 +118,7 @@ defmodule Gateway.Serialization.GetUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetUserByUsername do
@@ -115,7 +126,7 @@ defmodule Gateway.Serialization.GetUserByUsername do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.CreateUser do
@@ -123,7 +134,7 @@ defmodule Gateway.Serialization.CreateUser do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :username, 1, type: :string
+  field(:username, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.GetCampaigns do
@@ -131,7 +142,7 @@ defmodule Gateway.Serialization.GetCampaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetCampaign do
@@ -139,8 +150,8 @@ defmodule Gateway.Serialization.GetCampaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
 end
 
 defmodule Gateway.Serialization.GetLevel do
@@ -148,8 +159,8 @@ defmodule Gateway.Serialization.GetLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.FightLevel do
@@ -157,8 +168,8 @@ defmodule Gateway.Serialization.FightLevel do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :level_id, 2, type: :string, json_name: "levelId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:level_id, 2, type: :string, json_name: "levelId")
 end
 
 defmodule Gateway.Serialization.SelectUnit do
@@ -166,9 +177,9 @@ defmodule Gateway.Serialization.SelectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
-  field :slot, 3, type: :uint32
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field(:slot, 3, type: :uint32)
 end
 
 defmodule Gateway.Serialization.UnselectUnit do
@@ -176,8 +187,8 @@ defmodule Gateway.Serialization.UnselectUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.LevelUpUnit do
@@ -185,8 +196,8 @@ defmodule Gateway.Serialization.LevelUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.TierUpUnit do
@@ -194,8 +205,8 @@ defmodule Gateway.Serialization.TierUpUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.FuseUnit do
@@ -203,9 +214,9 @@ defmodule Gateway.Serialization.FuseUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :unit_id, 2, type: :string, json_name: "unitId"
-  field :consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:unit_id, 2, type: :string, json_name: "unitId")
+  field(:consumed_units_ids, 3, repeated: true, type: :string, json_name: "consumedUnitsIds")
 end
 
 defmodule Gateway.Serialization.EquipItem do
@@ -213,9 +224,9 @@ defmodule Gateway.Serialization.EquipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
-  field :unit_id, 3, type: :string, json_name: "unitId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
+  field(:unit_id, 3, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.UnequipItem do
@@ -223,8 +234,8 @@ defmodule Gateway.Serialization.UnequipItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.GetItem do
@@ -232,8 +243,8 @@ defmodule Gateway.Serialization.GetItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.LevelUpItem do
@@ -241,8 +252,8 @@ defmodule Gateway.Serialization.LevelUpItem do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :item_id, 2, type: :string, json_name: "itemId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:item_id, 2, type: :string, json_name: "itemId")
 end
 
 defmodule Gateway.Serialization.GetAfkRewards do
@@ -250,7 +261,7 @@ defmodule Gateway.Serialization.GetAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.ClaimAfkRewards do
@@ -258,7 +269,7 @@ defmodule Gateway.Serialization.ClaimAfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetBoxes do
@@ -266,7 +277,7 @@ defmodule Gateway.Serialization.GetBoxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.GetBox do
@@ -274,7 +285,7 @@ defmodule Gateway.Serialization.GetBox do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :box_id, 1, type: :string, json_name: "boxId"
+  field(:box_id, 1, type: :string, json_name: "boxId")
 end
 
 defmodule Gateway.Serialization.Summon do
@@ -282,8 +293,8 @@ defmodule Gateway.Serialization.Summon do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :box_id, 2, type: :string, json_name: "boxId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:box_id, 2, type: :string, json_name: "boxId")
 end
 
 defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
@@ -291,7 +302,7 @@ defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do
@@ -299,45 +310,50 @@ defmodule Gateway.Serialization.WebSocketResponse do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :response_type, 0
+  oneof(:response_type, 0)
 
-  field :user, 1, type: Gateway.Serialization.User, oneof: 0
-  field :unit, 2, type: Gateway.Serialization.Unit, oneof: 0
-  field :units, 3, type: Gateway.Serialization.Units, oneof: 0
+  field(:user, 1, type: Gateway.Serialization.User, oneof: 0)
+  field(:unit, 2, type: Gateway.Serialization.Unit, oneof: 0)
+  field(:units, 3, type: Gateway.Serialization.Units, oneof: 0)
 
-  field :unit_and_currencies, 4,
+  field(:unit_and_currencies, 4,
     type: Gateway.Serialization.UnitAndCurrencies,
     json_name: "unitAndCurrencies",
     oneof: 0
+  )
 
-  field :item, 5, type: Gateway.Serialization.Item, oneof: 0
-  field :campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0
-  field :campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0
-  field :level, 8, type: Gateway.Serialization.Level, oneof: 0
+  field(:item, 5, type: Gateway.Serialization.Item, oneof: 0)
+  field(:campaigns, 6, type: Gateway.Serialization.Campaigns, oneof: 0)
+  field(:campaign, 7, type: Gateway.Serialization.Campaign, oneof: 0)
+  field(:level, 8, type: Gateway.Serialization.Level, oneof: 0)
 
-  field :battle_result, 9,
+  field(:battle_result, 9,
     type: Gateway.Serialization.BattleResult,
     json_name: "battleResult",
     oneof: 0
+  )
 
-  field :error, 10, type: Gateway.Serialization.Error, oneof: 0
-  field :boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0
-  field :box, 12, type: Gateway.Serialization.Box, oneof: 0
+  field(:error, 10, type: Gateway.Serialization.Error, oneof: 0)
+  field(:boxes, 11, type: Gateway.Serialization.Boxes, oneof: 0)
+  field(:box, 12, type: Gateway.Serialization.Box, oneof: 0)
 
-  field :user_and_unit, 13,
+  field(:user_and_unit, 13,
     type: Gateway.Serialization.UserAndUnit,
     json_name: "userAndUnit",
     oneof: 0
+  )
 
-  field :afk_rewards, 14,
+  field(:afk_rewards, 14,
     type: Gateway.Serialization.AfkRewards,
     json_name: "afkRewards",
     oneof: 0
+  )
 
-  field :super_campaign_progresses, 15,
+  field(:super_campaign_progresses, 15,
     type: Gateway.Serialization.SuperCampaignProgresses,
     json_name: "superCampaignProgresses",
     oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.User do
@@ -345,18 +361,19 @@ defmodule Gateway.Serialization.User do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :username, 2, type: :string
-  field :level, 3, type: :uint64
-  field :experience, 4, type: :uint64
-  field :currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency
-  field :units, 8, repeated: true, type: Gateway.Serialization.Unit
-  field :items, 9, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:username, 2, type: :string)
+  field(:level, 3, type: :uint64)
+  field(:experience, 4, type: :uint64)
+  field(:currencies, 7, repeated: true, type: Gateway.Serialization.UserCurrency)
+  field(:units, 8, repeated: true, type: Gateway.Serialization.Unit)
+  field(:items, 9, repeated: true, type: Gateway.Serialization.Item)
 
-  field :afk_reward_rates, 10,
+  field(:afk_reward_rates, 10,
     repeated: true,
     type: Gateway.Serialization.AfkRewardRate,
     json_name: "afkRewardRates"
+  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgresses do
@@ -364,10 +381,11 @@ defmodule Gateway.Serialization.SuperCampaignProgresses do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :super_campaign_progresses, 1,
+  field(:super_campaign_progresses, 1,
     repeated: true,
     type: Gateway.Serialization.SuperCampaignProgress,
     json_name: "superCampaignProgresses"
+  )
 end
 
 defmodule Gateway.Serialization.SuperCampaignProgress do
@@ -375,10 +393,10 @@ defmodule Gateway.Serialization.SuperCampaignProgress do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
-  field :level_id, 3, type: :string, json_name: "levelId"
-  field :super_campaign_id, 4, type: :string, json_name: "superCampaignId"
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field(:level_id, 3, type: :string, json_name: "levelId")
+  field(:super_campaign_id, 4, type: :string, json_name: "superCampaignId")
 end
 
 defmodule Gateway.Serialization.AfkRewardRate do
@@ -386,9 +404,9 @@ defmodule Gateway.Serialization.AfkRewardRate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user_id, 1, type: :string, json_name: "userId"
-  field :currency_id, 2, type: :string, json_name: "currencyId"
-  field :rate, 3, type: :float
+  field(:user_id, 1, type: :string, json_name: "userId")
+  field(:currency_id, 2, type: :string, json_name: "currencyId")
+  field(:rate, 3, type: :float)
 end
 
 defmodule Gateway.Serialization.UserCurrency do
@@ -396,8 +414,8 @@ defmodule Gateway.Serialization.UserCurrency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :uint32
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :uint32)
 end
 
 defmodule Gateway.Serialization.Currency do
@@ -405,7 +423,7 @@ defmodule Gateway.Serialization.Currency do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :name, 1, type: :string
+  field(:name, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Unit do
@@ -413,16 +431,16 @@ defmodule Gateway.Serialization.Unit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :level, 2, type: :uint32
-  field :tier, 3, type: :uint32
-  field :rank, 4, type: :uint32
-  field :selected, 5, type: :bool
-  field :slot, 6, type: :uint32
-  field :campaign_level_id, 7, type: :string, json_name: "campaignLevelId"
-  field :user_id, 8, type: :string, json_name: "userId"
-  field :character, 9, type: Gateway.Serialization.Character
-  field :items, 10, repeated: true, type: Gateway.Serialization.Item
+  field(:id, 1, type: :string)
+  field(:level, 2, type: :uint32)
+  field(:tier, 3, type: :uint32)
+  field(:rank, 4, type: :uint32)
+  field(:selected, 5, type: :bool)
+  field(:slot, 6, type: :uint32)
+  field(:campaign_level_id, 7, type: :string, json_name: "campaignLevelId")
+  field(:user_id, 8, type: :string, json_name: "userId")
+  field(:character, 9, type: Gateway.Serialization.Character)
+  field(:items, 10, repeated: true, type: Gateway.Serialization.Item)
 end
 
 defmodule Gateway.Serialization.Units do
@@ -430,7 +448,7 @@ defmodule Gateway.Serialization.Units do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :units, 1, repeated: true, type: Gateway.Serialization.Unit
+  field(:units, 1, repeated: true, type: Gateway.Serialization.Unit)
 end
 
 defmodule Gateway.Serialization.UnitAndCurrencies do
@@ -438,12 +456,13 @@ defmodule Gateway.Serialization.UnitAndCurrencies do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :unit, 1, type: Gateway.Serialization.Unit
+  field(:unit, 1, type: Gateway.Serialization.Unit)
 
-  field :user_currency, 2,
+  field(:user_currency, 2,
     repeated: true,
     type: Gateway.Serialization.UserCurrency,
     json_name: "userCurrency"
+  )
 end
 
 defmodule Gateway.Serialization.Character do
@@ -451,10 +470,10 @@ defmodule Gateway.Serialization.Character do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :active, 1, type: :bool
-  field :name, 2, type: :string
-  field :faction, 3, type: :string
-  field :quality, 4, type: :uint32
+  field(:active, 1, type: :bool)
+  field(:name, 2, type: :string)
+  field(:faction, 3, type: :string)
+  field(:quality, 4, type: :uint32)
 end
 
 defmodule Gateway.Serialization.Item do
@@ -462,11 +481,11 @@ defmodule Gateway.Serialization.Item do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :level, 2, type: :uint32
-  field :template, 3, type: Gateway.Serialization.ItemTemplate
-  field :user_id, 4, type: :string, json_name: "userId"
-  field :unit_id, 5, type: :string, json_name: "unitId"
+  field(:id, 1, type: :string)
+  field(:level, 2, type: :uint32)
+  field(:template, 3, type: Gateway.Serialization.ItemTemplate)
+  field(:user_id, 4, type: :string, json_name: "userId")
+  field(:unit_id, 5, type: :string, json_name: "unitId")
 end
 
 defmodule Gateway.Serialization.ItemTemplate do
@@ -474,9 +493,9 @@ defmodule Gateway.Serialization.ItemTemplate do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :name, 2, type: :string
-  field :type, 3, type: :string
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:type, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.Campaigns do
@@ -484,7 +503,7 @@ defmodule Gateway.Serialization.Campaigns do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign
+  field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
 end
 
 defmodule Gateway.Serialization.Campaign do
@@ -492,10 +511,10 @@ defmodule Gateway.Serialization.Campaign do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :super_campaign_id, 2, type: :string, json_name: "superCampaignId"
-  field :campaign_number, 3, type: :uint32, json_name: "campaignNumber"
-  field :levels, 4, repeated: true, type: Gateway.Serialization.Level
+  field(:id, 1, type: :string)
+  field(:super_campaign_id, 2, type: :string, json_name: "superCampaignId")
+  field(:campaign_number, 3, type: :uint32, json_name: "campaignNumber")
+  field(:levels, 4, repeated: true, type: Gateway.Serialization.Level)
 end
 
 defmodule Gateway.Serialization.Level do
@@ -503,15 +522,16 @@ defmodule Gateway.Serialization.Level do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :campaign_id, 2, type: :string, json_name: "campaignId"
-  field :level_number, 3, type: :uint32, json_name: "levelNumber"
-  field :units, 4, repeated: true, type: Gateway.Serialization.Unit
+  field(:id, 1, type: :string)
+  field(:campaign_id, 2, type: :string, json_name: "campaignId")
+  field(:level_number, 3, type: :uint32, json_name: "levelNumber")
+  field(:units, 4, repeated: true, type: Gateway.Serialization.Unit)
 
-  field :currency_rewards, 5,
+  field(:currency_rewards, 5,
     repeated: true,
     type: Gateway.Serialization.CurrencyReward,
     json_name: "currencyRewards"
+  )
 end
 
 defmodule Gateway.Serialization.CurrencyReward do
@@ -519,8 +539,8 @@ defmodule Gateway.Serialization.CurrencyReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 3, type: :uint64
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 3, type: :uint64)
 end
 
 defmodule Gateway.Serialization.AfkRewards do
@@ -528,10 +548,11 @@ defmodule Gateway.Serialization.AfkRewards do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :afk_rewards, 1,
+  field(:afk_rewards, 1,
     repeated: true,
     type: Gateway.Serialization.AfkReward,
     json_name: "afkRewards"
+  )
 end
 
 defmodule Gateway.Serialization.AfkReward do
@@ -539,8 +560,8 @@ defmodule Gateway.Serialization.AfkReward do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :uint64
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :uint64)
 end
 
 defmodule Gateway.Serialization.Error do
@@ -548,7 +569,7 @@ defmodule Gateway.Serialization.Error do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :reason, 1, type: :string
+  field(:reason, 1, type: :string)
 end
 
 defmodule Gateway.Serialization.Boxes do
@@ -556,7 +577,7 @@ defmodule Gateway.Serialization.Boxes do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :boxes, 1, repeated: true, type: Gateway.Serialization.Box
+  field(:boxes, 1, repeated: true, type: Gateway.Serialization.Box)
 end
 
 defmodule Gateway.Serialization.Box do
@@ -564,17 +585,18 @@ defmodule Gateway.Serialization.Box do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :name, 2, type: :string
-  field :description, 3, type: :string
-  field :factions, 4, repeated: true, type: :string
+  field(:id, 1, type: :string)
+  field(:name, 2, type: :string)
+  field(:description, 3, type: :string)
+  field(:factions, 4, repeated: true, type: :string)
 
-  field :rank_weights, 5,
+  field(:rank_weights, 5,
     repeated: true,
     type: Gateway.Serialization.RankWeights,
     json_name: "rankWeights"
+  )
 
-  field :cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost
+  field(:cost, 6, repeated: true, type: Gateway.Serialization.CurrencyCost)
 end
 
 defmodule Gateway.Serialization.RankWeights do
@@ -582,8 +604,8 @@ defmodule Gateway.Serialization.RankWeights do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :rank, 1, type: :int32
-  field :weight, 2, type: :int32
+  field(:rank, 1, type: :int32)
+  field(:weight, 2, type: :int32)
 end
 
 defmodule Gateway.Serialization.CurrencyCost do
@@ -591,8 +613,8 @@ defmodule Gateway.Serialization.CurrencyCost do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :currency, 1, type: Gateway.Serialization.Currency
-  field :amount, 2, type: :int32
+  field(:currency, 1, type: Gateway.Serialization.Currency)
+  field(:amount, 2, type: :int32)
 end
 
 defmodule Gateway.Serialization.UserAndUnit do
@@ -600,8 +622,8 @@ defmodule Gateway.Serialization.UserAndUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :user, 1, type: Gateway.Serialization.User
-  field :unit, 2, type: Gateway.Serialization.Unit
+  field(:user, 1, type: Gateway.Serialization.User)
+  field(:unit, 2, type: Gateway.Serialization.Unit)
 end
 
 defmodule Gateway.Serialization.BattleResult do
@@ -609,9 +631,9 @@ defmodule Gateway.Serialization.BattleResult do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState"
-  field :steps, 2, repeated: true, type: Gateway.Serialization.Step
-  field :result, 3, type: :string
+  field(:initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState")
+  field(:steps, 2, repeated: true, type: Gateway.Serialization.Step)
+  field(:result, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.State do
@@ -619,7 +641,7 @@ defmodule Gateway.Serialization.State do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :units, 1, repeated: true, type: Gateway.Serialization.BattleUnit
+  field(:units, 1, repeated: true, type: Gateway.Serialization.BattleUnit)
 end
 
 defmodule Gateway.Serialization.BattleUnit do
@@ -627,11 +649,11 @@ defmodule Gateway.Serialization.BattleUnit do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :id, 1, type: :string
-  field :health, 2, type: :int32
-  field :slot, 3, type: :int32
-  field :character_id, 4, type: :string, json_name: "characterId"
-  field :team, 5, type: :int32
+  field(:id, 1, type: :string)
+  field(:health, 2, type: :int32)
+  field(:slot, 3, type: :int32)
+  field(:character_id, 4, type: :string, json_name: "characterId")
+  field(:team, 5, type: :int32)
 end
 
 defmodule Gateway.Serialization.Step do
@@ -639,8 +661,8 @@ defmodule Gateway.Serialization.Step do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :step_number, 1, type: :int32, json_name: "stepNumber"
-  field :actions, 2, repeated: true, type: Gateway.Serialization.Action
+  field(:step_number, 1, type: :int32, json_name: "stepNumber")
+  field(:actions, 2, repeated: true, type: Gateway.Serialization.Action)
 end
 
 defmodule Gateway.Serialization.Action do
@@ -648,30 +670,34 @@ defmodule Gateway.Serialization.Action do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  oneof :action_type, 0
+  oneof(:action_type, 0)
 
-  field :skill_action, 1,
+  field(:skill_action, 1,
     type: Gateway.Serialization.SkillAction,
     json_name: "skillAction",
     oneof: 0
+  )
 
-  field :modifier_received, 2,
+  field(:modifier_received, 2,
     type: Gateway.Serialization.ModifierReceived,
     json_name: "modifierReceived",
     oneof: 0
+  )
 
-  field :tag_received, 3,
+  field(:tag_received, 3,
     type: Gateway.Serialization.TagReceived,
     json_name: "tagReceived",
     oneof: 0
+  )
 
-  field :modifier_expired, 4,
+  field(:modifier_expired, 4,
     type: Gateway.Serialization.ModifierExpired,
     json_name: "modifierExpired",
     oneof: 0
+  )
 
-  field :tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0
-  field :death, 6, type: Gateway.Serialization.Death, oneof: 0
+  field(:tag_expired, 5, type: Gateway.Serialization.TagExpired, json_name: "tagExpired", oneof: 0)
+  field(:death, 6, type: Gateway.Serialization.Death, oneof: 0)
 end
 
 defmodule Gateway.Serialization.StatAffected do
@@ -679,8 +705,8 @@ defmodule Gateway.Serialization.StatAffected do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :stat, 1, type: Gateway.Serialization.Stat, enum: true
-  field :amount, 2, type: :float
+  field(:stat, 1, type: Gateway.Serialization.Stat, enum: true)
+  field(:amount, 2, type: :float)
 end
 
 defmodule Gateway.Serialization.SkillAction do
@@ -688,19 +714,21 @@ defmodule Gateway.Serialization.SkillAction do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :caster_id, 1, type: :string, json_name: "casterId"
-  field :target_ids, 2, repeated: true, type: :string, json_name: "targetIds"
-  field :skill_id, 3, type: :string, json_name: "skillId"
+  field(:caster_id, 1, type: :string, json_name: "casterId")
+  field(:target_ids, 2, repeated: true, type: :string, json_name: "targetIds")
+  field(:skill_id, 3, type: :string, json_name: "skillId")
 
-  field :skill_action_type, 4,
+  field(:skill_action_type, 4,
     type: Gateway.Serialization.SkillActionType,
     json_name: "skillActionType",
     enum: true
+  )
 
-  field :stats_affected, 5,
+  field(:stats_affected, 5,
     repeated: true,
     type: Gateway.Serialization.StatAffected,
     json_name: "statsAffected"
+  )
 end
 
 defmodule Gateway.Serialization.ModifierReceived do
@@ -708,9 +736,9 @@ defmodule Gateway.Serialization.ModifierReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
 end
 
 defmodule Gateway.Serialization.TagReceived do
@@ -718,9 +746,9 @@ defmodule Gateway.Serialization.TagReceived do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :tag, 3, type: :string
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:tag, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.ModifierExpired do
@@ -728,9 +756,9 @@ defmodule Gateway.Serialization.ModifierExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected"
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:stat_affected, 3, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
 end
 
 defmodule Gateway.Serialization.TagExpired do
@@ -738,9 +766,9 @@ defmodule Gateway.Serialization.TagExpired do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :skill_id, 1, type: :string, json_name: "skillId"
-  field :target_id, 2, type: :string, json_name: "targetId"
-  field :tag, 3, type: :string
+  field(:skill_id, 1, type: :string, json_name: "skillId")
+  field(:target_id, 2, type: :string, json_name: "targetId")
+  field(:tag, 3, type: :string)
 end
 
 defmodule Gateway.Serialization.Death do
@@ -748,5 +776,5 @@ defmodule Gateway.Serialization.Death do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field :unit_id, 1, type: :string, json_name: "unitId"
+  field(:unit_id, 1, type: :string, json_name: "unitId")
 end

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -372,7 +372,7 @@ syntax = "proto3";
   message TagReceived {
     string skill_id = 1;
     string target_id = 2;
-    string tag_name = 3;
+    string tag = 3;
   }
 
   message ModifierExpired {

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -384,7 +384,7 @@ syntax = "proto3";
   message TagExpired {
     string skill_id = 1;
     string target_id = 2;
-    string tag_name = 3;
+    string tag = 3;
   }
 
   message Death {


### PR DESCRIPTION
The protobuf messages didn't match with the names of the fields being returned in the history of the battles. In the protobuf messages "tag_name" has been changed to "tag" and now the history returns "target_id" instead of "unit_id" or "target_ids" for modifiers and tags received and expired.

All four of those messages should have the target_id like this:
```
%{
  action_type: {:tag_received,
   %{
     tag: "Stun",
     skill_id: "8cb48f51-0719-4d88-9b4f-6581efabf680",
     target_id: "64514657-0dc5-431b-ac19-5bb7cacb4a11"
   }}
}
```

And the `tag_received` message should send `tag` field instead of `tag_name`.

To test these changes run a battle and check that the history returned by the simulator complies with these conditions.