### PR TITLE
[GH-589] Fix valtimer walking instead of teleporting when teleporting inside cannon rock

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -438,8 +438,12 @@
             "y": -4450.0
           },
           {
-            "x": 1150.0,
-            "y": -5470.0
+            "x": 1300.0,
+            "y": -6500.0
+          },
+          {
+            "x": 360.0,
+            "y": -6500.0
           },
           {
             "x": 360.0,
@@ -496,8 +500,12 @@
             "y": 4900.0
           },
           {
-            "x": -748.0,
-            "y": 5674.0
+            "x": -1120.0,
+            "y": 6500.0
+          },
+          {
+            "x": -135.0,
+            "y": 6500.0
           },
           {
             "x": -135.0,
@@ -848,7 +856,7 @@
     "end_game_interval_ms": 1000,
     "shutdown_game_wait_ms": 10000,
     "natural_healing_interval_ms": 300,
-    "zone_shrink_start_ms": 35000,
+    "zone_shrink_start_ms": 9999999,
     "zone_shrink_radius_by": 10,
     "zone_shrink_interval": 100,
     "zone_stop_interval_ms": 13000,

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -856,7 +856,7 @@
     "end_game_interval_ms": 1000,
     "shutdown_game_wait_ms": 10000,
     "natural_healing_interval_ms": 300,
-    "zone_shrink_start_ms": 9999999,
+    "zone_shrink_start_ms": 35000,
     "zone_shrink_radius_by": 10,
     "zone_shrink_interval": 100,
     "zone_stop_interval_ms": 13000,


### PR DESCRIPTION
## Motivation

Valtimer was walking instead of teleporting when walking inside an obstacle, this was cause by the little space between the edges of the map and the obstacle. 
1. The algorithm pushes you inside the map 
2. Sat moved you slightly outside the map
The client doesn't allowed this so you walked to you position when moved since you got fixed then

Closes #589

## Summary of changes

- Make obstacles bigger

## How to test it?

Replicate the video teleport and it should't walk

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
