### PR TITLE
[GH-439] Currency Capping

### DIFF
--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -23,7 +23,7 @@ defmodule Champions.Users do
   """
   def register(username) do
     kaline_tree_level = GameBackend.Users.get_kaline_tree_level(1)
-    dungeon_settlement_level = GameBackend.Users.get_dungeon_settlement_level(1)
+    dungeon_settlement_level = GameBackend.Users.get_dungeon_settlement_level_by_number(1)
     {:ok, dungeon_base_setting} = Users.get_upgrade_by_name("Dungeon.BaseSetting")
 
     case Users.register_user(%{

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -3,6 +3,7 @@ defmodule Champions.Users do
   Users logic for Champions Of Mirra.
   """
 
+  alias GameBackend.Repo
   alias GameBackend.Users.Currencies.CurrencyCost
   alias Champions.Users
   alias GameBackend.Utils
@@ -43,6 +44,7 @@ defmodule Champions.Users do
         add_sample_items(user)
         add_sample_currencies(user)
         add_super_campaign_progresses(user)
+        add_currency_caps(user)
 
         Users.get_user(user.id)
 
@@ -162,6 +164,16 @@ defmodule Champions.Users do
         level_id: first_campaign.levels |> Enum.sort_by(& &1.level_number) |> hd() |> Map.get(:id)
       })
     end)
+  end
+
+  defp add_currency_caps(user) do
+    user = Repo.preload(user, [:dungeon_settlement_level])
+    # Supplies
+    Currencies.insert_user_currency_cap(%{
+      user_id: user.id,
+      currency_id: Currencies.get_currency_by_name_and_game!("Supplies", Utils.get_game_id(:champions_of_mirra)).id,
+      cap: user.dungeon_settlement_level.supply_cap
+    })
   end
 
   @doc """

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -3,19 +3,17 @@ defmodule Champions.Users do
   Users logic for Champions Of Mirra.
   """
 
-  alias GameBackend.Repo
-  alias GameBackend.Users.Currencies.CurrencyCost
+  alias Ecto.{Changeset, Multi}
   alias Champions.Users
-  alias GameBackend.Utils
-  alias Ecto.Changeset
-  alias Ecto.Multi
   alias GameBackend.Items
+  alias GameBackend.Repo
   alias GameBackend.Transaction
-  alias GameBackend.Users.Currencies
-  alias GameBackend.Users
-  alias GameBackend.Users.Currencies
   alias GameBackend.Units
   alias GameBackend.Units.Characters
+  alias GameBackend.Users
+  alias GameBackend.Users.Currencies
+  alias GameBackend.Users.Currencies.CurrencyCost
+  alias GameBackend.Utils
 
   @max_afk_reward_seconds 12 * 60 * 60
 

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -6,7 +6,6 @@ defmodule Champions.Users do
   alias Ecto.{Changeset, Multi}
   alias Champions.Users
   alias GameBackend.Items
-  alias GameBackend.Repo
   alias GameBackend.Transaction
   alias GameBackend.Units
   alias GameBackend.Units.Characters
@@ -165,12 +164,14 @@ defmodule Champions.Users do
   end
 
   defp add_currency_caps(user) do
-    user = Repo.preload(user, [:dungeon_settlement_level])
     # Supplies
+
+    dungeon_settlement_level = Users.get_dungeon_settlement_level(user.dungeon_settlement_level_id)
+
     Currencies.insert_user_currency_cap(%{
       user_id: user.id,
       currency_id: Currencies.get_currency_by_name_and_game!("Supplies", Utils.get_game_id(:champions_of_mirra)).id,
-      cap: user.dungeon_settlement_level.supply_cap
+      cap: dungeon_settlement_level.supply_cap
     })
   end
 

--- a/apps/champions/priv/dungeon_settlement_levels.json
+++ b/apps/champions/priv/dungeon_settlement_levels.json
@@ -3,7 +3,7 @@
         "level": 1,
         "max_dungeon": 25,
         "max_factional": 0,
