### PR TITLE
Fix failing dungeon test

### DIFF
--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -145,7 +145,7 @@ defmodule Champions.Users do
     Currencies.add_currency(
       user.id,
       Currencies.get_currency_by_name_and_game!("Supplies", Utils.get_game_id(:champions_of_mirra)).id,
-      100
+      5
     )
   end
 

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -141,6 +141,12 @@ defmodule Champions.Users do
       Currencies.get_currency_by_name_and_game!("Blueprints", Utils.get_game_id(:champions_of_mirra)).id,
       50
     )
+
+    Currencies.add_currency(
+      user.id,
+      Currencies.get_currency_by_name_and_game!("Supplies", Utils.get_game_id(:champions_of_mirra)).id,
+      100
+    )
   end
 
   defp add_super_campaign_progresses(user) do


### PR DESCRIPTION
## Motivation

A failing test was introduced by #658. The reason why this escaped the CI is that the branch was not up to date with main when the passing CI was ran. To avoid this issue in the future, we could implement a restriction in the repo where only up-to-date with `main` branches can be merged. We have this setting enabled in the [AFK Gacha Game](https://github.com/lambdaclass/afk_gacha_game) repo.

In main, max_units restrictions had been introduced for levels, together with the seeds that set that field to 1 in the first level of the dungeon. This is what was missing on the wrong-succesful CI.

## Summary of changes

- Add initial supplies currencies (cherrypicks from #677)
- Unselects all units but one from the user before fighting first dungeon level

## How to test it?

Run `mix tests`