### PR TITLE
[GH-467] Unequip previously equipped item on equip

### DIFF
--- a/apps/champions/lib/champions/items.ex
+++ b/apps/champions/lib/champions/items.ex
@@ -19,10 +19,10 @@ defmodule Champions.Items do
   def get_items(user_id), do: Items.get_items(user_id)
 
   @doc """
-  Equip an item to a unit.
+  Equip an item to a unit. Unequips the previously eqyupped item of the same type if there is any.
   """
   def equip_item(user_id, item_id, unit_id) do
-    Items.equip_item(user_id, item_id, unit_id)
+    Items.equip_item_and_unequip_previous(user_id, item_id, unit_id)
     get_item(item_id)
   end
 

--- a/apps/champions/lib/champions/items.ex
+++ b/apps/champions/lib/champions/items.ex
@@ -19,7 +19,7 @@ defmodule Champions.Items do
   def get_items(user_id), do: Items.get_items(user_id)
 
   @doc """
-  Equip an item to a unit. Unequips the previously eqyupped item of the same type if there is any.
+  Equip an item to a unit. Unequips the previously equipped item of the same type if there is any.
   """
   def equip_item(user_id, item_id, unit_id) do
     Items.equip_item_and_unequip_previous(user_id, item_id, unit_id)

--- a/apps/champions/lib/champions/items.ex
+++ b/apps/champions/lib/champions/items.ex
@@ -76,6 +76,9 @@ defmodule Champions.Items do
 
       {:consumed_items_valid, {false, _}} ->
         {:error, :consumed_items_invalid}
+
+      {:can_afford, false} ->
+        {:error, :cant_afford}
     end
   end
 


### PR DESCRIPTION
## Motivation

Items of the same type were not being unequipped when a unit equipped another one. We marked this as a bug instead of a feature because we thought it was already inclemented, but it seems like we just never actually did it.
Closes https://github.com/lambdaclass/afk_gacha_game/issues/467

## Summary of changes

- Create new equip item function that also unequips the previous item
- Fix a small warning in Items
- Add tests for this

## How to test it?

Create two items, or use the ones you gain by winning the first few levels of the campaign. Equip one of them to a unit. Then equip the other one (of the same type). Query the initial one, and you should see that its' `unit_id` is `nil`