-        "supply_limit": 10,
+        "supply_cap": 10,
         "afk_reward_rates": {
             "Supplies": 72
         },
@@ -22,7 +22,7 @@
         "level": 2,
         "max_dungeon": 50,
         "max_factional": 0,
-        "supply_limit": 10,
+        "supply_cap": 10,
         "afk_reward_rates": {
             "Supplies": 72
         },
@@ -41,7 +41,7 @@
         "level": 3,
         "max_dungeon": 75,
         "max_factional": 0,
-        "supply_limit": 10,
+        "supply_cap": 10,
         "afk_reward_rates": {
             "Supplies": 73
         },
@@ -60,7 +60,7 @@
         "level": 4,
         "max_dungeon": 100,
         "max_factional": 0,
-        "supply_limit": 10,
+        "supply_cap": 10,
         "afk_reward_rates": {
             "Supplies": 73
         },
@@ -79,7 +79,7 @@
         "level": 5,
         "max_dungeon": 125,
         "max_factional": 0,
-        "supply_limit": 12,
+        "supply_cap": 12,
         "afk_reward_rates": {
             "Supplies": 74
         },
@@ -98,7 +98,7 @@
         "level": 6,
         "max_dungeon": 150,
         "max_factional": 0,
-        "supply_limit": 12,
+        "supply_cap": 12,
         "afk_reward_rates": {
             "Supplies": 74
         },
@@ -117,7 +117,7 @@
         "level": 7,
         "max_dungeon": 175,
         "max_factional": 0,
-        "supply_limit": 12,
+        "supply_cap": 12,
         "afk_reward_rates": {
             "Supplies": 75
         },
@@ -136,7 +136,7 @@
         "level": 8,
         "max_dungeon": 200,
         "max_factional": 0,
-        "supply_limit": 12,
+        "supply_cap": 12,
         "afk_reward_rates": {
             "Supplies": 75
         },
@@ -155,7 +155,7 @@
         "level": 9,
         "max_dungeon": 225,
         "max_factional": 0,
-        "supply_limit": 12,
+        "supply_cap": 12,
         "afk_reward_rates": {
             "Supplies": 76
         },
@@ -174,7 +174,7 @@
         "level": 10,
         "max_dungeon": 250,
         "max_factional": 0,
-        "supply_limit": 14,
+        "supply_cap": 14,
         "afk_reward_rates": {
             "Supplies": 76
         },

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -10,7 +10,6 @@ defmodule GameBackend.Users do
   """
 
   import Ecto.Query, warn: false
-  alias Gateway.Serialization.DungeonSettlementLevel
   alias Ecto.Multi
   alias GameBackend.CurseOfMirra.Users, as: CurseUsers
   alias GameBackend.Matches.ArenaMatchResult

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -259,7 +259,7 @@ defmodule GameBackend.Users do
   Inserts a DungeonSettlementLevel into the database. If another one already exists with the same number, it updates it instead.
   """
   def upsert_dungeon_settlement_level(attrs) do
-    case get_dungeon_settlement_level(attrs.level) do
+    case get_dungeon_settlement_level_by_number(attrs.level) do
       nil -> insert_dungeon_settlement_level(attrs)
       dungeon_settlement_level -> update_dungeon_settlement_level(dungeon_settlement_level, attrs)
     end

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -201,19 +201,26 @@ defmodule GameBackend.Users do
   end
 
   @doc """
+  Gets a DungeonSettlementLevel by its id.
+  """
+  def get_dungeon_settlement_level(dungeon_settlement_level_id) do
+    Repo.get(DungeonSettlementLevel, dungeon_settlement_level_id)
+  end
+
+  @doc """
   Gets a DungeonSettlementLevel by its number.
 
   Returns {:error, :not_found} if no level is found.
 
   ## Examples
 
-      iex> get_dungeon_settlement_level(1)
+      iex> get_dungeon_settlement_level_by_number(1)
       %DungeonSettlementLevel{}
 
-      iex> get_dungeon_settlement_level(-1)
+      iex> get_dungeon_settlement_level_by_number(-1)
       nil
   """
