### PR TITLE
[GH-497] Add Upgrade config import

### DIFF
--- a/apps/champions/priv/upgrade_dependencies.json
+++ b/apps/champions/priv/upgrade_dependencies.json
@@ -1,0 +1,6 @@
+[
+    {
+        "blocked_upgrade": "Dungeon.HPUpgrade2",
+        "depends_on": "Dungeon.HPUpgrade1"
+    }
+]

--- a/apps/champions/priv/upgrades.json
+++ b/apps/champions/priv/upgrades.json
@@ -1,0 +1,73 @@
+[
+    {
+        "name": "Dungeon.BaseSetting",
+        "description": "This upgrade sets the base settings for the dungeon.",
+        "group": -1,
+        "cost": [],
+        "buffs": [
+            {
+                "modifiers": [
+                    {
+                        "attribute": "max_level",
+                        "magnitude": 10,
+                        "operation": "Add"
+                    },
+                    {
+                        "attribute": "health",
+                        "magnitude": 0.1,
+                        "operation": "Multiply"
+                    },
+                    {
+                        "attribute": "attack",
+                        "magnitude": 0.1,
+                        "operation": "Multiply"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Dungeon.HPUpgrade1",
+        "description": "This upgrade increases the health of all units by 5%.",
+        "group": 1,
+        "cost": [
+            {
+                "currency": "Pearls",
+                "amount": 5
+            }
+        ],
+        "buffs": [
+            {
+                "modifiers": [
+                    {
+                        "attribute": "health",
+                        "magnitude": 0.05,
+                        "operation": "Multiply"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Dungeon.HPUpgrade2",
+        "description": "This upgrade increases the health of all units by 10%.",
+        "group": 1,
+        "cost": [
+            {
+                "currency": "Pearls",
+                "amount": 10
+            }
+        ],
+        "buffs": [
+            {
+                "modifiers": [
+                    {
+                        "attribute": "health",
+                        "magnitude": 0.1,
+                        "operation": "Multiply"
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/apps/game_backend/priv/repo/migrations/20240612162821_remove_unused_fields_from_buffs.exs
+++ b/apps/game_backend/priv/repo/migrations/20240612162821_remove_unused_fields_from_buffs.exs
@@ -1,0 +1,10 @@
+defmodule GameBackend.Repo.Migrations.RemoveUnusedFieldsFromBuffs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:buffs) do
+      remove :game_id
+      remove :name
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,6 +1,6 @@
 alias GameBackend.{Gacha, Repo, Users, Utils}
 alias GameBackend.Campaigns.Rewards.AfkRewardRate
-alias GameBackend.Users.{KalineTreeLevel, Upgrade}
+alias GameBackend.Users.KalineTreeLevel
 alias GameBackend.Units.Characters
 alias GameBackend.CurseOfMirra.Config
 
@@ -55,7 +55,7 @@ champions_of_mirra_id = Utils.get_game_id(:champions_of_mirra)
 {:ok, _blueprints_currency} =
   Users.Currencies.insert_currency(%{game_id: champions_of_mirra_id, name: "Blueprints"})
 
-{:ok, pearls_currency} =
+{:ok, _pearls_currency} =
   Users.Currencies.insert_currency(%{game_id: champions_of_mirra_id, name: "Pearls"})
 
 ### Curse Currencies
@@ -157,72 +157,10 @@ Repo.insert_all(AfkRewardRate, afk_reward_rates)
 Champions.Config.import_super_campaigns_config()
 Champions.Config.import_main_campaign_levels_config()
 Champions.Config.import_dungeon_levels_config()
-
-Champions.Config.import_dungeon_settlement_levels_config()
-
-{:ok, _initial_debuff} =
-  Repo.insert(
-    Upgrade.changeset(%Upgrade{}, %{
-      game_id: champions_of_mirra_id,
-      name: "Dungeon.BaseSetting",
-      description: "This upgrade sets the base settings for the dungeon.",
-      group: -1,
-      buffs: [
-        %{
-          modifiers: [
-            %{attribute: "max_level", magnitude: 10, operation: "Add"},
-            %{attribute: "health", magnitude: 0.1, operation: "Multiply"},
-            %{attribute: "attack", magnitude: 0.1, operation: "Multiply"}
-          ]
-        }
-      ]
-    })
-  )
-
-{:ok, sample_hp_1} =
-  Repo.insert(
-    Upgrade.changeset(%Upgrade{}, %{
-      game_id: champions_of_mirra_id,
-      name: "Dungeon.HPUpgrade1",
-      description: "This upgrade increases the health of all units by 5%.",
-      group: 1,
-      cost: [
-        %{currency_id: pearls_currency.id, amount: 5}
-      ],
-      buffs: [
-        %{
-          modifiers: [
-            %{attribute: "health", magnitude: 0.05, operation: "Multiply"}
-          ]
-        }
-      ]
-    })
-  )
-
-{:ok, _sample_hp_2} =
-  Repo.insert(
-    Upgrade.changeset(%Upgrade{}, %{
-      game_id: champions_of_mirra_id,
-      name: "Dungeon.HPUpgrade2",
-      description: "This upgrade increases the health of all units by 10%.",
-      group: 1,
-      cost: [
-        %{currency_id: pearls_currency.id, amount: 10}
-      ],
-      upgrade_dependency_depends_on: [
-        %{depends_on_id: sample_hp_1.id}
-      ],
-      buffs: [
-        %{
-          modifiers: [
-            %{attribute: "health", magnitude: 1.1, operation: "Multiply"}
-          ]
-        }
-      ]
-    })
-  )
-
 Champions.Config.import_dungeon_levels_config()
+Champions.Config.import_dungeon_settlement_levels_config()
+Champions.Config.import_upgrades()
+Champions.Config.import_upgrade_dependencies()
 
 ##################### CURSE OF MIRRA #####################
 # Insert characters


### PR DESCRIPTION
## Motivation

Adds configuration for Upgrades and their dependencies. They have been made in two different files because it's easier for development. It also seems like the tidier way to do it, since otherwise it could become kind of messy and difficult to track.
Closes https://github.com/lambdaclass/afk_gacha_game/issues/497

## Summary of changes

- Add `upgrades.json` and `upgrade_dependencies.json`.
- Add import functions for them.
- Tidy up the Config module that was needing some love.
  - Move all private functions to the end of the module.
  - Add doc to missing functions.
- Remove wrong fields in Buffs

## How to test it?

- Run the app and check that everything runs normally.
- Tests too.
- Go through the steps in https://github.com/lambdaclass/mirra_backend/pull/632 and check that everything still works.
- Inspect the uploaded data (upgrades, buffs, dependencies) and check that everything is there.
