### PR TITLE
[GH-641] Matchmaking based on prestige

### DIFF
--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -159,17 +159,23 @@ defmodule Arena.GameLauncher do
     end
   end
 
-  ## TODO: make private
   defp put_in_queue(queues, client_id, prestige) do
     put_in_queue(queues, [], client_id, prestige)
   end
 
-  defp put_in_queue([%{first: first, last: last} = queue | rest], seen_q, client_id, prestige) when first <= prestige and prestige <= last do
+  defp put_in_queue([%{first: first, last: last} = queue | rest], seen_q, client_id, prestige)
+       when first <= prestige and prestige <= last do
     queue = %{queue | clients: [client_id | queue.clients]}
     seen_q ++ [queue | rest]
   end
 
-  defp put_in_queue([%{last: current_last} = current_queue, %{first: next_first} = next_queue | rest], seen_q, client_id, prestige) when current_last < prestige and prestige < next_first do
+  defp put_in_queue(
+         [%{last: current_last} = current_queue, %{first: next_first} = next_queue | rest],
+         seen_q,
+         client_id,
+         prestige
+       )
+       when current_last < prestige and prestige < next_first do
     new_queue = new_queue(client_id, current_queue.clients, prestige)
     seen_q ++ [current_queue, new_queue, next_queue | rest]
   end
@@ -201,6 +207,7 @@ defmodule Arena.GameLauncher do
   defp merge_queues([current_q, next_q | rest], acc) do
     range_1 = Range.new(current_q.first, current_q.last)
     range_2 = Range.new(next_q.first, next_q.last)
+
     case Range.disjoint?(range_1, range_2) do
       true ->
         merge_queues([next_q | rest], acc ++ [current_q])

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -138,9 +138,25 @@ defmodule Arena.GameLauncher do
     end)
   end
 
-  ## TODO: actually fetch prestige
-  defp get_prestige(_, _) do
-    Enum.random(100..200)
+  ## TODO: this is actually broken (will always be 0) because client_id is google_user_id and CharacterPrestige expects user_id
+  ##  No point in fixing this right now, it should be addressed as part of https://github.com/lambdaclass/mirra_backend/issues/640
+  defp get_prestige(client_id, character) do
+    gateway_url = Application.get_env(:arena, :gateway_url)
+    path = "/curse/users/#{client_id}/prestige/#{character}"
+
+    result =
+      Finch.build(:get, "#{gateway_url}#{path}", [{"content-type", "application/json"}])
+      |> Finch.request(Arena.Finch)
+
+    case result do
+      {:ok, %{status: 200, body: body}} ->
+        response = Jason.decode!(body)
+        response["prestige"]
+
+      _ ->
+        ## TODO: we probably want to log something here
+        0
+    end
   end
 
   ## TODO: make private

--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -7,6 +7,7 @@ defmodule Arena.GameLauncher do
 
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
+  @queue_lifetime_ms 10_000
   # The available names for bots to enter a match, we should change this in the future
   @bot_names [
     "TheBlackSwordman",
@@ -42,20 +43,16 @@ defmodule Arena.GameLauncher do
   # Callbacks
   @impl true
   def init(_) do
-    Process.send_after(self(), :launch_game?, 300)
-    {:ok, %{clients: [], batch_start_at: 0}}
+    Process.send_after(self(), :launch_matches, 1000)
+    {:ok, %{clients: %{}, batch_start_at: 0, queues: []}}
   end
 
   @impl true
-  def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, %{clients: clients} = state) do
-    batch_start_at = maybe_make_batch_start_at(state.clients, state.batch_start_at)
-
-    {:reply, :ok,
-     %{
-       state
-       | batch_start_at: batch_start_at,
-         clients: clients ++ [{client_id, character_name, player_name, from_pid}]
-     }}
+  def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, state) do
+    prestige = get_prestige(client_id, character_name)
+    queues = put_in_queue(state.queues, client_id, prestige)
+    clients = Map.put(state.clients, client_id, {client_id, character_name, player_name, from_pid})
+    {:reply, :ok, %{state | clients: clients, queues: queues}}
   end
 
   def handle_call({:leave, client_id}, _, state) do
@@ -71,16 +68,27 @@ defmodule Arena.GameLauncher do
   end
 
   @impl true