-  def get_dungeon_settlement_level(level_number) do
+  def get_dungeon_settlement_level_by_number(level_number) do
     Repo.get_by(DungeonSettlementLevel, level: level_number)
   end
 
@@ -322,7 +329,7 @@ defmodule GameBackend.Users do
   defp increment_settlement_level(user_id) do
     case get_user(user_id) do
       {:ok, user} ->
-        case get_dungeon_settlement_level(user.dungeon_settlement_level.level + 1) do
+        case get_dungeon_settlement_level_by_number(user.dungeon_settlement_level.level + 1) do
           nil ->
             {:error, :dungeon_settlement_level_not_found}
 

--- a/apps/game_backend/lib/game_backend/users/currencies.ex
+++ b/apps/game_backend/lib/game_backend/users/currencies.ex
@@ -5,10 +5,7 @@ defmodule GameBackend.Users.Currencies do
 
   import Ecto.Query, warn: false
 
-  alias GameBackend.Users.Currencies.UserCurrencyCap
-  alias GameBackend.Users.Currencies.UserCurrency
-  alias GameBackend.Users.Currencies.Currency
-  alias GameBackend.Users.Currencies.CurrencyCost
+  alias GameBackend.Users.Currencies.{Currency, CurrencyCost, UserCurrency, UserCurrencyCap}
   alias GameBackend.Repo
 
   @doc """

--- a/apps/game_backend/lib/game_backend/users/currencies.ex
+++ b/apps/game_backend/lib/game_backend/users/currencies.ex
@@ -240,6 +240,17 @@ defmodule GameBackend.Users.Currencies do
   end
 
   @doc """
+  Updates a User's UserCurrencyCap cap for a given currency.
+
+  Currency is identified by a name and a game id.
+  """
+  def update_user_currency_cap(user_id, {currency_name, game_id}, new_cap) do
+    get_user_currency_cap(user_id, get_currency_by_name_and_game!(currency_name, game_id).id)
+    |> UserCurrencyCap.update_changeset(%{cap: new_cap})
+    |> Repo.update()
+  end
+
+  @doc """
   Get an UserCurrencyCap.
   """
   def get_user_currency_cap(user_id, currency_id),

--- a/apps/game_backend/lib/game_backend/users/currencies.ex
+++ b/apps/game_backend/lib/game_backend/users/currencies.ex
@@ -230,6 +230,18 @@ defmodule GameBackend.Users.Currencies do
     end
   end
 
+  @doc """
+  Inserts an UserCurrencyCap.
+  """
+  def insert_user_currency_cap(attrs) do
+    %UserCurrencyCap{}
+    |> UserCurrencyCap.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Get an UserCurrencyCap.
+  """
   def get_user_currency_cap(user_id, currency_id),
     do: Repo.one(from(uc in UserCurrencyCap, where: uc.user_id == ^user_id and uc.currency_id == ^currency_id))
 end

--- a/apps/game_backend/lib/game_backend/users/currencies/user_currency_cap.ex
+++ b/apps/game_backend/lib/game_backend/users/currencies/user_currency_cap.ex
@@ -1,0 +1,36 @@
+defmodule GameBackend.Users.Currencies.UserCurrencyCap do
+  @moduledoc """
+  Represents a limit on the amount of a currency a user can have at any time.
+
+  If a User has no UserCurrencyCap for a given Currency, they can have an unlimited amount of that Currency.
+  """
+
+  use GameBackend.Schema
+  import Ecto.Changeset
+
+  alias GameBackend.Users.Currencies.Currency
+  alias GameBackend.Users.User
+
+  schema "user_currency_caps" do
+    belongs_to(:currency, Currency)
+    belongs_to(:user, User)
+    field(:cap, :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user_currency_cap, attrs) do
+    user_currency_cap
+    |> cast(attrs, [:currency_id, :user_id, :cap])
+    |> validate_number(:cap, greater_than_or_equal_to: 0)
+    |> validate_required([:currency_id, :user_id, :cap])
+  end
+
+  @doc false
+  def update_changeset(user_currency_cap, attrs) do
+    user_currency_cap
+    |> cast(attrs, [:cap])
+    |> validate_required([:cap])
+  end
+end

