### PR TITLE
Add a simple toggle for bot clients spawning

### DIFF
--- a/apps/arena/lib/arena/game_launcher.ex
+++ b/apps/arena/lib/arena/game_launcher.ex
@@ -132,7 +132,12 @@ defmodule Arena.GameLauncher do
   # Receives a list of clients.
   # Fills the given list with bots clients, creates a game and tells every client to join that game.
   defp create_game_for_clients(clients, game_params \\ %{}) do
-    bot_clients = get_bot_clients(Application.get_env(:arena, :players_needed_in_match) - Enum.count(clients))
+    bot_clients =
+      if Application.get_env(:arena, :spawn_bots) do
+        get_bot_clients(Application.get_env(:arena, :players_needed_in_match) - Enum.count(clients))
+      else
+        []
+      end
 
     {:ok, game_pid} =
       GenServer.start(Arena.GameUpdater, %{

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -162,10 +162,12 @@ defmodule Arena.GameSocketHandler do
 
   @impl true
   def terminate(_reason, _req, %{game_finished: false, player_alive: true} = state) do
-    spawn(fn ->
-      Finch.build(:get, Utils.get_bot_connection_url(state.game_id, state.client_id))
-      |> Finch.request(Arena.Finch)
-    end)
+    if Application.get_env(:arena, :spawn_bots) do
+      spawn(fn ->
+        Finch.build(:get, Utils.get_bot_connection_url(state.game_id, state.client_id))
+        |> Finch.request(Arena.Finch)
+      end)
+    end
 
     :ok
   end

--- a/config/config.exs
+++ b/config/config.exs
@@ -117,6 +117,7 @@ config :arena, Arena.Mailer, adapter: Swoosh.Adapters.Local
 
 # Amount of clients needed to start a game
 config :arena, :players_needed_in_match, 10
+config :arena, :spawn_bots, false
 
 ################################
 # App configuration: champions #

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,6 +88,7 @@ config :arena, ArenaWeb.Endpoint,
 
 # Enable dev routes for dashboard and mailbox
 config :arena, dev_routes: true
+config :arena, :spawn_bots, true
 
 ################################
 # App configuration: champions #


### PR DESCRIPTION
## Motivation

Business requirement to have it disabled quickly, a proper toggling mechanism will be implemented in #753 

## Summary of changes

- Add configuration disabling bots by in all environments
- Add override to configuration to enable bots in dev env

## How to test it?

Bots enabled, dev env
- Play a match and bots should spawn

Bots disabled, dev env
- Remove the line added in `dev.exs` `config :arena, :spawn_bots, true`
- Play a match and bots should not spawn

## Checklist
- [x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
