### PR TITLE
[GH-699] Add environment default options in quick game

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -661,7 +661,7 @@ defmodule Arena.GameUpdater do
       |> Map.put(:zone, %{
         radius: config.map.radius,
         enabled: config.game.zone_enabled,
-        shrinking: config.game.zone_enabled,
+        shrinking: false,
         next_zone_change_timestamp:
           initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms
       })

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -59,10 +59,6 @@ defmodule Arena.GameUpdater do
     game_state = new_game(game_id, clients ++ bot_clients, game_config)
     match_id = Ecto.UUID.generate()
 
-    unless game_config.game.bots_enabled do
-      Process.send_after(self(), :toggle_bots, 300)
-    end
-
     send(self(), :update_game)
     Process.send_after(self(), :selecting_bounty, game_config.game.bounty_pick_time_ms)
 
@@ -245,6 +241,10 @@ defmodule Arena.GameUpdater do
     send(self(), :pick_default_bouty_for_missing_players)
     send(self(), :natural_healing)
     send(self(), {:end_game_check, Map.keys(state.game_state.players)})
+
+    unless state.game_config.game.bots_enabled do
+      toggle_bots(self())
+    end
 
     {:noreply, put_in(state, [:game_state, :status], :RUNNING)}
   end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -51,11 +51,17 @@ defmodule Arena.GameUpdater do
   # END API
   ##########################
 
-  def init(%{clients: clients, bot_clients: bot_clients}) do
+  def init(%{clients: clients, bot_clients: bot_clients, game_params: game_params}) do
     game_id = self() |> :erlang.term_to_binary() |> Base58.encode()
     game_config = Configuration.get_game_config()
+    game_config = Map.put(game_config, :game, Map.merge(game_config.game, game_params))
+
     game_state = new_game(game_id, clients ++ bot_clients, game_config)
     match_id = Ecto.UUID.generate()
+
+    unless game_config.game.bots_enabled do
+      Process.send_after(self(), :toggle_bots, 300)
+    end
 
     send(self(), :update_game)
     Process.send_after(self(), :selecting_bounty, game_config.game.bounty_pick_time_ms)
@@ -174,6 +180,12 @@ defmodule Arena.GameUpdater do
   # Game Callbacks
   ##########################
 
+  def handle_info(:toggle_bots, state) do
+    GenServer.cast(self(), :toggle_bots)
+
+    {:noreply, state}
+  end
+
   def handle_info(:update_game, %{game_state: game_state} = state) do
     Process.send_after(self(), :update_game, state.game_config.game.tick_rate_ms)
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
@@ -234,12 +246,7 @@ defmodule Arena.GameUpdater do
     send(self(), :natural_healing)
     send(self(), {:end_game_check, Map.keys(state.game_state.players)})
 
-    state =
-      state
-      |> put_in([:game_state, :zone, :enabled], true)
-      |> put_in([:game_state, :status], :RUNNING)
-
-    {:noreply, state}
+    {:noreply, put_in(state, [:game_state, :status], :RUNNING)}
   end
 
   def handle_info({:end_game_check, last_players_ids}, state) do
@@ -653,8 +660,8 @@ defmodule Arena.GameUpdater do
       |> Map.put(:external_wall, Entities.new_external_wall(0, config.map.radius))
       |> Map.put(:zone, %{
         radius: config.map.radius,
-        enabled: false,
-        shrinking: false,
+        enabled: config.game.zone_enabled,
+        shrinking: config.game.zone_enabled,
         next_zone_change_timestamp:
           initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms
       })

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -852,7 +852,9 @@
     "zone_start_interval_ms": 20000,
     "zone_damage_interval_ms": 1000,
     "zone_damage": 40,
-    "item_spawn_interval_ms": 7500
+    "item_spawn_interval_ms": 7500,
+    "bots_enabled": true,
+    "zone_enabled": true
   },
   "skills": [
     {


### PR DESCRIPTION
## Motivation

Zone and bots can be toggled in client settings, but we need a faster way to test things without these kind of features.
Closes #699 

## Summary of changes

[Make zone and bots configurable and toggle them off in quick match](https://github.com/lambdaclass/mirra_backend/pull/701/commits/a7c7904c245aabff3f990b4cb28c7f3dc9725765)

## How to test it?

Play a quick match, both zone and bots should be disabled.
Play a regular match, both zone and bots are configurable in `apps/arena/priv/config.json`.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