-  def handle_info(:launch_game?, %{clients: clients} = state) do
-    Process.send_after(self(), :launch_game?, 300)
-    diff = System.monotonic_time(:millisecond) - state.batch_start_at
+  def handle_info(:launch_matches, state) do
+    Process.send_after(self(), :launch_matches, 1000)
+    ## TODO: time based launch
+    # diff = System.monotonic_time(:millisecond) - state.batch_start_at
 
-    if length(clients) >= Application.get_env(:arena, :players_needed_in_match) or
-         (diff >= @start_timeout_ms and length(clients) > 0) do
-      send(self(), :start_game)
-    end
+    {queues, client_groups} = take_ready_queues(state.queues, Application.get_env(:arena, :players_needed_in_match))
 
-    {:noreply, state}
+    clients =
+      Enum.reduce(client_groups, state.clients, fn client_ids, clients_acc ->
+        Map.take(clients_acc, client_ids)
+        |> Map.values()
+        |> create_game_for_clients()
+
+        Map.drop(clients_acc, client_ids)
+      end)
+
+    queues =
+      expand_queues(queues)
+      |> merge_queues()
+
+    {:noreply, %{state | queues: queues, clients: clients}}
   end
 
   def handle_info(:start_game, state) do
@@ -97,14 +105,6 @@ defmodule Arena.GameLauncher do
     end)
 
     {:noreply, state}
-  end
-
-  defp maybe_make_batch_start_at([], _) do
-    System.monotonic_time(:millisecond)
-  end
-
-  defp maybe_make_batch_start_at([_ | _], batch_start_at) do
-    batch_start_at
   end
 
   defp get_bot_clients(missing_clients) do
@@ -144,6 +144,92 @@ defmodule Arena.GameLauncher do
     Enum.each(clients, fn {_client_id, _character_name, _player_name, from_pid} ->
       Process.send(from_pid, {:join_game, game_id}, [])
       Process.send(from_pid, :leave_waiting_game, [])
+    end)
+  end
+
+  defp get_prestige(_, _) do
+    Enum.random(100..200)
+  end
+
+  ## TODO: make private
+  def put_in_queue(queues, client_id, prestige) do
+    put_in_queue(queues, [], client_id, prestige)
+  end
+
+  def put_in_queue([%{first: first, last: last} = queue | rest], seen_q, client_id, prestige) when first <= prestige and prestige <= last do
+    queue = %{queue | clients: [client_id | queue.clients]}
+    seen_q ++ [queue | rest]
+  end
+
+  def put_in_queue([%{last: current_last} = current_queue, %{first: next_first} = next_queue | rest], seen_q, client_id, prestige) when current_last < prestige and prestige < next_first do
+    new_queue = new_queue(client_id, current_queue.clients, prestige)
+    seen_q ++ [current_queue, new_queue, next_queue | rest]
+  end
+
+  def put_in_queue([], seen_q, client_id, prestige) do
+    new_queue = new_queue(client_id, prestige)
+    seen_q ++ [new_queue]
+  end
+
+  def put_in_queue([current_queue | rest], seen_q, client_id, prestige) do
+    seen_q = seen_q ++ [current_queue]
+    put_in_queue(rest, seen_q, client_id, prestige)
+  end
+
+  defp new_queue(client_id, clients \\ [], base) do
+    created_at = System.monotonic_time(:millisecond)
+    ## TODO: this has to be fixed and a more granular approach taken
+    ##  for example current prestige below 10 will have 0 margin and thus no range for the queue
+    ##  we probably want something more like
+    ##    - if < 100 -> 10
+    ##    - if < 500 -> %10
+    ##    - else -> %5
+    margin = div(base, 10)
+    %{clients: [client_id | clients], first: base - margin, last: base + margin, created_at: created_at}
+  end
+
+  def merge_queues(queues) do
+    merge_queues(queues, [])
+  end
+
+  def merge_queues([current_q, next_q | rest], acc) do
+    range_1 = Range.new(current_q.first, current_q.last)
+    range_2 = Range.new(next_q.first, next_q.last)
+    case Range.disjoint?(range_1, range_2) do
+      true ->
+        merge_queues([next_q | rest], acc ++ [current_q])
+
+      false ->
+        merged = %{clients: current_q.clients ++ next_q.clients, first: current_q.first, last: next_q.last}
+        merge_queues(rest, acc ++ [merged])
+    end
+  end
+
+  def merge_queues(rest, acc) do
+    acc ++ rest
+  end
+
+  def take_ready_queues(queues, players_needed) do
+    Enum.reduce(queues, {[], []}, fn queue, {remaining_queues, taken_clients} ->
+      case length(queue.clients) do
+        amount when amount > players_needed ->
+          clients = Enum.take(queue.clients, players_needed)
+          queue = %{queue | clients: Enum.drop(queue.clients, players_needed)}
+          {remaining_queues ++ [queue], [clients | taken_clients]}
+
+        amount when amount == players_needed ->
+          {remaining_queues, [queue.clients | taken_clients]}
+
+        _ ->
+          {remaining_queues ++ [queue], taken_clients}
+      end
+    end)
+  end
+
+  def expand_queues(queues) do
+    Enum.map(queues, fn queue ->
+      margin = div(queue.last - queue.first, 2)
+      %{queue | first: queue.first - margin, last: queue.last + margin}
     end)
   end
 end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -2,6 +2,7 @@ defmodule GameBackend.CurseOfMirra.Matches do
   @moduledoc """
   Matches
   """
