### PR TITLE
[GH-546] Add CoM User CRUD

### DIFF
--- a/apps/champions/README.md
+++ b/apps/champions/README.md
@@ -95,7 +95,7 @@ result = Champions.Battle.fight_level(user_id, level_id)
 The parameters described are the required ones, you can check for other parameters in the GameBackend.Units.Characters.Character module.
 
 ```
-{:ok, character} = GameBackend.Units.Characters.insert_character(%{game_id: Champions.Utils.game_id(), active: true, name: character_name, faction: faction_name})
+{:ok, character} = GameBackend.Units.Characters.insert_character(%{game_id: GameBackend.Utils.get_game_id(:champions_of_mirra), active: true, name: character_name, faction: faction_name})
 ```
 
 #### Create Unit
@@ -142,7 +142,7 @@ Slot must be an unoccupied slot identified by number, between 1 and 6.
 #### Create Item Template
 
 ```
-{:ok, item_template} = GameBackend.Items.insert_item_template(%{game_id: Champions.Utils.game_id(), name: name, type: item_type, base_modifiers: base_modifiers})
+{:ok, item_template} = GameBackend.Items.insert_item_template(%{game_id: GameBackend.Utils.get_game_id(:champions_of_mirra), name: name, type: item_type, base_modifiers: base_modifiers})
 ```
 
 #### Create Item

--- a/apps/champions/lib/champions/config.ex
+++ b/apps/champions/lib/champions/config.ex
@@ -4,7 +4,7 @@ defmodule Champions.Config do
   """
 
   alias Champions.Units
-  alias Champions.Utils
+  alias GameBackend.Utils
   alias GameBackend.Units.Characters
   alias GameBackend.Units.Skills
 
@@ -52,7 +52,7 @@ defmodule Champions.Config do
         base_attack: Integer.parse(attack) |> elem(0),
         base_health: Integer.parse(health) |> elem(0),
         base_defense: Integer.parse(defense) |> elem(0),
-        game_id: Utils.game_id(),
+        game_id: Utils.get_game_id(:champions_of_mirra),
         basic_skill_id: get_skill_id(basic_skill),
         ultimate_skill_id: get_skill_id(ultimate_skill),
         active: true

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -5,7 +5,7 @@ defmodule Champions.Users do
 
   alias GameBackend.Users.Currencies.CurrencyCost
   alias Champions.Users
-  alias Champions.Utils
+  alias GameBackend.Utils
   alias Ecto.Changeset
   alias Ecto.Multi
   alias GameBackend.Items
@@ -28,7 +28,7 @@ defmodule Champions.Users do
 
     case Users.register_user(%{
            username: username,
-           game_id: Utils.game_id(),
+           game_id: Utils.get_game_id(:champions_of_mirra),
            level: 1,
            experience: 0,
            kaline_tree_level_id: kaline_tree_level.id
@@ -109,7 +109,7 @@ defmodule Champions.Users do
     # Add SuperCampaignProgress for each SuperCampaign
     Enum.each(campaigns, fn {super_campaign_id, [first_campaign | _campaigns]} ->
       GameBackend.Campaigns.insert_super_campaign_progress(%{
-        game_id: Utils.game_id(),
+        game_id: Utils.get_game_id(:champions_of_mirra),
         user_id: user.id,
         super_campaign_id: super_campaign_id,
         level_id: first_campaign.levels |> Enum.sort_by(& &1.level_number) |> hd() |> Map.get(:id)

--- a/apps/champions/lib/champions/utils.ex
+++ b/apps/champions/lib/champions/utils.ex
@@ -1,5 +1,0 @@
-defmodule Champions.Utils do
-  @moduledoc false
-
-  def game_id(), do: 2
-end

--- a/apps/champions/test/units_test.exs
+++ b/apps/champions/test/units_test.exs
@@ -3,7 +3,7 @@ defmodule Champions.Test.Units do
   Tests for Champions of Mirra units.
   """
   alias GameBackend.Repo
