### PR TITLE
Add pool activation delay

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -160,7 +160,8 @@ defmodule Arena.Entities do
         stat_multiplier: 0,
         duration_ms: duration_ms,
         pull_immunity: true,
-        spawn_at: spawn_at
+        spawn_at: spawn_at,
+        status: :ACTIVATING
       },
       collides_with: []
     }
@@ -367,7 +368,8 @@ defmodule Arena.Entities do
   def maybe_add_custom_info(entity) when entity.category == :pool do
     {:pool,
      %Arena.Serialization.Pool{
-       owner_id: entity.aditional_info.owner_id
+       owner_id: entity.aditional_info.owner_id,
+       status: entity.aditional_info.status
      }}
   end
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -161,7 +161,7 @@ defmodule Arena.Entities do
         duration_ms: duration_ms,
         pull_immunity: true,
         spawn_at: spawn_at,
-        status: :ACTIVATING
+        status: :WAITING
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -302,13 +302,15 @@ defmodule Arena.Game.Skill do
 
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
+    Process.send_after(self(), {:activate_pool, last_id}, pool_params.activation_delay)
+
     pool =
       Entities.new_pool(
         last_id,
         target_position,
         pool_params.effects_to_apply,
         pool_params.radius,
-        pool_params.duration_ms,
+        pool_params.duration_ms + pool_params.activation_delay,
         player.id,
         now
       )

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -557,6 +557,13 @@ defmodule Arena.GameUpdater do
     {:noreply, state}
   end
 
+  def handle_info({:activate_pool, pool_id}, state) do
+    state =
+      put_in(state, [:game_state, :pools, pool_id, :aditional_info, :status], :ACTIVATED)
+
+    {:noreply, state}
+  end
+
   ##########################
   # End callbacks
   ##########################
@@ -1440,13 +1447,17 @@ defmodule Arena.GameUpdater do
     entities = Map.merge(crates, players)
 
     Enum.reduce(pools, game_state, fn {pool_id, pool}, game_state ->
-      Enum.reduce(entities, game_state, fn {entity_id, entity}, acc ->
-        if entity_id in pool.collides_with do
-          add_pool_effects(acc, game_config, entity, pool)
-        else
-          Effect.remove_owner_effects(acc, entity_id, pool_id)
-        end
-      end)
+      if pool.aditional_info.status == :ACTIVATED do
+        Enum.reduce(entities, game_state, fn {entity_id, entity}, acc ->
+          if entity_id in pool.collides_with do
+            add_pool_effects(acc, game_config, entity, pool)
+          else
+            Effect.remove_owner_effects(acc, entity_id, pool_id)
+          end
+        end)
+      else
+        game_state
+      end
     end)
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1471,18 +1471,14 @@ defmodule Arena.GameUpdater do
   defp handle_pools(%{pools: pools, crates: crates, players: players} = game_state, game_config) do
     entities = Map.merge(crates, players)
 
-    Enum.reduce(pools, game_state, fn {pool_id, pool}, game_state ->
-      if pool.aditional_info.status == :ACTIVATED do
-        Enum.reduce(entities, game_state, fn {entity_id, entity}, acc ->
-          if entity_id in pool.collides_with do
-            add_pool_effects(acc, game_config, entity, pool)
-          else
-            Effect.remove_owner_effects(acc, entity_id, pool_id)
-          end
-        end)
-      else
-        game_state
-      end
+    Enum.reduce(pools, game_state, fn {_pool_id, pool}, game_state ->
+      Enum.reduce(entities, game_state, fn {entity_id, entity}, acc ->
+        if entity_id in pool.collides_with and pool.aditional_info.status == :ACTIVATED do
+          add_pool_effects(acc, game_config, entity, pool)
+        else
+          Effect.remove_owner_effects(acc, entity_id, pool.id)
+        end
+      end)
     end)
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -577,7 +577,7 @@ defmodule Arena.GameUpdater do
 
   def handle_info({:activate_pool, pool_id}, state) do
     state =
-      put_in(state, [:game_state, :pools, pool_id, :aditional_info, :status], :ACTIVATED)
+      put_in(state, [:game_state, :pools, pool_id, :aditional_info, :status], :READY)
 
     {:noreply, state}
   end
@@ -1473,7 +1473,7 @@ defmodule Arena.GameUpdater do
 
     Enum.reduce(pools, game_state, fn {_pool_id, pool}, game_state ->
       Enum.reduce(entities, game_state, fn {entity_id, entity}, acc ->
-        if entity_id in pool.collides_with and pool.aditional_info.status == :ACTIVATED do
+        if entity_id in pool.collides_with and pool.aditional_info.status == :READY do
           add_pool_effects(acc, game_config, entity, pool)
         else
           Effect.remove_owner_effects(acc, entity_id, pool.id)

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -67,8 +67,8 @@ defmodule Arena.Serialization.PoolStatus do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ACTIVATING, 0)
-  field(:ACTIVATED, 1)
+  field(:WAITING, 0)
+  field(:READY, 1)
 end
 
 defmodule Arena.Serialization.Direction do

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -61,6 +61,15 @@ defmodule Arena.Serialization.TrapStatus do
   field(:USED, 3)
 end
 
+defmodule Arena.Serialization.PoolStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:ACTIVATING, 0)
+  field(:ACTIVATED, 1)
+end
+
 defmodule Arena.Serialization.Direction do
   @moduledoc false
 
@@ -562,6 +571,7 @@ defmodule Arena.Serialization.Pool do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: Arena.Serialization.PoolStatus, enum: true)
 end
 
 defmodule Arena.Serialization.Bush do

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -898,6 +898,7 @@
             "duration_ms": 5000,
             "radius": 450.0,
             "range": 1200.0,