--- a/apps/game_backend/lib/game_backend/users/dungeon_settlement_level.ex
+++ b/apps/game_backend/lib/game_backend/users/dungeon_settlement_level.ex
@@ -21,7 +21,7 @@ defmodule GameBackend.Users.DungeonSettlementLevel do
     field(:max_factional, :integer)
 
     # The amount of Supplies currency that a player can hold at a time // TODO: [#CHoM-439]
-    field(:supply_limit, :integer)
+    field(:supply_cap, :integer)
 
     has_many(:afk_reward_rates, AfkRewardRate)
 
@@ -33,9 +33,9 @@ defmodule GameBackend.Users.DungeonSettlementLevel do
   @doc false
   def changeset(dungeon_settlement_level, attrs) do
     dungeon_settlement_level
-    |> cast(attrs, [:level, :max_dungeon, :max_factional, :supply_limit])
+    |> cast(attrs, [:level, :max_dungeon, :max_factional, :supply_cap])
     |> cast_assoc(:afk_reward_rates)
     |> cast_embed(:level_up_costs)
-    |> validate_required([:level, :max_dungeon, :max_factional, :supply_limit])
+    |> validate_required([:level, :max_dungeon, :max_factional, :supply_cap])
   end
 end

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -7,9 +7,17 @@ defmodule GameBackend.Users.User do
   import Ecto.Changeset
   alias GameBackend.Campaigns.SuperCampaignProgress
   alias GameBackend.Items.Item
-  alias GameBackend.Units.Unit
-  alias GameBackend.Users.{Currencies.UserCurrency, DungeonSettlementLevel, KalineTreeLevel, GoogleUser, Unlock}
   alias GameBackend.Quests.UserQuest
+  alias GameBackend.Units.Unit
+
+  alias GameBackend.Users.{
+    Currencies.UserCurrency,
+    Currencies.UserCurrencyCap,
+    DungeonSettlementLevel,
+    KalineTreeLevel,
+    GoogleUser,
+    Unlock
+  }
 
   schema "users" do
     field(:game_id, :integer)
@@ -32,6 +40,7 @@ defmodule GameBackend.Users.User do
     has_many(:user_quests, UserQuest)
     has_many(:super_campaign_progresses, SuperCampaignProgress)
     has_many(:unlocks, Unlock)
+    has_many(:currency_caps, UserCurrencyCap)
 
     timestamps()
   end

--- a/apps/game_backend/priv/repo/migrations/20240605134407_add_user_currency_caps.exs
+++ b/apps/game_backend/priv/repo/migrations/20240605134407_add_user_currency_caps.exs
@@ -1,0 +1,15 @@
+defmodule GameBackend.Repo.Migrations.AddUserCurrencyCaps do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_currency_caps) do
+      add :currency_id, references(:currencies, on_delete: :delete_all)
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :cap, :integer, null: :false
+
+      timestamps()
+    end
+
+    create index(:user_currency_caps, [:currency_id, :user_id], unique: true)
+  end
+end

--- a/apps/game_backend/priv/repo/migrations/20240605184601_rename_supply_limit_to_supply_cap.exs
+++ b/apps/game_backend/priv/repo/migrations/20240605184601_rename_supply_limit_to_supply_cap.exs
@@ -1,0 +1,10 @@
+defmodule GameBackend.Repo.Migrations.RenameSupplyLimitToSupplyCap do
+  use Ecto.Migration
+
+  def change do
+    alter table(:dungeon_settlement_levels) do
+      remove :supply_limit
+      add :supply_cap, :integer
+    end
+  end
+end

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -467,7 +467,7 @@ defmodule Gateway.Serialization.DungeonSettlementLevel do
 
   field(:max_dungeon, 4, type: :uint64, json_name: "maxDungeon")
   field(:max_factional, 5, type: :uint64, json_name: "maxFactional")