+  import Ecto.Query
   alias GameBackend.Units.Unit
   alias GameBackend.CurseOfMirra.Quests
   alias GameBackend.Users.Currencies
@@ -130,7 +131,15 @@ defmodule GameBackend.CurseOfMirra.Matches do
   end
 
   def get_prestige(user_id, character) do
-    Repo.get_by(CharacterPrestige, user_id: user_id, character: character)
+    q =
+      from(u in Unit,
+        join: c in Character,
+        on: u.character_id == c.id,
+        where: u.user_id == ^user_id and c.name == ^character,
+        select: u.level
+      )
+
+    Repo.one(q)
   end
 
   ####################

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -129,6 +129,10 @@ defmodule GameBackend.CurseOfMirra.Matches do
     end)
   end
 
+  def get_prestige(user_id, character) do
+    Repo.get_by(CharacterPrestige, user_id: user_id, character: character)
+  end
+
   ####################
   #      Helpers     #
   ####################

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -3,16 +3,16 @@ defmodule GameBackend.CurseOfMirra.Matches do
   Matches
   """
   import Ecto.Query
-  alias GameBackend.Units.Unit
-  alias GameBackend.CurseOfMirra.Quests
-  alias GameBackend.Users.Currencies
-  alias GameBackend.Quests.UserQuest
-
-  alias GameBackend.Utils
-  alias GameBackend.Users
   alias Ecto.Multi
+  alias GameBackend.CurseOfMirra.Quests
   alias GameBackend.Matches.ArenaMatchResult
+  alias GameBackend.Quests.UserQuest
   alias GameBackend.Repo
+  alias GameBackend.Units.Characters.Character
+  alias GameBackend.Units.Unit
+  alias GameBackend.Users
+  alias GameBackend.Users.Currencies
+  alias GameBackend.Utils
 
   def create_arena_match_results(match_id, results) do
     Multi.new()
@@ -136,7 +136,7 @@ defmodule GameBackend.CurseOfMirra.Matches do
         join: c in Character,
         on: u.character_id == c.id,
         where: u.user_id == ^user_id and c.name == ^character,
-        select: u.level
+        select: u.prestige
       )
 
     Repo.one(q)

--- a/apps/gateway/lib/gateway/controllers/curse_of_mirra/user_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/curse_of_mirra/user_controller.ex
@@ -3,6 +3,7 @@ defmodule Gateway.Controllers.CurseOfMirra.UserController do
   Controller for CurseOfMirra.User modifications.
   """
   use Gateway, :controller
+  alias GameBackend.Matches
   alias GameBackend.Users
   alias GameBackend.Rewards
   alias GameBackend.Utils
@@ -25,6 +26,13 @@ defmodule Gateway.Controllers.CurseOfMirra.UserController do
         |> Rewards.mark_user_daily_rewards_as_completed(user)
 
       send_resp(conn, 200, Jason.encode!(user_daily_reward_status))
+    end
+  end
+
+  def get_prestige(conn, %{"user_id" => user_id, "character" => character}) do
+    case Matches.get_prestige(user_id, character) do
+      nil -> send_resp(conn, 200, Jason.encode!(%{prestige: 0}))
+      prestige -> send_resp(conn, 200, Jason.encode!(%{prestige: prestige.amount}))
     end
   end
 end

