### PR TITLE
Delete unnecessary devops folder in bot_manager app

### DIFF
--- a/apps/bot_manager/devops/entrypoint.sh
+++ b/apps/bot_manager/devops/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -ex
-
-$HOME/mirra_backend/_build/prod/rel/bot_manager/bin/bot_manager start


### PR DESCRIPTION
## Motivation
We had a "devops" folder with a script that's not being used or needed.
## Changes
[Delete unnecessary devops folder in bot_manager app](https://github.com/lambdaclass/mirra_backend/commit/f94eb96cb16d9f31ac6a55f2bb6b58b4cfc9b2a2)