### PR TITLE
[GH-258] Send unit and level rewards to client

### DIFF
--- a/apps/champions/lib/champions/campaigns.ex
+++ b/apps/champions/lib/champions/campaigns.ex
@@ -89,7 +89,6 @@ defmodule Champions.Campaigns do
         %{
           user_id: user_id,
           template_id: item_reward.item_template_id,
-          level: 1,
           inserted_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
           updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
         }

--- a/apps/champions/lib/champions/users.ex
+++ b/apps/champions/lib/champions/users.ex
@@ -94,7 +94,7 @@ defmodule Champions.Users do
   end
 
   defp add_sample_items(user) do
-    Items.get_item_templates()
+    Items.get_item_templates(Utils.get_game_id(:champions_of_mirra))
     |> Enum.each(fn template ->
       Items.insert_item(%{user_id: user.id, template_id: template.id, level: Enum.random(1..5)})
     end)

--- a/apps/game_backend/lib/game_backend/campaigns.ex
+++ b/apps/game_backend/lib/game_backend/campaigns.ex
@@ -131,6 +131,9 @@ defmodule GameBackend.Campaigns do
       |> Repo.preload([
         :currency_rewards,
         campaign: :super_campaign,
+        attempt_cost: :currency,
+        item_rewards: :item_template,
+        unit_rewards: :character,
         units: [
           :items,
           character: [basic_skill: [mechanics: :apply_effects_to], ultimate_skill: [mechanics: :apply_effects_to]]

--- a/apps/game_backend/lib/game_backend/campaigns.ex
+++ b/apps/game_backend/lib/game_backend/campaigns.ex
@@ -40,7 +40,13 @@ defmodule GameBackend.Campaigns do
     do:
       from(l in Level,
         order_by: [asc: l.level_number],
-        preload: [currency_rewards: :currency, units: [:items, :character], attempt_cost: :currency]
+        preload: [
+          currency_rewards: :currency,
+          units: [:items, :character],
+          attempt_cost: :currency,
+          item_rewards: :item,
+          unit_rewards: :character
+        ]
       )
 
   @doc """

--- a/apps/game_backend/lib/game_backend/campaigns.ex
+++ b/apps/game_backend/lib/game_backend/campaigns.ex
@@ -44,7 +44,7 @@ defmodule GameBackend.Campaigns do
           currency_rewards: :currency,
           units: [:items, :character],
           attempt_cost: :currency,
-          item_rewards: :item,
+          item_rewards: :item_template,
           unit_rewards: :character
         ]
       )

--- a/apps/game_backend/lib/game_backend/items.ex
+++ b/apps/game_backend/lib/game_backend/items.ex
@@ -87,13 +87,13 @@ defmodule GameBackend.Items do
   end
 
   @doc """
-  Get all item templates.
+  Get all item templates from a game.
 
   ## Examples
-      iex> get_item_templates()
+      iex> get_item_templates(game_id)
       [%ItemTemplate{}]
   """
-  def get_item_templates(), do: Repo.all(ItemTemplate)
+  def get_item_templates(game_id), do: Repo.all(from(it in ItemTemplate, where: it.game_id == ^game_id))
 
   @doc """
   Get an item template by id.

--- a/apps/game_backend/lib/game_backend/units/characters.ex
+++ b/apps/game_backend/lib/game_backend/units/characters.ex
@@ -75,13 +75,14 @@ defmodule GameBackend.Units.Characters do
   def get_character(id), do: Repo.get(Character, id) |> Repo.preload([:basic_skill, :ultimate_skill])
 
   @doc """
-  Get all Characters.
+  Get all Characters from a game.
 
   ## Examples
-      iex> get_characters()
+      iex> get_characters(1)
       [%Character{}]
   """
-  def get_characters(), do: Repo.all(Character) |> Repo.preload([:basic_skill, :ultimate_skill])
+  def get_characters(game_id),
+    do: Repo.all(from(c in Character, where: c.game_id == ^game_id)) |> Repo.preload([:basic_skill, :ultimate_skill])
 
   @doc """
   Get a Character by name.

--- a/apps/gateway/lib/gateway/champions_socket_handler.ex
+++ b/apps/gateway/lib/gateway/champions_socket_handler.ex
@@ -283,7 +283,8 @@ defmodule Gateway.ChampionsSocketHandler do
           level.unit_rewards,
           &%{
             character_name: &1.character.name,
-            rank: &1.rank
+            rank: &1.rank,
+            amount: &1.amount
           }
         ),
       experience_reward: level.experience_reward,

--- a/apps/gateway/lib/gateway/champions_socket_handler.ex
+++ b/apps/gateway/lib/gateway/champions_socket_handler.ex
@@ -259,7 +259,36 @@ defmodule Gateway.ChampionsSocketHandler do
       id: campaign.id,
       super_campaign_name: campaign.super_campaign.name,
       campaign_number: campaign.campaign_number,
-      levels: campaign.levels
+      levels: Enum.map(campaign.levels, &prepare_level/1)
+    }
+  end
+
+  defp prepare_level(level) do
+    %{
+      id: level.id,
+      campaign_id: level.campaign_id,
+      level_number: level.level_number,
+      units: level.units,
+      currency_rewards: level.currency_rewards,
+      item_rewards:
+        Enum.map(
+          level.item_rewards,
+          &%{
+            item_template_name: &1.item_template.name,
+            amount: &1.amount
+          }
+        ),
+      unit_rewards:
+        Enum.map(
+          level.unit_rewards,
+          &%{
+            character_name: &1.character.name,
+            rank: &1.rank
+          }
+        ),
+      experience_reward: level.experience_reward,
+      attempt_cost: level.attempt_cost,
+      max_units: level.max_units
     }
   end
 

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -683,7 +683,7 @@ defmodule Gateway.Serialization.CurrencyReward do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
-  field(:amount, 3, type: :uint64)
+  field(:amount, 2, type: :uint64)
 end
 
 defmodule Gateway.Serialization.ItemReward do
@@ -693,6 +693,7 @@ defmodule Gateway.Serialization.ItemReward do
 
   field(:item_template_name, 1, type: :string, json_name: "itemTemplateName")
   field(:level, 2, type: :uint32)
+  field(:amount, 3, type: :uint32)
 end
 
 defmodule Gateway.Serialization.UnitReward do
@@ -701,7 +702,8 @@ defmodule Gateway.Serialization.UnitReward do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:character_name, 1, type: :string, json_name: "characterName")
-  field(:rank, 4, type: :uint32)
+  field(:rank, 2, type: :uint32)
+  field(:amount, 3, type: :uint32)
 end
 
 defmodule Gateway.Serialization.AfkRewards do

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -654,9 +654,21 @@ defmodule Gateway.Serialization.Level do
     json_name: "currencyRewards"
   )
 
-  field(:experience_reward, 6, type: :uint32, json_name: "experienceReward")
+  field(:item_rewards, 6,
+    repeated: true,
+    type: Gateway.Serialization.ItemReward,
+    json_name: "itemRewards"
+  )
 
-  field(:attempt_cost, 7,
+  field(:unit_rewards, 7,
+    repeated: true,
+    type: Gateway.Serialization.UnitReward,
+    json_name: "unitRewards"
+  )
+
+  field(:experience_reward, 9, type: :uint32, json_name: "experienceReward")
+
+  field(:attempt_cost, 10,
     repeated: true,
     type: Gateway.Serialization.CurrencyCost,
     json_name: "attemptCost"
@@ -672,6 +684,24 @@ defmodule Gateway.Serialization.CurrencyReward do
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 3, type: :uint64)
+end
+
+defmodule Gateway.Serialization.ItemReward do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:item_template_name, 1, type: :string, json_name: "itemTemplateName")
+  field(:level, 2, type: :uint32)
+end
+
+defmodule Gateway.Serialization.UnitReward do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:character_name, 1, type: :string, json_name: "characterName")
+  field(:rank, 4, type: :uint32)
 end
 
 defmodule Gateway.Serialization.AfkRewards do

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -692,8 +692,7 @@ defmodule Gateway.Serialization.ItemReward do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:item_template_name, 1, type: :string, json_name: "itemTemplateName")
-  field(:level, 2, type: :uint32)
-  field(:amount, 3, type: :uint32)
+  field(:amount, 2, type: :uint32)
 end
 
 defmodule Gateway.Serialization.UnitReward do

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -304,14 +304,26 @@ syntax = "proto3";
     uint32 level_number = 3;
     repeated Unit units = 4;
     repeated CurrencyReward currency_rewards = 5;
-    uint32 experience_reward = 6;    
-    repeated CurrencyCost attempt_cost = 7;
+    repeated ItemReward item_rewards = 6;
+    repeated UnitReward unit_rewards = 7;
+    uint32 experience_reward = 9;    
+    repeated CurrencyCost attempt_cost = 10;
     uint32 max_units = 8;
   }
 
   message CurrencyReward {
     Currency currency = 1; 
     uint64 amount = 3;
+  }
+
+  message ItemReward {
+    string item_template_name = 1;
+    uint32 level = 2;
+  }
+
+  message UnitReward {
+    string character_name = 1;
+    uint32 rank = 4;
   }
 
   message AfkRewards {

--- a/apps/serialization/gateway.proto
+++ b/apps/serialization/gateway.proto
@@ -313,17 +313,18 @@ syntax = "proto3";
 
   message CurrencyReward {
     Currency currency = 1; 
-    uint64 amount = 3;
+    uint64 amount = 2;
   }
 
   message ItemReward {
     string item_template_name = 1;
-    uint32 level = 2;
+    uint32 amount = 2;
   }
 
   message UnitReward {
     string character_name = 1;
-    uint32 rank = 4;
+    uint32 rank = 2;
+    uint32 amount = 3;
   }
 
   message AfkRewards {

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -236,23 +236,22 @@ main_campaign_1 =
 
 level_1 = Enum.find(main_campaign_1.levels, &(&1.level_number == 1))
 
-{:ok, _} =
-  %UnitReward{}
-  |> UnitReward.changeset(%{
-    character_id: Characters.get_characters(champions_of_mirra_id),
-    level_id: level_1.id,
-    amount: 1,
-    rank: 5
-  })
-  |> Repo.insert()
+%UnitReward{}
+|> UnitReward.changeset(%{
+  character_id: Characters.get_characters(champions_of_mirra_id) |> hd() |> Map.get(:id),
+  level_id: level_1.id,
+  amount: 1,
+  rank: 5
+})
+|> Repo.insert!()
 
-{:ok, _} =
-  %ItemReward{}
-  |> ItemReward.changeset(%{
-    item_template_id: Items.get_item_templates(champions_of_mirra_id) |> hd() |> Map.get(:id),
-    level_id: level_1.id,
-    amount: 1
-  })
+%ItemReward{}
+|> ItemReward.changeset(%{
+  item_template_id: Items.get_item_templates(champions_of_mirra_id) |> hd() |> Map.get(:id),
+  level_id: level_1.id,
+  amount: 1
+})
+|> Repo.insert!()
 
 ##################### CURSE OF MIRRA #####################
 # Insert characters


### PR DESCRIPTION
To be merged with: https://github.com/lambdaclass/afk_gacha_game/pull/496

## Motivation

This PR adds the UnitRewards and ItemRewards of protobuf messages on levels to the frontend in order to display them on level win.
Part of https://github.com/lambdaclass/afk_gacha_game/issues/258

## Summary of changes

- Add UnitRewards and ItemRewards to Protobuf message
- Add sample UnitReward and ItemReward to first level

## How to test it?

Playing the first level in this branch of the client should display a unit and a currency reward.
Note: For some reason it breaks experience rewarsd on main but this is saved in https://github.com/lambdaclass/afk_gacha_game/pull/496 so let's merge them together!