### PR TITLE
[GH-438] Fixes for Dungeon Settlement level up

### DIFF
--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -133,6 +133,12 @@ defmodule Champions.Users do
       Currencies.get_currency_by_name_and_game!("Hero Souls", Utils.get_game_id(:champions_of_mirra)).id,
       100
     )
+
+    Currencies.add_currency(
+      user.id,
+      Currencies.get_currency_by_name_and_game!("Blueprints", Utils.get_game_id(:champions_of_mirra)).id,
+      100
+    )
   end
 
   defp add_super_campaign_progresses(user) do

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -137,7 +137,7 @@ defmodule Champions.Users do
     Currencies.add_currency(
       user.id,
       Currencies.get_currency_by_name_and_game!("Blueprints", Utils.get_game_id(:champions_of_mirra)).id,
-      100
+      50
     )
   end
 

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -295,7 +295,7 @@ defmodule GameBackend.Users do
   Returns the updated user if the operation was successful.
   """
   def level_up_dungeon_settlement(user_id, level_up_costs) do
-    {:ok, _result} =
+    result =
       Multi.new()
       |> Multi.run(:user, fn _, _ -> increment_settlement_level(user_id) end)
       |> Multi.run(:user_currency, fn _, _ ->
@@ -303,17 +303,25 @@ defmodule GameBackend.Users do
       end)
       |> Repo.transaction()
 
-    get_user(user_id)
+    case result do
+      {:error, reason} -> {:error, reason}
+      {:error, _, _, _} -> {:error, :transaction}
+      {:ok, _} -> get_user(user_id)
+    end
   end
 
   defp increment_settlement_level(user_id) do
     case get_user(user_id) do
       {:ok, user} ->
-        next_level = get_dungeon_settlement_level(user.dungeon_settlement_level.level + 1)
+        case get_dungeon_settlement_level(user.dungeon_settlement_level.level + 1) do
+          nil ->
+            {:error, :dungeon_settlement_level_not_found}
 
-        user
-        |> User.changeset(%{dungeon_settlement_level_id: next_level.id})
-        |> Repo.update()
+          next_level ->
+            user
+            |> User.changeset(%{dungeon_settlement_level_id: next_level.id})
+            |> Repo.update()
+        end
 
       error ->
         error

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -442,10 +442,10 @@ defmodule Gateway.Serialization.DungeonSettlementLevel do
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint64)
 
-  field(:upgrade_costs, 3,
+  field(:level_up_costs, 3,
     repeated: true,
     type: Gateway.Serialization.CurrencyCost,
-    json_name: "upgradeCosts"
+    json_name: "levelUpCosts"
   )
 
   field(:max_dungeon, 4, type: :uint64, json_name: "maxDungeon")

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -846,14 +846,10 @@ defmodule Gateway.Test.Champions do
       initial_blueprints = Currencies.get_amount_of_currency_by_name(user.id, "Blueprints")
       initial_gold = Currencies.get_amount_of_currency_by_name(user.id, "Gold")
 
-      assert initial_blueprints == 0
       # Due to sample currencies
+      assert initial_blueprints == 50
       assert initial_gold == 100
       initial_currencies = %{"Blueprints" => initial_blueprints, "Gold" => initial_gold}
-
-      # Add enough blueprints for 1 upgrade
-      {:ok, _} =
-        Currencies.add_currency_by_name_and_game!(user.id, "Blueprints", Utils.get_game_id(:champions_of_mirra), 50)
 
       # Level up Dungeon Settlements with enough Blueprints and Gold should return an updated user.
       SocketTester.level_up_dungeon_settlement(socket_tester, user.id)

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -192,7 +192,7 @@ syntax = "proto3";
   message DungeonSettlementLevel {
     string id = 1;
     uint64 level = 2;
-    repeated CurrencyCost upgrade_costs = 3;
+    repeated CurrencyCost level_up_costs = 3;
     uint64 max_dungeon = 4;
     uint64 max_factional = 5;
     uint64 supply_limit = 6;


### PR DESCRIPTION


## Motivation

The name for the level up cost field of a Dungeon Settlement level didn't match the name in the schema. This resulted in a 0 value for this field in all levels.

Closes https://github.com/lambdaclass/afk_gacha_game/issues/438

## Summary of changes

- Fixed the level up cost field name in gateway.proto
- Added an initial value of Blueprints that is enough to level up once, such as we did with the fertilizer for the Kaline Tree. This makes the testing of these features much easier.

## How to test it?

Open the client following: https://github.com/lambdaclass/afk_gacha_game/pull/472
You should see an initial amount of 50 blueprints when you go to the Dungeon Settlement scene, and a cost of 100 Gold and 50 Blueprints to level up.

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