-  field(:supply_limit, 6, type: :uint64, json_name: "supplyLimit")
+  field(:supply_cap, 6, type: :uint64, json_name: "supplyLimit")
 
   field(:afk_reward_rates, 7,
     repeated: true,

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -955,6 +955,7 @@ defmodule Gateway.Test.Champions do
                      Enum.find(currencies_before_claiming, &(&1.currency.name == currency.currency.name)).amount
 
                    expected_amount = trunc(currency_before_claim + reward_rate * seconds_to_wait)
+                   # Note: This will fail if the initial amount for a user exceeds the UserCurrencyCap
                    user_currency.amount in expected_amount..trunc(expected_amount * 1.1)
                end
              end)

--- a/apps/gateway/test/champions_test.exs
+++ b/apps/gateway/test/champions_test.exs
@@ -1014,7 +1014,7 @@ defmodule Gateway.Test.Champions do
           Currencies.get_user_currency_cap(
             more_advanced_user.id,
             Currencies.get_currency_by_name_and_game!("Supplies", Utils.get_game_id(:champions_of_mirra)).id
-          )
+          ).cap
         )
 
       # If we claim the rewards, the amount should not change, as it has reached the cap

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -202,7 +202,7 @@ syntax = "proto3";
     repeated CurrencyCost level_up_costs = 3;
     uint64 max_dungeon = 4;
     uint64 max_factional = 5;
-    uint64 supply_limit = 6;
+    uint64 supply_cap = 6;
     repeated AfkRewardRate afk_reward_rates = 7;
   }
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -290,7 +290,7 @@ _dungeon_settlement_levels =
             level: level_number,
             max_dungeon: level_number * 10,
             max_factional: level_number * 5,
-            supply_cap: level_number * 5,
+            supply_cap: level_number * 10,
             afk_reward_rates: [
               %{rate: 10.0 * (level_number - 1), currency_id: supplies_currency.id}
             ],

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -290,7 +290,7 @@ _dungeon_settlement_levels =
             level: level_number,
             max_dungeon: level_number * 10,
             max_factional: level_number * 5,
-            supply_limit: level_number * 5,
+            supply_cap: level_number * 5,
             afk_reward_rates: [
               %{rate: 10.0 * (level_number - 1), currency_id: supplies_currency.id}
             ],


### PR DESCRIPTION
## Motivation

Adds caps to user currencies. They have been dynamic to meet with the general requirements of our backend: you can create a UserCurrencyCap for any user-currency combo. These caps can differ between users.

For AFK Autobattler we want to update the limit everytime with each Dungeon Settlement level up.

We could have gone for an implementation more similar to how we handle afk currencies, where the max supply is stored on each DungeonSettlementLevel and it's obtained by calling something like `get_currency_cap(user_id, "Supplies")` and pattern matching it and handling it like this. I chose to go for this approach because I wanted to keep the initial implementation of currency caps more abstract and usable across our games. We can and probably should go for that optimization later, but in order to introduce the concept I think this is the best we can do right now.

Closes https://github.com/lambdaclass/afk_gacha_game/issues/439

## Summary of changes

- Create user_currency_caps table and schema.
- Rename supply_limit to supply_cap.
- Add initial cap to user's Supplies based on initial DungeonSettlementLevel's cap.
- Modify user's Supplies on every DungeonSettlement level up.

## How to test it?

Give some "Supplies" to a user! You'll find that you're able to do so freely up until you reach 10 or more (initial `dungeon_settlement_level` setting). Afterwards, you won't be able to add anymore to them until you spend enough to cross the treshold.