### PR TITLE
Fix gateway.proto

### DIFF
--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -181,20 +181,22 @@ syntax = "proto3";
   }
 
   message KalineTreeLevel {
-    uint64 level = 1;
-    uint64 fertilizer_level_up_cost = 2;
-    uint64 gold_level_up_cost = 3;
-    repeated string unlock_features = 4;
-    repeated AfkRewardRate afk_reward_rates = 5;
-  }
-
-  message DungeonSettlementLevel {
-    uint64 level = 1;
-    repeated CurrencyCost upgrade_costs = 2;
-    uint64 max_dungeon = 3;
-    uint64 max_factional = 4;
-    uint64 supply_limit = 5;
+    string id = 1;
+    uint64 level = 2;
+    uint64 fertilizer_level_up_cost = 3;
+    uint64 gold_level_up_cost = 4;
+    repeated string unlock_features = 5;
     repeated AfkRewardRate afk_reward_rates = 6;
+  }
+  
+  message DungeonSettlementLevel {
+    string id = 1;
+    uint64 level = 2;
+    repeated CurrencyCost upgrade_costs = 3;
+    uint64 max_dungeon = 4;
+    uint64 max_factional = 5;
+    uint64 supply_limit = 6;
+    repeated AfkRewardRate afk_reward_rates = 7;
   }
 
   message SuperCampaignProgresses {


### PR DESCRIPTION
## Motivation

We introduced a change that was breaking tests, but since we forgot to run make generate-protos we didn't notice it until someone else ran it for a different PR.

Since this id is needed for tests, it makes no sense to remove it, so we will restore the changes.