### PR TITLE
Fix Modifiers

### DIFF
--- a/apps/champions/docs/battle.md
+++ b/apps/champions/docs/battle.md
@@ -3,8 +3,8 @@ Sample code to create two teams of Mufluses and make them battle. Change [1..n] 
 ```
 {:ok, user_1} = Champions.Users.register("User1")
 {:ok, user_2} = Champions.Users.register("User2")
-team1 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [[items: :template, basic_skill: [mechanics: :apply_effects_to],ultimate_skill: [mechanics: :apply_effects_to]]]) end)
-team2 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [[items: :template, basic_skill: [mechanics: :apply_effects_to],ultimate_skill: [mechanics: :apply_effects_to]]]) end)
+team1 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, level: 1, tier: 1, rank: 1, selected: true, user_id: user_1.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [basic_skill: [mechanics: :apply_effects_to], ultimate_skill: [mechanics: :apply_effects_to]], items: :template) end)
+team2 = Enum.map(1..6, fn slot -> GameBackend.Units.insert_unit(%{character_id: GameBackend.Units.Characters.get_character_by_name("Muflus").id, level: 1, tier: 1, rank: 1, selected: true, user_id: user_2.id, slot: slot}) |> elem(1) |> GameBackend.Repo.preload(character: [basic_skill: [mechanics: :apply_effects_to], ultimate_skill: [mechanics: :apply_effects_to]], items: :template) end)
 result = Champions.Battle.Simulator.run_battle(team1, team2)
 ```
 

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -656,7 +656,7 @@ defmodule Champions.Battle.Simulator do
     {target, new_history}
   end
 
-  defp get_duration(%{duration: duration}), do: div(duration, @miliseconds_per_step)
+  defp get_duration(%{duration: duration}), do: duration
   defp get_duration(_type), do: -1
 
   # Return whether an effect hits.
@@ -882,11 +882,9 @@ defmodule Champions.Battle.Simulator do
     do: %{
       type:
         Enum.into(effect.type, %{}, fn
-          {key, value} when is_binary(value) ->
-            {string_to_atom(key), string_to_atom(value)}
-
-          {key, value} ->
-            {string_to_atom(key), value}
+          {"type", type} -> {:type, string_to_atom(type)}
+          {"period", period} -> {:period, div(period, @miliseconds_per_step)}
+          {"duration", duration} -> {:duration, div(duration, @miliseconds_per_step)}
         end),
       delay: div(effect.initial_delay, @miliseconds_per_step),
       # TODO: replace random for the corresponding target strategy name (CHoM #325)

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -16,8 +16,8 @@ defmodule Champions.Battle.Simulator do
 
   They also have different targeting strategies:
   [x] Random
-  [ ] Nearest
-  [ ] Furthest
+  [X] Nearest
+  [X] Furthest
   [ ] Frontline - Heroes in slots 1 and 2
   [ ] Backline - Heroes in slots 2 to 4
   [ ] Factions
@@ -592,8 +592,10 @@ defmodule Champions.Battle.Simulator do
         # If it's permanent, we set its duration to -1
         new_modifier =
           modifier
-          |> Map.put(:remaining_steps, Map.get(effect.type, "duration", -1))
+          |> Map.put(:remaining_steps, get_duration(effect.type))
           |> Map.put(:step_applied_at, current_step_number)
+
+        Logger.info("Applying modifier [#{format_modifier_name(new_modifier)}] to #{format_unit_name(target)}.")
 
         new_history =
           add_to_history(
@@ -653,6 +655,9 @@ defmodule Champions.Battle.Simulator do
 
     {target, new_history}
   end
+
+  defp get_duration(%{duration: duration}), do: div(duration, @miliseconds_per_step)
+  defp get_duration(_type), do: -1
 
   # Return whether an effect hits.
   defp effect_hits?(effect, target_id) when is_binary(target_id), do: !chance_to_apply_hits?(effect)
@@ -857,8 +862,8 @@ defmodule Champions.Battle.Simulator do
           else
             "random"
           end,
-        count: mechanic.apply_effects_to.targeting_strategy.count,
-        target_allies: mechanic.apply_effects_to.targeting_strategy.target_allies
+        count: mechanic.apply_effects_to.targeting_strategy.count || 1,
+        target_allies: mechanic.apply_effects_to.targeting_strategy.target_allies || false
       }
     }
 
@@ -946,11 +951,12 @@ defmodule Champions.Battle.Simulator do
   defp string_to_atom("type"), do: :type
   defp string_to_atom("duration"), do: :duration
   defp string_to_atom("period"), do: :period
-  defp string_to_atom("instant"), do: :type
+  defp string_to_atom("instant"), do: :instant
 
   defp string_to_atom("ATTACK"), do: :ATTACK
   defp string_to_atom("DEFENSE"), do: :DEFENSE
   defp string_to_atom("HEALTH"), do: :HEALTH
   defp string_to_atom("ENERGY"), do: :ENERGY
   defp string_to_atom("SPEED"), do: :SPEED
+  defp string_to_atom("DAMAGE_REDUCTION"), do: :DAMAGE_REDUCTION
 end

--- a/apps/champions/priv/skills.json
+++ b/apps/champions/priv/skills.json
@@ -1516,7 +1516,7 @@
               "components": [],
               "modifiers": [
                 {
-                  "attribute": "dmg-red%",
+                  "attribute": "damage_reduction",
                   "modifier_operation": "Add",
                   "magnitude_calc_type": "float",
                   "float_magnitude": 0.2


### PR DESCRIPTION
Modifiers were working incorrectly: They were fetching the duration with a `"duration"` key instead of a `:duration` key. This was making all modifiers permanent (as it always defaulted to -1). We also were not transforming config duration ms to steps

Also, the units with "self" strategies were not defaulting to "random" correctly, as they did not define a `count` and a `targets_allies`. We also add these values.

# To Test

Run a battle with Grimstein and check that somewhere in the logs the following shows up (with different numbers):
`Modifier [Add damage_reduction by 0.2] remaining time reduced for Grimstein-790.`