### PR TITLE
[GH-671] Fix error due to zero division error

### DIFF
--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -206,6 +206,9 @@ fn direction_from_positions(position_a: Position, position_b: Position) -> Direc
     let x = position_b.x - position_a.x;
     let y = position_b.y - position_a.y;
     let len = (x.powi(2) + y.powi(2)).sqrt();
+    if len == 0.0 {
+        return Direction { x: 0.0, y: 0.0 };
+    }
     Direction {
         x: x / len,
         y: y / len,


### PR DESCRIPTION
## Motivation

There was an error that crashes the GameLauncher GenServer.
Closes #671 

## Summary of changes

[Fix error due to zero division error](https://github.com/lambdaclass/mirra_backend/pull/672/commits/4b068c020256327780e01270dc40831c7c06aa51)

## How to test it?

You can run the following:
```
Physics.get_direction_from_positions(%{y: -607.9176025390625, x: -578.56005859375}, %{y: -607.9176025390625, x: -578.5600738525391})
```
It will return the direction {0, 0} since the positions are overlapping.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
