### PR TITLE
Fix game timers

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -673,10 +673,10 @@ defmodule Arena.GameUpdater do
         enabled: config.game.zone_enabled,
         shrinking: false,
         next_zone_change_timestamp:
-          initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms
+          initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms + config.game.bounty_pick_time_ms
       })
       |> Map.put(:status, :PREPARING)
-      |> Map.put(:start_game_timestamp, initial_timestamp + config.game.start_game_time_ms)
+      |> Map.put(:start_game_timestamp, initial_timestamp + config.game.start_game_time_ms + config.game.bounty_pick_time_ms)
       |> Map.put(:positions, %{})
       |> Map.put(:traps, %{})
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -673,10 +673,14 @@ defmodule Arena.GameUpdater do
         enabled: config.game.zone_enabled,
         shrinking: false,
         next_zone_change_timestamp:
-          initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms + config.game.bounty_pick_time_ms
+          initial_timestamp + config.game.zone_shrink_start_ms + config.game.start_game_time_ms +
+            config.game.bounty_pick_time_ms
       })
       |> Map.put(:status, :PREPARING)
-      |> Map.put(:start_game_timestamp, initial_timestamp + config.game.start_game_time_ms + config.game.bounty_pick_time_ms)
+      |> Map.put(
+        :start_game_timestamp,
+        initial_timestamp + config.game.start_game_time_ms + config.game.bounty_pick_time_ms
+      )
       |> Map.put(:positions, %{})
       |> Map.put(:traps, %{})
 


### PR DESCRIPTION
## Motivation
When adding the bounties screen we did not take into account this extra time before starting the battle. We need to contemplate this time for the zone shrinking time and the start game timestamp. 

## Summary of changes
Added `bounty_pick_time_ms` to the `next_zone_change_timestamp` and `start_game_timestamp`.

## How to test it?
Test with this [client PR](https://github.com/lambdaclass/champions_of_mirra/pull/1873). 

Check that the following are working as expected:
- Bounties screen and countdown
- Players screen and countdown
- Survive animation
- Movement when battle starts
- Zone timer

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
