### PR TITLE
[GH-422] increase health when picking up power up

### DIFF
--- a/apps/arena/docs/src/configuration/power_ups.md
+++ b/apps/arena/docs/src/configuration/power_ups.md
@@ -10,6 +10,7 @@ The power ups are entities droped when a player dies that can be picked up for p
 - `power_up`: Determines the specs of the power up that will be dropped
 - `distance_to_power_up`: Distance from the position where the player dies to where the power up will be, it'll spawn in a random direction
 - `power_up_damage_modifier`: How much additional damage the power up will provide
+- `power_up_health_modifier`: How much additional health the power up will provide
 - `radius`: The radius of pickup of the power up
 
 
@@ -25,6 +26,7 @@ The power ups are entities droped when a player dies that can be picked up for p
     "power_up": {
       "distance_to_power_up": 500,
       "power_up_damage_modifier": 0.10,
+      "power_up_health_modifier": 0.10,
       "radius": 10.0
     }
   }

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -21,6 +21,7 @@ defmodule Arena.Entities do
       aditional_info: %{
         health: character.base_health,
         base_health: character.base_health,
+        max_health: character.base_health,
         base_speed: character.base_speed,
         base_stamina_interval: character.stamina_interval,
         skills: character.skills,
@@ -93,7 +94,9 @@ defmodule Arena.Entities do
       aditional_info: %{
         owner_id: owner_id,
         status: :AVAILABLE,
-        remove_on_collision: true
+        remove_on_collision: true,
+        power_up_damage_modifier: power_up.power_up_damage_modifier,
+        power_up_health_modifier: power_up.power_up_health_modifier
       }
     }
   end

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -340,12 +340,12 @@ defmodule Arena.Game.Player do
 
     case heal_interval? and damage_interval? and use_skill_interval? do
       true ->
-        heal_amount = floor(player.aditional_info.base_health * 0.1)
+        heal_amount = floor(player.aditional_info.max_health * 0.1)
 
         Map.update!(player, :aditional_info, fn info ->
           %{
             info
-            | health: min(info.health + heal_amount, info.base_health),
+            | health: min(info.health + heal_amount, info.max_health),
               last_natural_healing_update: now
           }
         end)

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -5,7 +5,7 @@ defmodule Arena.GameLauncher do
   use GenServer
 
   # Amount of clients needed to start a game
-  @clients_needed 10
+  @clients_needed 3
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
   # The available names for bots to enter a match, we should change this in the future

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -5,7 +5,7 @@ defmodule Arena.GameLauncher do
   use GenServer
 
   # Amount of clients needed to start a game
-  @clients_needed 3
+  @clients_needed 10
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
   # The available names for bots to enter a match, we should change this in the future

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -10,6 +10,7 @@ defmodule Arena.GameUpdater do
   alias Arena.Game.{Player, Skill}
   alias Arena.Serialization.{GameEvent, GameState, GameFinished}
   alias Phoenix.PubSub
+  alias Arena.Utils
 
   ##########################
   # API
@@ -1019,11 +1020,18 @@ defmodule Arena.GameUpdater do
         update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
         |> update_in([:aditional_info], fn additional_info ->
           Map.update(additional_info, :health, additional_info.health, fn current_health ->
-            (current_health + additional_info.base_health * power_up.aditional_info.power_up_health_modifier)
-            |> round()
+            Utils.increase_value_by_base_percentage(
+              current_health,
+              additional_info.base_health,
+              power_up.aditional_info.power_up_health_modifier
+            )
           end)
           |> Map.update(:max_health, additional_info.max_health, fn max_health ->
-            (max_health + additional_info.base_health * power_up.aditional_info.power_up_health_modifier) |> round()
+            Utils.increase_value_by_base_percentage(
+              max_health,
+              additional_info.base_health,
+              power_up.aditional_info.power_up_health_modifier
+            )
           end)
         end)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1027,8 +1027,6 @@ defmodule Arena.GameUpdater do
           end)
         end)
 
-      update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
-
       {Map.put(players_acc, player.id, updated_player), Map.put(power_ups_acc, power_up.id, updated_power_up)}
     else
       {players_acc, power_ups_acc}

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1015,7 +1015,19 @@ defmodule Arena.GameUpdater do
     if power_up.aditional_info.status == :AVAILABLE && Player.alive?(player) do
       updated_power_up = put_in(power_up, [:aditional_info, :status], :TAKEN)
 
-      updated_player = update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
+      updated_player =
+        update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
+        |> update_in([:aditional_info], fn additional_info ->
+          Map.update(additional_info, :health, additional_info.health, fn current_health ->
+            (current_health + additional_info.base_health * power_up.aditional_info.power_up_health_modifier)
+            |> round()
+          end)
+          |> Map.update(:max_health, additional_info.max_health, fn max_health ->
+            (max_health + additional_info.base_health * power_up.aditional_info.power_up_health_modifier) |> round()
+          end)
+        end)
+
+      update_in(player, [:aditional_info, :power_ups], fn amount -> amount + 1 end)
 
       {Map.put(players_acc, player.id, updated_player), Map.put(power_ups_acc, power_up.id, updated_power_up)}
     else

--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -12,4 +12,13 @@ defmodule Arena.Utils do
     length = :math.sqrt(x * x + y * y)
     %{x: x / length, y: y / length}
   end
+
+  def increase_value_by_base_percentage(current_value, base_value, amount) when is_integer(current_value) do
+    (current_value + base_value * amount)
+    |> round()
+  end
+
+  def increase_value_by_base_percentage(current_value, base_value, amount) do
+    current_value + base_value * amount
+  end
 end

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -487,6 +487,7 @@
     "power_up": {
       "distance_to_power_up": 500,
       "power_up_damage_modifier": 0.10,
+      "power_up_health_modifier": 0.10,
       "radius": 200.0
     }
   },
@@ -521,8 +522,7 @@
         "reduce_stamina_interval": {
           "decrease_by": 0.3
         },
-        "refresh_stamina": {
-        }
+        "refresh_stamina": {}
       }
     },
     {
@@ -540,7 +540,7 @@
       "duration_ms": 10000,
       "remove_on_action": false,
       "effect_mechanics": {
-        "damage_immunity": { }
+        "damage_immunity": {}
       }
     },
     {


### PR DESCRIPTION
Closes #422

Now when picking up power ups you also get a configurable amount of health that scales based on the base health