+            "activation_delay": 200,
             "effects_to_apply": [
               "singularity"
             ]
@@ -952,6 +953,7 @@
             "duration_ms": 2500,
             "radius": 500.0,
             "range": 1200.0,
+            "activation_delay": 1000,
             "effects_to_apply": [
               "denial_of_service"
             ]

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -898,7 +898,7 @@
             "duration_ms": 5000,
             "radius": 450.0,
             "range": 1200.0,
-            "activation_delay": 200,
+            "activation_delay": 400,
             "effects_to_apply": [
               "singularity"
             ]
@@ -953,7 +953,7 @@
             "duration_ms": 2500,
             "radius": 500.0,
             "range": 1200.0,
-            "activation_delay": 200,
+            "activation_delay": 250,
             "effects_to_apply": [
               "denial_of_service"
             ]

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -953,7 +953,7 @@
             "duration_ms": 2500,
             "radius": 500.0,
             "range": 1200.0,
-            "activation_delay": 1000,
+            "activation_delay": 200,
             "effects_to_apply": [
               "denial_of_service"
             ]

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -67,8 +67,8 @@ defmodule ArenaLoadTest.Serialization.PoolStatus do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ACTIVATING, 0)
-  field(:ACTIVATED, 1)
+  field(:WAITING, 0)
+  field(:READY, 1)
 end
 
 defmodule ArenaLoadTest.Serialization.Direction do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -61,6 +61,15 @@ defmodule ArenaLoadTest.Serialization.TrapStatus do
   field(:USED, 3)
 end
 
+defmodule ArenaLoadTest.Serialization.PoolStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:ACTIVATING, 0)
+  field(:ACTIVATED, 1)
+end
+
 defmodule ArenaLoadTest.Serialization.Direction do
   @moduledoc false
 
@@ -609,6 +618,7 @@ defmodule ArenaLoadTest.Serialization.Pool do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: ArenaLoadTest.Serialization.PoolStatus, enum: true)
 end
 
 defmodule ArenaLoadTest.Serialization.Bush do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -61,6 +61,15 @@ defmodule BotManager.Protobuf.TrapStatus do
   field(:USED, 3)
 end
 
+defmodule BotManager.Protobuf.PoolStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:ACTIVATING, 0)
+  field(:ACTIVATED, 1)
+end
+
 defmodule BotManager.Protobuf.Direction do
   @moduledoc false
 
@@ -562,6 +571,7 @@ defmodule BotManager.Protobuf.Pool do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: BotManager.Protobuf.PoolStatus, enum: true)
 end
 
 defmodule BotManager.Protobuf.Bush do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -67,8 +67,8 @@ defmodule BotManager.Protobuf.PoolStatus do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ACTIVATING, 0)
