### PR TITLE
[GH-309] Implement Additive and Multiplicative modifiers

### DIFF
--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -1253,7 +1253,16 @@ defmodule Champions.Battle.Simulator do
         end),
       delay: div(effect.initial_delay, @miliseconds_per_step),
       components: effect.components,
-      modifiers: Enum.map(effect.modifiers, &Map.put(&1, :skill_id, skill_id)),
+      modifiers:
+        Enum.map(
+          effect.modifiers,
+          fn modifier ->
+            modifier
+            |> Map.put(:skill_id, skill_id)
+            # Default to "Additive" if no multiply_type is provided
+            |> Map.put(:multiply_type, &1.multiply_type || "Additive")
+          end
+        ),
       executions: effect.executions,
       skill_id: skill_id
     }

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -1103,7 +1103,8 @@ defmodule Champions.Battle.Simulator do
 
       (unit[attribute] + addition) * multiplication
     else
-      Enum.min_by(overrides, & &1.step_applied_at).magnitude
+      # We want to apply that was applied the last
+      Enum.max_by(overrides, & &1.step_applied_at).magnitude
     end
   end
 

--- a/apps/champions/lib/champions/battle/simulator.ex
+++ b/apps/champions/lib/champions/battle/simulator.ex
@@ -1102,7 +1102,12 @@ defmodule Champions.Battle.Simulator do
           unit.modifiers.multiply,
           &(&1.multiply_type == "Additive" and &1.attribute == Atom.to_string(attribute))
         )
-        |> Enum.reduce(1, fn mod, acc -> mod.magnitude * acc end)
+        |> Enum.reduce(0, fn mod, acc -> mod.magnitude + acc end)
+        |> case do
+          # Keep the identity value for multiplication
+          0 -> 1
+          x -> x
+        end
 
       multiply_multiplicative =
         Enum.filter(
@@ -1224,8 +1229,6 @@ defmodule Champions.Battle.Simulator do
     apply_effects_to = %{
       effects: Enum.map(mechanic.apply_effects_to.effects, &create_effect_map(&1, skill_id)),
       targeting_strategy: %{
-        # TODO: replace random for the corresponding target type name (CHoM #325)
-        # type: mechanic.apply_effects_to.targeting_strategy.type,
         type:
           cond do
             is_binary(targeting_strategy_type) && targeting_strategy_type in @implemented_targeting_strategies ->

--- a/apps/game_backend/lib/game_backend/units/skills/mechanics/effects/modifier.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/mechanics/effects/modifier.ex
@@ -6,6 +6,7 @@ defmodule GameBackend.Units.Skills.Mechanics.Effects.Modifier do
   - `"Add"`: Adds the result to the Modifier's specified Attribute. Use a negative value for subtraction.
   - `"Multiply"`: Multiplies the result to the Modifier's specified Attribute. Use a value between 0 and 1 for division.
   - `"Override"`: Overrides the Modifier's specified Attribute with the result.
+  For `"Multiply"`, the `multiply_type` field is used to determine how the value is multiplied. It can be `"Additive"` or `"Multiplicative"`. The default is `"Additive"`. This value is ignored for `"Add"` and `"Override"` operations.
 
   The `CurrentValue` of an `Attribute` is the aggregate result of all of its `Modifiers` added to its `BaseValue`.
   The formula for how `Modifiers` are aggregated is defined as follows:
@@ -40,11 +41,12 @@ defmodule GameBackend.Units.Skills.Mechanics.Effects.Modifier do
     field(:attribute, :string)
     field(:operation, :string)
     field(:magnitude, :float)
+    field(:multiply_type, :string)
   end
 
   def changeset(modifier, attrs) do
     modifier
-    |> cast(attrs, [:attribute, :operation, :magnitude])
+    |> cast(attrs, [:attribute, :operation, :magnitude, :multiply_type])
     |> validate_inclusion(:operation, ~w[Add Multiply Override])
     |> validate_required([:operation, :magnitude, :attribute])
   end

--- a/apps/game_backend/lib/game_backend/units/skills/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/skill.ex
@@ -23,6 +23,7 @@ defmodule GameBackend.Units.Skills.Skill do
   def changeset(skill, attrs \\ %{}) do
     skill
     |> cast(attrs, [:name, :cooldown, :energy_regen, :animation_duration, :buff_id])
+    |> unique_constraint(:name, name: :skills_name_index)
     |> cast_assoc(:mechanics)
   end
 end


### PR DESCRIPTION
## Motivation
Adds the ability to determine whether a multiplicative modifier stacks up multiplicatively or additively with others. If you're not aware of what this means, picture the following example:
You have a unit with an `attack = 1` and two multiplicative modifiers. One multiplies its' attack by 15, and the other one by 5. If both are additive, the final value is `1 * (15+5)= 20`. However, they are multiplicative, the final value is `1 * (15 * 5) = 75`.
If 15 was additive, 5 was multiplicative, and we added another additive of 25, then te equation would look like `1 * (15+ 25)* (5) 200`.
Here is the mathematical equation used:
![image](https://github.com/lambdaclass/mirra_backend/assets/31993243/8c426144-8e90-47db-8277-6f761b6842a9)
Closes https://github.com/lambdaclass/afk_gacha_game/issues/309
## Summary of changes
- Add multiply_type to modifiers, defaulted to Additive in simulator.ex
- Implement additive and multiplicative calculation
- Add test
- Fix small issue in overrides where we were getting the first override applied instead of the last
## How to test it?
Play around with the values for additive and multiplicative modifiers! You can see the added test for an example.
Remember that you can add modifiers to a character's skills by modifying its entries in the `skills.json` file and running `Champions.Config.import_skills_config()`