### PR TITLE
[GH-621] Fix leap duration on auto aim

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -369,10 +369,10 @@ defmodule Arena.Game.Skill do
   def maybe_auto_aim(%{x: x, y: y}, skill, player, entities) when x == 0.0 and y == 0.0 do
     case skill.autoaim do
       true ->
-        nearest_entity_direction_in_range =
-          Physics.nearest_entity_direction_in_range(player, entities, skill.max_autoaim_range)
+        nearest_entity_position_in_range =
+          Physics.nearest_entity_position_in_range(player, entities, skill.max_autoaim_range)
 
-        {nearest_entity_direction_in_range != player.direction, nearest_entity_direction_in_range}
+        {nearest_entity_position_in_range != player.direction, nearest_entity_position_in_range}
 
       false ->
         {false, player.direction |> maybe_normalize(not skill.can_pick_destination)}
@@ -413,11 +413,11 @@ defmodule Arena.Game.Skill do
     game_state
   end
 
-  defp maybe_multiply_by_range(%{x: x, y: y}, false = _auto_aim?, range) do
+  def maybe_multiply_by_range(%{x: x, y: y}, false = _auto_aim?, range) do
     %{x: x * range, y: y * range}
   end
 
-  defp maybe_multiply_by_range(direction, true = _auto_aim?, _range) do
+  def maybe_multiply_by_range(direction, true = _auto_aim?, _range) do
     direction
   end
 end

--- a/apps/arena/lib/physics.ex
+++ b/apps/arena/lib/physics.ex
@@ -38,5 +38,5 @@ defmodule Physics do
 
   def distance_between_entities(_entity, _entities), do: :erlang.nif_error(:nif_not_loaded)
 
-  def nearest_entity_direction_in_range(_entity, _entities, _range), do: :erlang.nif_error(:nif_not_loaded)
+  def nearest_entity_position_in_range(_entity, _entities, _range), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -140,13 +140,13 @@ fn calculate_duration(position_a: Position, position_b: Position, speed: f32) ->
 }
 
 #[rustler::nif()]
-fn nearest_entity_direction_in_range(
+fn nearest_entity_position_in_range(
     entity: Entity,
     entities: HashMap<u64, Entity>,
     range: i64,
-) -> Direction {
+) -> Position {
     let mut max_distance = range as f32;
-    let mut direction = Direction {
+    let mut position = Position {
         x: entity.direction.x,
         y: entity.direction.y,
     };
@@ -158,7 +158,7 @@ fn nearest_entity_direction_in_range(
                 max_distance = distance;
                 let difference_between_positions =
                     Position::sub(&other_entity.position, &entity.position);
-                direction = Direction {
+                position = Position {
                     x: difference_between_positions.x,
                     y: difference_between_positions.y,
                 };
@@ -166,7 +166,7 @@ fn nearest_entity_direction_in_range(
         }
     }
 
-    direction
+    position
 }
 #[rustler::nif()]
 fn distance_between_entities(entity_a: Entity, entity_b: Entity) -> f32 {
@@ -225,7 +225,7 @@ rustler::init!(
         get_direction_from_positions,
         calculate_duration,
         distance_between_entities,
-        nearest_entity_direction_in_range,
+        nearest_entity_position_in_range,
         get_closest_available_position
     ]
 );

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -26,8 +26,8 @@ defmodule BotManager.GameSocketHandler do
   #######################
 
   def handle_connect(_conn, state) do
-    # send(self(), :decide_action)
-    # send(self(), :perform_action)
+    send(self(), :decide_action)
+    send(self(), :perform_action)
     {:ok, state}
   end
 

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -26,8 +26,8 @@ defmodule BotManager.GameSocketHandler do
   #######################
 
   def handle_connect(_conn, state) do
-    send(self(), :decide_action)
-    send(self(), :perform_action)
+    # send(self(), :decide_action)
+    # send(self(), :perform_action)
     {:ok, state}
   end
 


### PR DESCRIPTION
## Motivation

The leap duration was being wrong calculated on auto aim

Closes #621 

## Summary of changes

Calculated the duration corectly

## How to test it?

Jump

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
