### PR TITLE
[Front-1762] Increase start fame time

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -852,7 +852,7 @@
   },
   "game": {
     "tick_rate_ms": 30,
-    "start_game_time_ms": 10000,
+    "start_game_time_ms": 15000,
     "end_game_interval_ms": 1000,
     "shutdown_game_wait_ms": 10000,
     "natural_healing_interval_ms": 300,


### PR DESCRIPTION
## Motivation
Since we are adding the screen to select a bounty before the match we need to increase the start of game delay. 

## Summary of changes
Increased the start_game_time_ms by 5000 milliseconds. 

## How to test it?
Play the game with this branch and this front [PR](https://github.com/lambdaclass/champions_of_mirra/pull/1791)

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
