### PR TITLE
Add fuse requirements configuration

### DIFF
--- a/apps/champions/lib/champions/application.ex
+++ b/apps/champions/lib/champions/application.ex
@@ -3,6 +3,8 @@ defmodule Champions.Application do
   # for more information on OTP Applications
   @moduledoc false
 
+  alias Champions.Config
+
   use Application
 
   @impl true
@@ -15,7 +17,8 @@ defmodule Champions.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
 
-    Champions.Config.import_proximity_config()
+    Config.import_proximity_config()
+    Config.import_fusion_config()
 
     opts = [strategy: :one_for_one, name: Champions.Supervisor]
     Supervisor.start_link(children, opts)

--- a/apps/champions/lib/champions/config.ex
+++ b/apps/champions/lib/champions/config.ex
@@ -87,4 +87,26 @@ defmodule Champions.Config do
       )
     end)
   end
+
+  def import_fusion_config() do
+    {:ok, fusion_json} =
+      Application.app_dir(:champions, "priv/fusion.json")
+      |> File.read()
+
+    fusion_rules = Jason.decode!(fusion_json, [{:keys, :atoms}])
+
+    Enum.each(fusion_rules, fn fusion_rule ->
+      Application.put_env(
+        :champions,
+        :"rank_#{fusion_rule.rank}_fusion",
+        %{
+          same_character_amount: fusion_rule.same_character_amount,
+          same_character_rank: fusion_rule.same_character_rank,
+          same_faction_amount: fusion_rule.same_faction_amount,
+          same_faction_rank: fusion_rule.same_faction_rank
+        },
+        persistent: true
+      )
+    end)
+  end
 end

--- a/apps/champions/lib/champions/units.ex
+++ b/apps/champions/lib/champions/units.ex
@@ -286,17 +286,16 @@ defmodule Champions.Units do
   end
 
   defp meets_fuse_requirements?(unit, unit_list) do
-    {same_character_amount, same_character_rank} = same_character_requirements(unit)
-    {same_faction_amount, same_faction_rank} = same_faction_requirements(unit)
+    requirements = Application.get_env(:champions, :"rank_#{unit.rank}_fusion")
 
     with {:ok, removed_same_character} <-
-           remove_same_character(unit, unit_list, same_character_amount, same_character_rank),
+           remove_same_character(unit, unit_list, requirements.same_character_amount, requirements.same_character_rank),
          {:ok, removed_same_faction} <-
            remove_same_faction(
              unit,
              removed_same_character,
-             same_faction_amount,
-             same_faction_rank
+             requirements.same_faction_amount,
+             requirements.same_faction_rank
            ) do
       # If we got here with an empty list, then the units are valid
       if Enum.empty?(removed_same_faction), do: true, else: false
@@ -304,18 +303,6 @@ defmodule Champions.Units do
       :error -> false
     end
   end
-
-  defp same_character_requirements(%Unit{rank: @star4}), do: {2, @star4}
-  defp same_character_requirements(%Unit{rank: @star5}), do: {1, @star5}
-  defp same_character_requirements(%Unit{rank: @illumination1}), do: {1, @star5}
-  defp same_character_requirements(%Unit{rank: @illumination2}), do: {1, @star5}
-  defp same_character_requirements(%Unit{rank: @illumination3}), do: {3, @star5}
-
-  defp same_faction_requirements(%Unit{rank: @star4}), do: {4, @star4}
-  defp same_faction_requirements(%Unit{rank: @star5}), do: {4, @star5}
-  defp same_faction_requirements(%Unit{rank: @illumination1}), do: {1, @illumination1}
-  defp same_faction_requirements(%Unit{rank: @illumination2}), do: {2, @illumination2}
-  defp same_faction_requirements(%Unit{rank: @illumination3}), do: {2, @illumination2}
 
   defp remove_same_character(unit, unit_list, amount, rank) do
     Enum.reduce_while(1..amount, unit_list, fn _, list ->

--- a/apps/champions/priv/fusion.json
+++ b/apps/champions/priv/fusion.json
@@ -1,0 +1,37 @@
+[
+    {
+        "rank": 4,
+        "same_character_amount": 2,
+        "same_character_rank": 4,
+        "same_faction_amount": 4,
+        "same_faction_rank": 4
+    },
+    {
+        "rank": 5,
+        "same_character_amount": 1,
+        "same_character_rank": 5,
+        "same_faction_amount": 4,
+        "same_faction_rank": 5
+    },
+    {
+        "rank": 6,
+        "same_character_amount": 1,
+        "same_character_rank": 5,
+        "same_faction_amount": 1,
+        "same_faction_rank": 6
+    },
+    {
+        "rank": 7,
+        "same_character_amount": 1,
+        "same_character_rank": 5,
+        "same_faction_amount": 2,
+        "same_faction_rank": 6
+    },
+    {
+        "rank": 8,
+        "same_character_amount": 3,
+        "same_character_rank": 5,
+        "same_faction_amount": 2,
+        "same_faction_rank": 6
+    }
+]


### PR DESCRIPTION
## Motivation

We want to be able to configure fusion configurations without touching code. For now, we will be using a json file. Eventually this would be handled through some kind of configurator app.
Closes https://github.com/lambdaclass/champions_of_mirra/issues/189

## Summary of changes

Adds fusion configuration

## How to test it?

You can give your user whichever unit/character you want with 
```
{:ok, consumed_unit_1} = GameBackend.Units.insert_unit(%{user_id: user.id, rank: DESIRED_RANK, character_id: GameBackend.Units.Characters.get_character_by_name("DESIRED_CHARACTER").id})
```
Then you can test fusion with 
```
Champions.Untis.fuse(user.id, target_unit_id, [consumed_unit_1, ...]
```
To re-import fusion.json, run 
```
Champions.Config.import_fusion_config()
```
