### PR TITLE
Game client bot toggle

### DIFF
--- a/apps/game_client/lib/game_client/client_socket_handler.ex
+++ b/apps/game_client/lib/game_client/client_socket_handler.ex
@@ -73,6 +73,17 @@ defmodule GameClient.ClientSocketHandler do
     {:reply, {:binary, game_action}, state}
   end
 
+  def handle_info(:toggle_bots, state) do
+    Logger.info("Sending GameAction frame with toggle_bots payload")
+
+    game_action =
+      GameClient.Protobuf.GameAction.encode(%GameClient.Protobuf.GameAction{
+        action_type: {:toggle_bots, %GameClient.Protobuf.ToggleBots{}}
+      })
+
+    {:reply, {:binary, game_action}, state}
+  end
+
   def handle_info(:close, state) do
     Logger.info("ClientSocket closed")
     {:close, state}

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -95,6 +95,10 @@ defmodule GameClientWeb.BoardLive.Show do
     {:noreply, assign(socket, :ping_latency, ping_event.latency)}
   end
 
+  defp handle_game_event({noop_event, _}, socket) when noop_event in [:toggle_bots] do
+    {:noreply, socket}
+  end
+
   defp transform_entity_entry({_entity_id, entity}) do
     %{
       id: entity.id,

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -63,6 +63,11 @@ defmodule GameClientWeb.BoardLive.Show do
     {:noreply, socket}
   end
 
+  def handle_event("toggle_bots", _, socket) do
+    send(socket.assigns.game_socket_handler_pid, :toggle_bots)
+    {:noreply, socket}
+  end
+
   defp player_name(player_id), do: "P#{player_id}"
 
   defp handle_game_event({:joined, _joined_info}, socket) do

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.html.heex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.html.heex
@@ -9,6 +9,9 @@
         <li>
           Status: <%= @game_status %>
         </li>
+        <li>
+          <button phx-click="toggle_bots">Toggle bots</button>
+        </li>
       </ul>
     </div>
     <div>


### PR DESCRIPTION
## Motivation

`game_client` is broken and also missing a way to toggle bots

## Summary of changes

- Fix game_client by processing ToggleBot event (and doing nothing)
- Add a button to toggle bots in game_client

## How to test it?

Play a match in game_client and try to toggle bots

## Checklist
- [x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
