### PR TITLE
[GH-676] Make skills auto aim to crates too

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -3,6 +3,7 @@ defmodule Arena.Game.Player do
   Module for interacting with Player entity
   """
 
+  alias Arena.Game.Crate
   alias Arena.GameUpdater
   alias Arena.GameTracker
   alias Arena.Utils
@@ -175,6 +176,13 @@ defmodule Arena.Game.Player do
         {auto_aim?, skill_direction} =
           skill_params.target
           |> Skill.maybe_auto_aim(skill, player, targetable_players(game_state.players))
+          |> case do
+            {false, _} ->
+              Skill.maybe_auto_aim(skill_params.target, skill, player, Crate.interactable_crates(game_state.crates))
+
+            auto_aim ->
+              auto_aim
+          end
 
         execution_duration = calculate_duration(skill, player.position, skill_direction, auto_aim?)
         Process.send_after(self(), {:block_actions, player.id}, execution_duration)

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -375,11 +375,10 @@ defmodule Arena.Game.Skill do
   def maybe_auto_aim(%{x: x, y: y}, skill, player, entities) when x == 0.0 and y == 0.0 do
     case skill.autoaim do
       true ->
-        nearest_entity_position_in_range =
+        {use_autoaim?, nearest_entity_position_in_range} =
           Physics.nearest_entity_position_in_range(player, entities, skill.max_autoaim_range)
-          |> maybe_normalize(not skill.can_pick_destination)
 
-        {nearest_entity_position_in_range != player.direction, nearest_entity_position_in_range}
+        {use_autoaim?, nearest_entity_position_in_range |> maybe_normalize(not skill.can_pick_destination)}
 
       false ->
         {false, player.direction |> maybe_normalize(not skill.can_pick_destination)}

--- a/apps/arena/native/physics/src/lib.rs
+++ b/apps/arena/native/physics/src/lib.rs
@@ -145,12 +145,13 @@ fn nearest_entity_position_in_range(
     entity: Entity,
     entities: HashMap<u64, Entity>,
     range: i64,
-) -> Position {
+) -> (bool, Position) {
     let mut max_distance = range as f32;
     let mut position = Position {
         x: entity.direction.x,
         y: entity.direction.y,
     };
+    let mut use_autoaim: bool = false;
 
     for other_entity in entities.values() {
         if entity.id != other_entity.id {
@@ -163,11 +164,12 @@ fn nearest_entity_position_in_range(
                     x: difference_between_positions.x,
                     y: difference_between_positions.y,
                 };
+                use_autoaim = true;
             }
         }
     }
 
-    position
+    (use_autoaim, position)
 }
 #[rustler::nif()]
 fn distance_between_entities(entity_a: Entity, entity_b: Entity) -> f32 {


### PR DESCRIPTION
## Motivation

Skills should auto aim to hit crates too, It should prioritize players over crates in the auto aim check

Closes #676

## Summary of changes

- Check for crates in the autoaim if no players are found
- This check to see if we were executing an auto aim had two issues: `nearest_entity_position_in_range != player.direction`
  - Sometimes you returned a position that can be not normalized, so this will never match since the player direction is normalized
  - If you normalized the `nearest_entity_position_in_range` you encountered precision errors
  - Now we'll check in rust if we'll auto aim or not and return it instead of comparing in elixir

## How to test it?

Start a match and try to hit a crate without aiming, if you have a player nearby it should prioritize it 

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