--- a/apps/gateway/lib/gateway/controllers/curse_of_mirra/user_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/curse_of_mirra/user_controller.ex
@@ -3,7 +3,7 @@ defmodule Gateway.Controllers.CurseOfMirra.UserController do
   Controller for CurseOfMirra.User modifications.
   """
   use Gateway, :controller
-  alias GameBackend.Matches
+  alias GameBackend.CurseOfMirra.Matches
   alias GameBackend.Users
   alias GameBackend.Rewards
   alias GameBackend.Utils
@@ -32,7 +32,7 @@ defmodule Gateway.Controllers.CurseOfMirra.UserController do
   def get_prestige(conn, %{"user_id" => user_id, "character" => character}) do
     case Matches.get_prestige(user_id, character) do
       nil -> send_resp(conn, 200, Jason.encode!(%{prestige: 0}))
-      prestige -> send_resp(conn, 200, Jason.encode!(%{prestige: prestige.amount}))
+      prestige -> send_resp(conn, 200, Jason.encode!(%{prestige: prestige}))
     end
   end
 end

--- a/apps/gateway/lib/gateway/router.ex
+++ b/apps/gateway/lib/gateway/router.ex
@@ -28,6 +28,7 @@ defmodule Gateway.Router do
       get "/claim_daily_reward", UserController, :claim_daily_reward
       get "/get_daily_reward_status", UserController, :get_daily_reward_status
       get "/quest/:quest_id/reroll_daily_quest", QuestController, :reroll_daily_quest
+      get "/prestige/:character", UserController, :get_prestige
 
       scope "/items" do
         put "/equip", ItemController, :equip


### PR DESCRIPTION
## Motivation

Closes #641 

## Summary of changes

Instead of a single queue where every player joins to we will have an infinite amount of queues (created on-demand) where players join based on their prestige. Initially the queue will accept a small range, but as time goes by queues will accept a bigger and bigger range. Eventually if `@queue_lifetime_ms` time has elapse (now set to 10 seconds) the queue will start a match with the player it has and fill with bots

### Step by step

Player joins
1. Fetch prestige from gateway
2. Join or create a queue, this means that it will try to find a queue for which its prestige is in the accepted range (between `first` and `last`), but if none is found it will create a new queue using its prestige as the base and create a range from it (see `calculate_margin/1` for details)

Start game cycle (every second)
1. Get all client groups from queues that are ready to launch, each client group is a match that will be started
    - If the queue `@queue_lifetime_ms` has elapsed or it has exactly the amount of players needed it is removed from existing queues and clients
    - If the queue has more than the needed players then we it will take out the 10 needed, the rest will remain and the queue has its `created_at` reset, its range remains the same
2. Expand range of remaining queues, for now it will double the range
3. Merge overlapping queues, if queues have overlapping ranges they get merged together (players from lower queue go first) and the new queue keeps the oldest `created_at`

## How to test it?

Easiest is in the console to do

```elixir
Arena.GameLauncher.join(Ecto.UUID.generate(), "h4ck", "muflus")
```

And then you can inspect the state with

```elixir
:sys.get_state(Arena.GameLauncher)
```

Sadly this will end up making queues for 0 prestige users, if you want to try different prestiges you will need to preemptively create users, set some prestige for them, and then use them

```elixir
user_ids = 
  Enum.map(1..10, fn i ->
    {:ok, %{user: %{id: user_id}}} = GameBackend.Users.find_or_create_google_user_by_email("test#{i}")
    user_id
  end)

Enum.each(user_ids, fn user_id ->
  prestige = Enum.random(100..1000) ## Feel free to modify this as you wish
  %{id: muflus_id} = GameBackend.Repo.get_by(GameBackend.Units.Characters.Character, game_id: GameBackend.Utils.get_game_id(:curse_of_mirra), name: "muflus")
  unit = GameBackend.Repo.get_by(GameBackend.Units.Unit, user_id: user_id, character_id: muflus_id)
  attrs = %{prestige: prestige, rank: 1, sub_rank: 1}
  GameBackend.Units.Unit.curse_of_mirra_update_changeset(unit, attrs)
  |> GameBackend.Repo.update!()
end)

## and then you can pick one of the ids
Arena.GameLauncher.join(Enum.random(user_ids), "muflus", "bob")
```

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
