### PR TITLE
Add quest import in seeds file

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -306,4 +306,6 @@ valtimer_params = %{
   |> Characters.insert_character()
 end)
 
+GameBackend.CurseOfMirra.Config.import_quest_descriptions_config()
+
 ################### END CURSE OF MIRRA ###################


### PR DESCRIPTION
## Motivation
Every time we reseted the db we need to run `GameBackend.CurseOfMirra.Config.import_quest_descriptions_config` to have quests, this should be ran in the seeds file

## Summary of changes

- Add GameBackend.CurseOfMirra.Config.import_quest_descriptions_config to seeds file

## How to test it?

Run make start and you should have quests in the db, you can run `GameBackend.Repo.all(GameBackend.Quests.Quest)`

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
