### PR TITLE
Refresh effect time instead of losing item

### DIFF
--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -37,8 +37,8 @@ defmodule Arena.Game.Effect do
       if same_applied_effect && effect.one_time_application do
         updated_effects =
           Enum.map(entity.aditional_info.effects, fn effect ->
-            if effect.id == same_applied_effect.id do
-              refresh_effect_expires_at(same_applied_effect, now)
+            if effect.id == same_applied_effect.id and same_applied_effect.expires_at do
+              Map.put(effect, :expires_at, now + same_applied_effect.duration_ms)
             else
               effect
             end
@@ -305,15 +305,4 @@ defmodule Arena.Game.Effect do
   end
 
   defp maybe_send_to_killfeed(entity, _pool_owner_id), do: entity
-
-  defp refresh_effect_expires_at(effect, start_time) do
-    new_expires_at =
-      if effect.expires_at do
-        start_time + effect.duration_ms
-      else
-        nil
-      end
-
-    Map.put(effect, :expires_at, new_expires_at)
-  end
 end

--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -35,20 +35,26 @@ defmodule Arena.Game.Effect do
 
     updated_entity =
       if same_applied_effect && effect.one_time_application do
-        removed_effect =
-          Enum.reject(entity.aditional_info.effects, fn effect -> effect.id == same_applied_effect.id end)
+        updated_effects =
+          Enum.map(entity.aditional_info.effects, fn effect ->
+            if effect.id == same_applied_effect.id do
+              new_expires_at =
+                if same_applied_effect.expires_at do
+                  now + same_applied_effect.duration_ms
+                else
+                  nil
+                end
 
-        new_expires_at =
-          if same_applied_effect.expires_at do
-            now + same_applied_effect.duration_ms
-          else
-            nil
-          end
+              Map.put(effect, :expires_at, new_expires_at)
+            else
+              effect
+            end
+          end)
 
         put_in(
           entity,
           [:aditional_info, :effects],
-          removed_effect ++ [Map.put(same_applied_effect, :expires_at, new_expires_at)]
+          updated_effects
         )
       else
         action_removal_at = now + start_action_removal_in_ms

--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -38,14 +38,7 @@ defmodule Arena.Game.Effect do
         updated_effects =
           Enum.map(entity.aditional_info.effects, fn effect ->
             if effect.id == same_applied_effect.id do
-              new_expires_at =
-                if same_applied_effect.expires_at do
-                  now + same_applied_effect.duration_ms
-                else
-                  nil
-                end
-
-              Map.put(effect, :expires_at, new_expires_at)
+              refresh_effect_expires_at(same_applied_effect, now)
             else
               effect
             end
@@ -312,4 +305,15 @@ defmodule Arena.Game.Effect do
   end
 
   defp maybe_send_to_killfeed(entity, _pool_owner_id), do: entity
+
+  defp refresh_effect_expires_at(effect, start_time) do
+    new_expires_at =
+      if effect.expires_at do
+        start_time + effect.duration_ms
+      else
+        nil
+      end
+
+    Map.put(effect, :expires_at, new_expires_at)
+  end
 end


### PR DESCRIPTION
## Motivation

Currently whenever you use an item and you already have that item effect applied you lose that item effect, that's wrong

The correct behavior should be to refresh the item effect duration to his original duration, notice that we don't add up durations, take the next scenario as example:
1. You use an item that lasts 10 seconds
2. After 5 seconds you use that item again
3. The remaining duration of the effect should be 10 again 

## Summary of changes

Change effect application behavior when an item has the `one_time_application` flag in true

## How to test it?

Start a match and use an item twice, the total duration should depend in the second item usage

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
