### PR TITLE
[GH-634] - Add traps documentation

### DIFF
--- a/apps/arena/docs/src/attributes/traps.md
+++ b/apps/arena/docs/src/attributes/traps.md
@@ -1,24 +1,24 @@
-# Traps attributes
+# Trap Attributes
 
-## Non-changeable attributes
+## Non-Changeable Attributes
 
-- `id` Unique identifier for the projectile
-- `category` The category of this entity
-- `name` Name of the trap used to instantiate it
-- `position` Position of the trap
-- `direction` The angle where the trap is facing
-- `speed` The speed of the trap
-- `shape` The shape of the trap, at the moment is not editable.
-- `mechanics` The mechanics which the trap has
-- `owner_id` the ID of the player who owns the trap.
-- `preparation_delay_ms` The amount of time in milliseconds to wait until the trap is available to be triggered
-- `activation_delay_ms` After the trap gets triggered, this is the time in milliseconds until the trap activates its mechanic.
-- `activate_on_proximity` A boolean that determines whether a trap is activated when someone walks near it or just by time.
+- `id`: Unique identifier for the projectile
+- `category`: The category of this entity
+- `name`: Name of the trap used to instantiate it
+- `position`: Position of the trap
+- `direction`: The angle where the trap is facing
+- `speed`: The speed of the trap
+- `shape`: The shape of the trap, which is currently not editable
+- `mechanics`: The mechanics of the trap
+- `owner_id`: The ID of the player who owns the trap
+- `preparation_delay_ms`: The amount of time in milliseconds to wait until the trap is available to be triggered
+- `activation_delay_ms`: The time in milliseconds after the trap gets triggered until it activates its mechanic
+- `activate_on_proximity`: A boolean that determines whether the trap is activated when someone walks near it or just by time
 
-## Changeable attributes
+## Changeable Attributes
 
-- `status` Changes depending on the status of the trap, could be one of the following statuses:
-    - PENDING: The trap is waiting to be set, depends on the field `preparation_delay_ms`
-    - PREPARED: The trap is waiting to be triggered
-    - TRIGGERED: The trap is already triggered and is going to use activate its mechanic. Depends on the fields `activation_delay_ms` and `activate_on_proximity`
-    - USED: This status is set once the finished its operations/mechanics. This status led us delete the trap from the game state
+- `status`: Changes depending on the status of the trap and can be one of the following:
+  - `PENDING`: The trap is waiting to be set, depending on the field `preparation_delay_ms`
+  - `PREPARED`: The trap is waiting to be triggered
+  - `TRIGGERED`: The trap is already triggered and is going to activate its mechanic, depending on the fields `activation_delay_ms` and `activate_on_proximity`
+  - `USED`: This status is set once the trap has finished its operations/mechanics, indicating it can be deleted from the game state

--- a/apps/arena/docs/src/attributes/traps.md
+++ b/apps/arena/docs/src/attributes/traps.md
@@ -1,0 +1,24 @@
+# Traps attributes
+
+## Non-changeable attributes
+
+- `id` Unique identifier for the projectile
+- `category` The category of this entity
+- `name` Name of the trap used to instantiate it
+- `position` Position of the trap
+- `direction` The angle where the trap is facing
+- `speed` The speed of the trap
+- `shape` The shape of the trap, at the moment is not editable.
+- `mechanics` The mechanics which the trap has
+- `owner_id` the ID of the player who owns the trap.
+- `preparation_delay_ms` The amount of time in milliseconds to wait until the trap is available to be triggered
+- `activation_delay_ms` After the trap gets triggered, this is the time in milliseconds until the trap activates its mechanic.
+- `activate_on_proximity` A boolean that determines whether a trap is activated when someone walks near it or just by time.
+
+## Changeable attributes
+
+- `status` Changes depending on the status of the trap, could be one of the following statuses:
+    - PENDING: The trap is waiting to be set, depends on the field `preparation_delay_ms`
+    - PREPARED: The trap is waiting to be triggered
+    - TRIGGERED: The trap is already triggered and is going to use activate its mechanic. Depends on the fields `activation_delay_ms` and `activate_on_proximity`
+    - USED: This status is set once the finished its operations/mechanics. This status led us delete the trap from the game state

--- a/apps/arena/docs/src/attributes/traps.md
+++ b/apps/arena/docs/src/attributes/traps.md
@@ -2,7 +2,7 @@
 
 ## Non-Changeable Attributes
 
-- `id`: Unique identifier for the projectile
+- `id`: Unique identifier for the trap
 - `category`: The category of this entity
 - `name`: Name of the trap used to instantiate it
 - `position`: Position of the trap
@@ -22,3 +22,24 @@
   - `PREPARED`: The trap is waiting to be triggered
   - `TRIGGERED`: The trap is already triggered and is going to activate its mechanic, depending on the fields `activation_delay_ms` and `activate_on_proximity`
   - `USED`: This status is set once the trap has finished its operations/mechanics, indicating it can be deleted from the game state
+
+
+## Example
+
+```json
+{
+  "name": "bomb",
+  "radius": 200.0,
+  "activation_delay_ms": 3000,
+  "preparation_delay_ms": 3000,
+  "activate_on_proximity": true,
+  "vertices": [],
+  "mechanics": {
+    "circle_hit": {
+      "damage": 64,
+      "range": 380.0,
+      "offset": 400
+    }
+  }
+}
+```

--- a/apps/arena/docs/src/attributes/traps.md
+++ b/apps/arena/docs/src/attributes/traps.md
@@ -1,8 +1,14 @@
-# Trap Attributes
+# Traps
 
-## Non-Changeable Attributes
+Traps are entities with the sole purpose of affecting players' gameplay by causing damage,
+slowing them down, or granting negative effects. Additionally, a trap can be set by a player to use to their advantage.
+
+## Trap Attributes
+
+### Non-Changeable Attributes
 
 - `id`: Unique identifier for the trap
+- `owner_id` (Optional) Unique identifier for the entity that owns the trap
 - `category`: The category of this entity
 - `name`: Name of the trap used to instantiate it
 - `position`: Position of the trap
@@ -15,7 +21,7 @@
 - `activation_delay_ms`: The time in milliseconds after the trap gets triggered until it activates its mechanic
 - `activate_on_proximity`: A boolean that determines whether the trap is activated when someone walks near it or just by time
 
-## Changeable Attributes
+### Changeable Attributes
 
 - `status`: Changes depending on the status of the trap and can be one of the following:
   - `PENDING`: The trap is waiting to be set, depending on the field `preparation_delay_ms`
@@ -24,7 +30,7 @@
   - `USED`: This status is set once the trap has finished its operations/mechanics, indicating it can be deleted from the game state
 
 
-## Example
+### Example
 
 ```json
 {


### PR DESCRIPTION
## Motivation

Add documentation regarding the new implemented feature "Traps"
Closes #634

## Summary of changes

- Added a markdown explaining what traps are and their fields

## How to test it?

Read it (?)

## Checklist
- [ ] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
