### PR TITLE
[GH-642] Add skill direction to the trap do_mechanic

### DIFF
--- a/apps/arena/lib/arena/game/trap.ex
+++ b/apps/arena/lib/arena/game/trap.ex
@@ -18,6 +18,6 @@ defmodule Arena.Game.Trap do
   """
   def do_mechanic(game_state, entity, {:circle_hit, circle_hit}) do
     # We will be using the skill mechanic here until we abstract the attacks
-    Skill.do_mechanic(game_state, entity, {:circle_hit, circle_hit}, %{})
+    Skill.do_mechanic(game_state, entity, {:circle_hit, circle_hit}, %{skill_direction: entity.direction})
   end
 end


### PR DESCRIPTION
## Motivation

The game updater was breaking when a trap casted a :circle_hit
Closes #642

## Summary of changes

- Added skill direction to the trap do mechanic call

## How to test it?

Replace the item list in the config.json file with:
```json
  {
      "name": "fake_item",
      "radius": 200.0,
      "effects": [],
      "mechanics": {
        "spawn_bomb": {
          "name": "bomb",
          "radius": 200.0,
          "preparation_delay_ms": 2000,
          "activation_delay_ms": 3000,
          "vertices": [],
          "activate_on_proximity": true,
          "mechanics": {
            "circle_hit": {
              "damage": 64,
              "range": 380.0,
              "offset": 400
            }
          }
        }
      }
    }
```

Play a match and use an item, this should place a trap that after a timer before being stepped on should explode dealing damage

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
