### PR TITLE
[GH-734] implement crate dropping delay and power up activation delay

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -108,7 +108,7 @@ defmodule Arena.Entities do
       is_moving: false,
       aditional_info: %{
         owner_id: owner_id,
-        status: :AVAILABLE,
+        status: :UNAVAILABLE,
         remove_on_collision: true,
         pull_immunity: true,
         power_up_damage_modifier: power_up.power_up_damage_modifier,
@@ -229,7 +229,8 @@ defmodule Arena.Entities do
         shape: shape,
         vertices: vertices,
         health: health,
-        amount_of_power_ups: amount_of_power_ups
+        amount_of_power_ups: amount_of_power_ups,
+        power_up_spawn_delay_ms: power_up_spawn_delay_ms
       }) do
     %{
       id: id,
@@ -250,7 +251,8 @@ defmodule Arena.Entities do
         amount_of_power_ups: amount_of_power_ups,
         status: :FINE,
         pull_immunity: true,
-        effects: []
+        effects: [],
+        power_up_spawn_delay_ms: power_up_spawn_delay_ms
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -35,6 +35,7 @@ defmodule Arena.Serialization.PowerUpstatus do
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
+  field(:UNAVAILABLE, 2)
 end
 
 defmodule Arena.Serialization.PlayerActionType do

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -1206,7 +1206,8 @@
       "distance_to_power_up": 400,
       "power_up_damage_modifier": 0.08,
       "power_up_health_modifier": 0.08,
-      "radius": 200.0
+      "radius": 200.0,
+      "activation_delay_ms": 500
     }
   },
   "effects": [
@@ -1363,7 +1364,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1374,7 +1376,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1385,7 +1388,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1396,7 +1400,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1407,7 +1412,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1418,7 +1424,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1429,7 +1436,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1440,7 +1448,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     },
     {
       "position": {
@@ -1451,7 +1460,8 @@
       "radius": 150.0,
       "health": 250,
       "vertices": [],
-      "amount_of_power_ups": 1
+      "amount_of_power_ups": 1,
+      "power_up_spawn_delay_ms": 300 
     }
   ],
   "traps": []

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -35,6 +35,7 @@ defmodule ArenaLoadTest.Serialization.PowerUpstatus do
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
+  field(:UNAVAILABLE, 2)
 end
 
 defmodule ArenaLoadTest.Serialization.PlayerActionType do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -35,6 +35,7 @@ defmodule BotManager.Protobuf.PowerUpstatus do
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
+  field(:UNAVAILABLE, 2)
 end
 
 defmodule BotManager.Protobuf.PlayerActionType do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -11012,7 +11012,8 @@ proto.CrateStatus = {
  */
 proto.PowerUpstatus = {
   AVAILABLE: 0,
-  TAKEN: 1
+  TAKEN: 1,
+  UNAVAILABLE: 2
 };
 
 /**

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -35,6 +35,7 @@ defmodule GameClient.Protobuf.PowerUpstatus do
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
+  field(:UNAVAILABLE, 2)
 end
 
 defmodule GameClient.Protobuf.PlayerActionType do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -241,6 +241,7 @@ enum CrateStatus {
 enum  PowerUpstatus {
   AVAILABLE = 0;
   TAKEN = 1;
+  UNAVAILABLE = 2;
 }
 
 message Pool {


### PR DESCRIPTION
> [!Warning]
> This pr should be merges alongside [This client pr](https://github.com/lambdaclass/champions_of_mirra/pull/1882) 

## Motivation

Crates needs a time to play an animation before spawning a new power up
If you stand in the same place as the power up spawn you instantaneously pick it up, we should wait some time before being able to pick power ups up to play an animation

Closes #734 

## Summary of changes

- Added a delayed power up spawn mechanic to power ups spawned by crates
- Now power ups will start with the field status as unavailable and will change to available after a delay to be pickupable 

## How to test it?

Play a match with the correct client branch and destroy a crate, the power up should spawn after some delay. Also if you stand over the crate or a player when you kill/destroy it you shouldn't pick up any power up

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
