### PR TITLE
[GH-607] Only spawn bots if player is alive

### DIFF
--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -153,7 +153,7 @@ defmodule Arena.GameSocketHandler do
   end
 
   @impl true
-  def terminate(_reason, _req, %{game_finished: false} = state) do
+  def terminate(_reason, _req, %{game_finished: false, enable: true} = state) do
     spawn(fn ->
       Finch.build(:get, Utils.get_bot_connection_url(state.game_id, state.client_id))
       |> Finch.request(Arena.Finch)

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -34,6 +34,7 @@ defmodule Arena.GameSocketHandler do
       |> Map.put(:enable, game_status == :RUNNING)
       |> Map.put(:block_actions, false)
       |> Map.put(:game_finished, game_status == :ENDED)
+      |> Map.put(:player_alive, true)
 
     encoded_msg =
       GameEvent.encode(%GameEvent{
@@ -131,7 +132,12 @@ defmodule Arena.GameSocketHandler do
   @impl true
   def websocket_info({:player_dead, player_id}, state) do
     if state.player_id == player_id do
-      {:ok, Map.put(state, :enable, false)}
+      state =
+        state
+        |> Map.put(:enable, false)
+        |> Map.put(:player_alive, false)
+
+      {:ok, state}
     else
       {:ok, state}
     end
@@ -153,7 +159,7 @@ defmodule Arena.GameSocketHandler do
   end
 
   @impl true
-  def terminate(_reason, _req, %{game_finished: false, enable: true} = state) do
+  def terminate(_reason, _req, %{game_finished: false, player_alive: true} = state) do
     spawn(fn ->
       Finch.build(:get, Utils.get_bot_connection_url(state.game_id, state.client_id))
       |> Finch.request(Arena.Finch)


### PR DESCRIPTION
## Motivation

We were spawning bots that could move when a dead player leaves a match.

Closes #607

## Summary of changes

- Now we'll only spawn bots if the player is alive, we're updating the enable field when a player dies so we'll use that

## How to test it?

1. Change the players_needed_in_match variable to 3
2. Join a match with the browser client and the unity client
3. Die to the spawned bot in the unity client and leave the match
4. In main you'll see that the dead players is moving
5. In this branch that shouldn't happen

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