-  field(:ACTIVATED, 1)
+  field(:WAITING, 0)
+  field(:READY, 1)
 end
 
 defmodule BotManager.Protobuf.Direction do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -11103,8 +11103,8 @@ proto.TrapStatus = {
  * @enum {number}
  */
 proto.PoolStatus = {
-  ACTIVATING: 0,
-  ACTIVATED: 1
+  WAITING: 0,
+  READY: 1
 };
 
 goog.object.extend(exports, proto);

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -62,6 +62,7 @@ goog.exportSymbol('proto.Player', null, global);
 goog.exportSymbol('proto.PlayerAction', null, global);
 goog.exportSymbol('proto.PlayerActionType', null, global);
 goog.exportSymbol('proto.Pool', null, global);
+goog.exportSymbol('proto.PoolStatus', null, global);
 goog.exportSymbol('proto.Position', null, global);
 goog.exportSymbol('proto.PowerUp', null, global);
 goog.exportSymbol('proto.PowerUpstatus', null, global);
@@ -7985,7 +7986,8 @@ proto.Pool.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Pool.toObject = function(includeInstance, msg) {
   var f, obj = {
-    ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0)
+    ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    status: jspb.Message.getFieldWithDefault(msg, 2, 0)
   };
 
   if (includeInstance) {
@@ -8026,6 +8028,10 @@ proto.Pool.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {number} */ (reader.readUint64());
       msg.setOwnerId(value);
       break;
+    case 2:
+      var value = /** @type {!proto.PoolStatus} */ (reader.readEnum());
+      msg.setStatus(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -8062,6 +8068,13 @@ proto.Pool.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
+  f = message.getStatus();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      2,
+      f
+    );
+  }
 };
 
 
@@ -8080,6 +8093,24 @@ proto.Pool.prototype.getOwnerId = function() {
  */
 proto.Pool.prototype.setOwnerId = function(value) {
   return jspb.Message.setProto3IntField(this, 1, value);
+};
+
+
+/**
+ * optional PoolStatus status = 2;
+ * @return {!proto.PoolStatus}
+ */
+proto.Pool.prototype.getStatus = function() {
+  return /** @type {!proto.PoolStatus} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
+};
+
+
+/**
+ * @param {!proto.PoolStatus} value
+ * @return {!proto.Pool} returns this
+ */
+proto.Pool.prototype.setStatus = function(value) {
+  return jspb.Message.setProto3EnumField(this, 2, value);
 };
 
 
@@ -11065,6 +11096,14 @@ proto.TrapStatus = {
   PREPARED: 1,
   TRIGGERED: 2,
   USED: 3
+};
+
+/**
+ * @enum {number}
+ */
+proto.PoolStatus = {
+  ACTIVATING: 0,
+  ACTIVATED: 1
 };
 
 goog.object.extend(exports, proto);

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -61,6 +61,15 @@ defmodule GameClient.Protobuf.TrapStatus do
   field(:USED, 3)
 end
 
+defmodule GameClient.Protobuf.PoolStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field(:ACTIVATING, 0)
+  field(:ACTIVATED, 1)
+end
+
 defmodule GameClient.Protobuf.Direction do
   @moduledoc false
 
@@ -562,6 +571,7 @@ defmodule GameClient.Protobuf.Pool do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
+  field(:status, 2, type: GameClient.Protobuf.PoolStatus, enum: true)
 end
 
 defmodule GameClient.Protobuf.Bush do

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -67,8 +67,8 @@ defmodule GameClient.Protobuf.PoolStatus do
 
   use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  field(:ACTIVATING, 0)
-  field(:ACTIVATED, 1)
+  field(:WAITING, 0)
+  field(:READY, 1)
 end
 
 defmodule GameClient.Protobuf.Direction do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -246,6 +246,7 @@ enum  PowerUpstatus {
 
 message Pool {
   uint64 owner_id = 1;
+  PoolStatus status = 2;
 }
 
 message Bush {
@@ -278,6 +279,11 @@ enum TrapStatus{
   PREPARED = 1;
   TRIGGERED = 2;
   USED = 3;
+}
+
+enum PoolStatus{
+  ACTIVATING = 0;
+  ACTIVATED = 1;
 }
 
 /*

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -283,8 +283,8 @@ enum TrapStatus{
 }
 
 enum PoolStatus{
-  ACTIVATING = 0;
-  ACTIVATED = 1;
+  WAITING = 0;
+  READY = 1;
 }
 
 /*


### PR DESCRIPTION
>[!Warning]
> Merge alongside this [Client pr](https://github.com/lambdaclass/champions_of_mirra/pull/1900)

## Motivation

Pools were delay damage before the cliend could display the visual representation of them, we should add a little delay before the pool start performing his mechanic to the players above it 

## Summary of changes

- Add new `status` field to the pool entity 
- Trigger a pool activation message after some delay 
- Do not add pool effects to players over when the pool isn't activated

## How to test it?

Play as either valtimer or h4ck and use you ultimate, the pool should start doing mechanics after the animation runs in the client

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