-  alias Champions.Utils
+  alias GameBackend.Utils
   alias Champions.Units
   alias Champions.Users
 
@@ -14,7 +14,7 @@ defmodule Champions.Test.Units do
 
     {:ok, character} =
       GameBackend.Units.Characters.insert_character(%{
-        game_id: Utils.game_id(),
+        game_id: Utils.get_game_id(:champions_of_mirra),
         name: "Test character",
         base_health: 100,
         faction: "Kaline"

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -17,6 +17,7 @@ defmodule GameBackend.Users do
   alias GameBackend.Users.Currencies
   alias GameBackend.Users.User
   alias GameBackend.Users.GoogleUser
+  alias GameBackend.Utils
 
   @doc """
   Registers a user.
@@ -111,7 +112,25 @@ defmodule GameBackend.Users do
   end
 
   defp create_google_user_by_email(email) do
-    GoogleUser.changeset(%GoogleUser{}, %{email: email})
+    # TODO delete the following in a future refactor -> https://github.com/lambdaclass/mirra_backend/issues/557
+    kaline_tree_id = GameBackend.Users.get_kaline_tree_level(1).id
+    level = 1
+    experience = 1
+    amount_of_users = Repo.aggregate(GameBackend.Users.User, :count)
+    username = "User_#{amount_of_users + 1}"
+    ##################################################################
+    game_id = Utils.get_game_id("curse_of_mirra")
+
+    GoogleUser.changeset(%GoogleUser{}, %{
+      email: email,
+      user: %{
+        kaline_tree_level_id: kaline_tree_id,
+        game_id: game_id,
+        username: username,
+        level: level,
+        experience: experience
+      }
+    })
     |> Repo.insert()
   end
 

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -62,10 +62,10 @@ defmodule GameBackend.Users do
 
   ## Examples
 
-      iex> update_user("51646f3a-d9e9-4ce6-8341-c90b8cad3bdf")
+      iex> update_user("51646f3a-d9e9-4ce6-8341-c90b8cad3bdf", %{valid_param: valid_value})
       {:ok, %User{}}
 
-      iex> update_user("9483ae81-f3e8-4050-acea-13940d47d8ed")
+      iex> update_user("9483ae81-f3e8-4050-acea-13940d47d8ed", %{invalid_param: invalid_value})
       {:error, %Changeset{}}
   """
   def update_user(%User{} = user, params) do

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -38,20 +38,38 @@ defmodule GameBackend.Users do
 
   @doc """
   Gets a single user.
-
+  Returns {:ok, User}.
   Returns {:error, :not_found} if no user is found.
 
   ## Examples
 
       iex> get_user("51646f3a-d9e9-4ce6-8341-c90b8cad3bdf")
-      %User{}
+      {:ok, %User{}}
 
       iex> get_user("9483ae81-f3e8-4050-acea-13940d47d8ed")
-      nil
+      {:error, :not_found}
   """
   def get_user(id) do
     user = Repo.get(User, id) |> preload()
     if user, do: {:ok, user}, else: {:error, :not_found}
+  end
+
+  @doc """
+  Updates the given user by given params.
+  Returns {:ok, User}.
+  Returns {:error, Changeset} if update transaction fails.
+
+  ## Examples
+
+      iex> update_user("51646f3a-d9e9-4ce6-8341-c90b8cad3bdf")
+      {:ok, %User{}}
+
+      iex> update_user("9483ae81-f3e8-4050-acea-13940d47d8ed")
+      {:error, %Changeset{}}
+  """
+  def update_user(%User{} = user, params) do
+    User.changeset(user, params)
+    |> Repo.update()
   end
 
   @doc """

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -119,7 +119,7 @@ defmodule GameBackend.Users do
     amount_of_users = Repo.aggregate(GameBackend.Users.User, :count)
     username = "User_#{amount_of_users + 1}"
     ##################################################################
-    game_id = Utils.get_game_id("curse_of_mirra")
+    game_id = Utils.get_game_id(:curse_of_mirra)
 
     GoogleUser.changeset(%GoogleUser{}, %{
       email: email,

--- a/apps/game_backend/lib/game_backend/users/google_user.ex
+++ b/apps/game_backend/lib/game_backend/users/google_user.ex
@@ -8,7 +8,7 @@ defmodule GameBackend.Users.GoogleUser do
 
   schema "google_users" do
     field(:email, :string)
-    has_one(:user, User)
+    has_one(:user, GameBackend.Users.User)
     timestamps()
   end
 

--- a/apps/game_backend/lib/game_backend/users/google_user.ex
+++ b/apps/game_backend/lib/game_backend/users/google_user.ex
@@ -8,6 +8,7 @@ defmodule GameBackend.Users.GoogleUser do
 
   schema "google_users" do
     field(:email, :string)
+    has_one(:user, User)
     timestamps()
   end
 
@@ -15,6 +16,7 @@ defmodule GameBackend.Users.GoogleUser do
   def changeset(user, attrs) do
     user
     |> cast(attrs, [:email])
-    |> validate_required([:email])
+    |> cast_assoc(:user, with: &GameBackend.Users.User.changeset/2)
+    |> validate_required([:email, :user])
   end
 end

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -18,8 +18,10 @@ defmodule GameBackend.Users.User do
     field(:level, :integer)
     field(:experience, :integer)
     field(:last_afk_reward_claim, :utc_datetime)
+    field(:profile_picture, :string)
 
     belongs_to(:kaline_tree_level, KalineTreeLevel)
+    belongs_to(:google_user, GoogleUser)
 
     has_many(:currencies, UserCurrency)
     has_many(:units, Unit, preload_order: [desc: :level])
@@ -33,9 +35,18 @@ defmodule GameBackend.Users.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:game_id, :username, :last_afk_reward_claim, :kaline_tree_level_id, :level, :experience])
-    |> unique_constraint([:game_id, :username])
-    |> validate_required([:game_id, :username, :kaline_tree_level_id])
+    |> cast(attrs, [
+      :game_id,
+      :username,
+      :last_afk_reward_claim,
+      :kaline_tree_level_id,
+      :level,
+      :experience,
+      :profile_picture,
+      :google_user_id
+    ])
+    |> unique_constraint([:game_id, :username, :profile_picture])
+    |> validate_required([:game_id, :username, :kaline_tree_level_id, :google_user_id])
   end
 
   def experience_changeset(user, attrs), do: user |> cast(attrs, [:experience, :level])

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -45,8 +45,9 @@ defmodule GameBackend.Users.User do
       :profile_picture,
       :google_user_id
     ])
-    |> unique_constraint([:game_id, :username, :profile_picture])
-    |> validate_required([:game_id, :username, :kaline_tree_level_id, :google_user_id])
+    |> unique_constraint([:game_id, :username])
+    |> assoc_constraint(:google_user)
+    |> validate_required([:game_id, :username, :kaline_tree_level_id])
   end
 
   def experience_changeset(user, attrs), do: user |> cast(attrs, [:experience, :level])

--- a/apps/game_backend/lib/game_backend/utils.ex
+++ b/apps/game_backend/lib/game_backend/utils.ex
@@ -3,6 +3,6 @@ defmodule GameBackend.Utils do
   Helper module
   """
 
-  def get_game_id("curse_of_mirra"), do: 1
-  def get_game_id("champions_of_mirra"), do: 2
+  def get_game_id(:curse_of_mirra), do: 1
+  def get_game_id(:champions_of_mirra), do: 2
 end

--- a/apps/game_backend/lib/game_backend/utils.ex
+++ b/apps/game_backend/lib/game_backend/utils.ex
@@ -1,0 +1,8 @@
+defmodule GameBackend.Utils do
+  @moduledoc """
+  Helper module
+  """
+
+  def get_game_id("curse_of_mirra"), do: 1
+  def get_game_id("champions_of_mirra"), do: 2
+end

--- a/apps/game_backend/priv/repo/migrations/20240429180719_add_google_user_assoc_to_users.exs
+++ b/apps/game_backend/priv/repo/migrations/20240429180719_add_google_user_assoc_to_users.exs
@@ -1,0 +1,10 @@
+defmodule GameBackend.Repo.Migrations.AddGoogleUserAssocToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :google_user_id, references(:google_users, on_delete: :delete_all)
+      add :profile_picture, :string
+    end
+  end
+end

--- a/apps/gateway/lib/gateway/controllers/user_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/user_controller.ex
@@ -5,23 +5,15 @@ defmodule Gateway.Controllers.UserController do
   use Gateway, :controller
   alias GameBackend.Users
 
-  def change_username(conn, params) do
-    update_user_params(conn, params.user_id, %{"username" => params.username})
-  end
-
-  def change_profile_picture(conn, params) do
-    update_user_params(conn, params.user_id, %{"profile_picture" => params.profile_picture})
-  end
-
-  defp update_user_params(conn, user_id, params) do
+  def update(conn, params) do
     conn = put_resp_content_type(conn, "application/json")
 
-    with {:ok, user} <- Users.get_user(user_id),
+    with {:ok, user} <- Users.get_user(params["user_id"]),
          {:ok, user} <- Users.update_user(user, params) do
-      send_resp(conn, 200, Jason.encode!(user))
+      send_resp(conn, 200, Jason.encode!(user.id))
     else
-      {:error, :not_found} -> send_resp(conn, 200, Jason.encode!(%{"error" => "not found"}))
-      {:error, _changeset} -> send_resp(conn, 200, Jason.encode!(%{"error" => "failed to update"}))
+      {:error, :not_found} -> send_resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+      {:error, _changeset} -> send_resp(conn, 400, Jason.encode!(%{"error" => "failed to update"}))
     end
   end
 end

--- a/apps/gateway/lib/gateway/controllers/user_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/user_controller.ex
@@ -6,8 +6,6 @@ defmodule Gateway.Controllers.UserController do
   alias GameBackend.Users
 
   def update(conn, params) do
-    conn = put_resp_content_type(conn, "application/json")
-
     with {:ok, user} <- Users.get_user(params["user_id"]),
          {:ok, user} <- Users.update_user(user, params) do
       send_resp(conn, 200, Jason.encode!(user.id))

--- a/apps/gateway/lib/gateway/controllers/user_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/user_controller.ex
@@ -1,0 +1,27 @@
+defmodule Gateway.Controllers.UserController do
+  @moduledoc """
+  Controller for User modifications.
+  """
+  use Gateway, :controller
+  alias GameBackend.Users
+
+  def change_username(conn, params) do
+    update_user_params(conn, params.user_id, %{"username" => params.username})
+  end
+
+  def change_profile_picture(conn, params) do
+    update_user_params(conn, params.user_id, %{"profile_picture" => params.profile_picture})
+  end
+
+  defp update_user_params(conn, user_id, params) do
+    conn = put_resp_content_type(conn, "application/json")
+
+    with {:ok, user} <- Users.get_user(user_id),
+         {:ok, user} <- Users.update_user(user, params) do
+      send_resp(conn, 200, Jason.encode!(user))
+    else
+      {:error, :not_found} -> send_resp(conn, 200, Jason.encode!(%{"error" => "not found"}))
+      {:error, _changeset} -> send_resp(conn, 200, Jason.encode!(%{"error" => "failed to update"}))
+    end
+  end
+end

--- a/apps/gateway/lib/gateway/router.ex
+++ b/apps/gateway/lib/gateway/router.ex
@@ -15,6 +15,13 @@ defmodule Gateway.Router do
     get "/:provider/token/:token_id", Controllers.AuthController, :validate_token
   end
 
+  scope "/users", Gateway do
+    pipe_through :api
+
+    post "/users/:user_id/change_username/:username", Controllers.UserController, :change_username
+    post "/users/:user_id/change_profile_picture/:profile_picture", Controllers.UserController, :change_profile_picture
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", Gateway do
   #   pipe_through :api

--- a/apps/gateway/lib/gateway/router.ex
+++ b/apps/gateway/lib/gateway/router.ex
@@ -9,17 +9,11 @@ defmodule Gateway.Router do
     pipe_through :api
   end
 
-  scope "/auth", Gateway do
+  scope "/", Gateway do
     pipe_through :api
 
-    get "/:provider/token/:token_id", Controllers.AuthController, :validate_token
-  end
-
-  scope "/users", Gateway do
-    pipe_through :api
-
-    post "/users/:user_id/change_username/:username", Controllers.UserController, :change_username
-    post "/users/:user_id/change_profile_picture/:profile_picture", Controllers.UserController, :change_profile_picture
+    get "/auth/:provider/token/:token_id", Controllers.AuthController, :validate_token
+    put "/users/:user_id", Controllers.UserController, :update
   end
 
   # Other scopes may use custom stacks.

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -196,7 +196,7 @@ defmodule Gateway.Test.Champions do
 
       {:ok, same_faction_character} =
         GameBackend.Units.Characters.insert_character(%{
-          game_id: Utils.game_id(),
+          game_id: Utils.get_game_id(:champions_of_mirra),
           active: true,
           name: "SameFactionUnit",
           faction: muflus.faction,
@@ -574,7 +574,7 @@ defmodule Gateway.Test.Champions do
 
       {:ok, epic_bow} =
         Items.insert_item_template(%{
-          game_id: Utils.game_id(),
+          game_id: Utils.get_game_id(:champions_of_mirra),
           name: "Epic Bow of Testness",
           type: "weapon",
           modifiers: [
@@ -616,7 +616,7 @@ defmodule Gateway.Test.Champions do
 
       {:ok, epic_item} =
         Items.insert_item_template(%{
-          game_id: Utils.game_id(),
+          game_id: Utils.get_game_id(:champions_of_mirra),
           name: "Epic Upgrader of All Stats",
           type: "weapon",
           base_modifiers: [
@@ -724,7 +724,7 @@ defmodule Gateway.Test.Champions do
 
       {:ok, epic_axe} =
         Items.insert_item_template(%{
-          game_id: Utils.game_id(),
+          game_id: Utils.get_game_id(:champions_of_mirra),
           name: "Epic Axe of Testness",
           type: "weapon",
           modifiers: [

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -6,7 +6,8 @@ defmodule Gateway.Test.Champions do
 
   use ExUnit.Case
 
-  alias Champions.{Units, Users, Utils}
+  alias Champions.{Units, Users}
+  alias GameBackend.Utils
   alias GameBackend.Campaigns.Rewards.CurrencyReward
   alias GameBackend.Repo
   alias GameBackend.Items


### PR DESCRIPTION
## Motivation
Closes #546 
We need to allow users to change their information (username, profile pic).
This User must be associated with the one created with google.

## Changes
- [Add google user assoc and profile picture field to users table](https://github.com/lambdaclass/mirra_backend/pull/548/commits/9274011e62da5120692ad485d4a88c4bcaf2c0d7)
- [Add update_user/2 function to update a user's params](https://github.com/lambdaclass/mirra_backend/pull/548/commits/e4b297f92ceaf0d8768bd4b6d970c77475546de9)
- [Add new fields and assocs to User and GoogleUser schemas](https://github.com/lambdaclass/mirra_backend/pull/548/commits/0fae34239872d8c4f1562ace53a8c4fbca928148)
- [Add new endpoints and controller to handle username and profile picture](https://github.com/lambdaclass/mirra_backend/pull/548/commits/0ec87b02793cff03ad3f67b0128189b19c17f463)
- [Fix google_user and user associations and changeset rules](https://github.com/lambdaclass/mirra_backend/pull/548/commits/027eea4abf8896f02c8ad74a4712fde195758ac8)
- [Create User when GoogleUser is created](https://github.com/lambdaclass/mirra_backend/pull/548/commits/14701eddc26e4111559c1edfbe113b5671b143c4)