### PR TITLE
[GH-629] Fix game updater process crashing when someone dies to the zone

### DIFF
--- a/apps/arena/lib/arena/game_tracker.ex
+++ b/apps/arena/lib/arena/game_tracker.ex
@@ -46,7 +46,8 @@ defmodule Arena.GameTracker do
           controller: if(Enum.member?(human_clients, player_to_client[player.id]), do: :human, else: :bot),
           character: player.aditional_info.character_name,
           kills: [],
-          death: nil
+          death: nil,
+          position: nil
         }
 
         {player.id, player_data}
@@ -79,6 +80,13 @@ defmodule Arena.GameTracker do
   def handle_cast({:push_event, match_pid, event}, state) do
     state = update_in(state, [:matches, match_pid], fn data -> update_data(data, event) end)
     {:noreply, state}
+  end
+
+  defp update_data(data, {:kill, %{character_name: "Zone"}, victim}) do
+    data
+    |> put_in([:players, victim.id, :death], "Zone")
+    |> put_in([:players, victim.id, :position], data.position_on_death)
+    |> put_in([:position_on_death], data.position_on_death - 1)
   end
 
   defp update_data(data, {:kill, killer, victim}) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -340,7 +340,23 @@ defmodule Arena.GameUpdater do
       ) do
     entry = %{killer_id: killer_id, victim_id: victim_id}
     victim = Map.get(game_state.players, victim_id)
-    killer = Map.get(game_state.players, killer_id)
+
+    Map.get(game_state.players, killer_id)
+    |> case do
+      nil ->
+        GameTracker.push_event(
+          self(),
+          {:kill, %{id: killer_id, character_name: "Zone"},
+           %{id: victim.id, character_name: victim.aditional_info.character_name}}
+        )
+
+      killer ->
+        GameTracker.push_event(
+          self(),
+          {:kill, %{id: killer.id, character_name: killer.aditional_info.character_name},
+           %{id: victim.id, character_name: victim.aditional_info.character_name}}
+        )
+    end
 
     amount_of_power_ups = get_amount_of_power_ups(victim, game_config.power_ups.power_ups_per_kill)
 
@@ -352,12 +368,6 @@ defmodule Arena.GameUpdater do
       |> put_player_position(victim_id)
 
     broadcast_player_dead(state.game_state.game_id, victim_id)
-
-    GameTracker.push_event(
-      self(),
-      {:kill, %{id: killer.id, character_name: killer.aditional_info.character_name},
-       %{id: victim.id, character_name: victim.aditional_info.character_name}}
-    )
 
     {:noreply, %{state | game_state: game_state}}
   end


### PR DESCRIPTION
## Motivation

When someone dies to the zone the game_updater process crashes since it isn't finding any player with the zone id 
Closes #629

## Summary of changes

Now when someone dies to the zone we register the player name as "Zone"

## How to test it?

Play a match in main and when someone dies to the zone it will crash the match
On this pr this shouldn't happen

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
