### PR TITLE
Implement GetDungeonAfkRewards message

### DIFF
--- a/apps/gateway/lib/gateway/champions_socket_handler.ex
+++ b/apps/gateway/lib/gateway/champions_socket_handler.ex
@@ -52,7 +52,8 @@ defmodule Gateway.ChampionsSocketHandler do
     GetUserSuperCampaignProgresses,
     LevelUpKalineTree,
     ClaimDungeonAfkRewards,
-    LevelUpDungeonSettlement
+    LevelUpDungeonSettlement,
+    GetDungeonAfkRewards
   }
 
   @behaviour :cowboy_websocket
@@ -232,6 +233,9 @@ defmodule Gateway.ChampionsSocketHandler do
       {:error, reason} -> prepare_response({:error, reason}, nil)
     end
   end
+
+  defp handle(%GetDungeonAfkRewards{user_id: user_id}),
+    do: prepare_response(%{afk_rewards: Users.get_afk_rewards(user_id, :dungeon)}, :afk_rewards)
 
   defp handle(%ClaimDungeonAfkRewards{user_id: user_id}) do
     Users.claim_afk_rewards(user_id, :dungeon) |> prepare_response(:user)

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -129,6 +129,12 @@ defmodule Gateway.Serialization.WebSocketRequest do
     json_name: "purchaseDungeonUpgrade",
     oneof: 0
   )
+
+  field(:get_dungeon_afk_rewards, 28,
+    type: Gateway.Serialization.GetDungeonAfkRewards,
+    json_name: "getDungeonAfkRewards",
+    oneof: 0
+  )
 end
 
 defmodule Gateway.Serialization.GetUser do
@@ -354,6 +360,14 @@ defmodule Gateway.Serialization.PurchaseDungeonUpgrade do
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:upgrade_id, 2, type: :string, json_name: "upgradeId")
+end
+
+defmodule Gateway.Serialization.GetDungeonAfkRewards do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:user_id, 1, type: :string, json_name: "userId")
 end
 
 defmodule Gateway.Serialization.WebSocketResponse do

--- a/apps/gateway/test/support/socket_tester.ex
+++ b/apps/gateway/test/support/socket_tester.ex
@@ -53,7 +53,8 @@ defmodule Gateway.SocketTester do
     LevelUpKalineTree,
     ClaimDungeonAfkRewards,
     LevelUpDungeonSettlement,
-    PurchaseDungeonUpgrade
+    PurchaseDungeonUpgrade,
+    GetDungeonAfkRewards
   }
 
   def start_link() do
@@ -293,6 +294,16 @@ defmodule Gateway.SocketTester do
         {:binary,
          WebSocketRequest.encode(%WebSocketRequest{
            request_type: {:level_up_kaline_tree, %LevelUpKalineTree{user_id: user_id}}
+         })}
+      )
+
+  def get_dungeon_afk_rewards(pid, user_id),
+    do:
+      WebSockex.send_frame(
+        pid,
+        {:binary,
+         WebSocketRequest.encode(%WebSocketRequest{
+           request_type: {:get_dungeon_afk_rewards, %GetDungeonAfkRewards{user_id: user_id}}
          })}
       )
 

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -28,6 +28,7 @@ syntax = "proto3";
       ClaimDungeonAfkRewards claim_dungeon_afk_rewards = 25;
       LevelUpDungeonSettlement level_up_dungeon_settlement = 26;
       PurchaseDungeonUpgrade purchase_dungeon_upgrade = 27;
+      GetDungeonAfkRewards get_dungeon_afk_rewards = 28;
     }
   }
 
@@ -152,6 +153,9 @@ syntax = "proto3";
     string upgrade_id = 2;
   }
 
+  message GetDungeonAfkRewards {
+    string user_id = 1;
+  }
   ////////////////////////////////////////
 
   message WebSocketResponse {


### PR DESCRIPTION
## Motivation

We need to get the Dungeon AFK rewards and send them to the client.

## Summary of changes

Implement the GetDungeonAfkRewards message and the logic for its response.

## How to test it?

Follow the steps to claim the Dungeon AFK Rewards here: https://github.com/lambdaclass/afk_gacha_game/pull/487

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
