### PR TITLE
[GH-570] Spawn bot with random character

### DIFF
--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -100,10 +100,15 @@ defmodule Arena.GameLauncher do
   end
 
   defp get_bot_clients(missing_clients) do
+    characters =
+      Arena.Configuration.get_game_config()
+      |> Map.get(:characters)
+      |> Enum.filter(fn chara -> chara.active end)
+
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
-      {client_id, "h4ck", Enum.at(@bot_names, i), nil}
+      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
     end)
   end
 

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -103,7 +103,7 @@ defmodule Arena.GameLauncher do
     characters =
       Arena.Configuration.get_game_config()
       |> Map.get(:characters)
-      |> Enum.filter(fn chara -> chara.active end)
+      |> Enum.filter(fn character -> character.active end)
 
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()


### PR DESCRIPTION
## Motivation

bot were always spawning with the h4ck character
Closes #570

## Summary of changes

Randomized bot spawn

## How to test it?

Start a match with bots, this is harder in the client. I suggest using the unity app

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
