### PR TITLE
Add gateway url vars to loadtest workflows

### DIFF
--- a/.github/workflows/loadtest-brazil-server-deploy.yml
+++ b/.github/workflows/loadtest-brazil-server-deploy.yml
@@ -48,6 +48,7 @@ jobs:
           PHX_SERVER: ${{ vars.PHX_SERVER }}
           PHX_HOST: ${{ vars.LOADTEST_SERVER_HOST }}
           PORT: ${{ vars.ARENA_PORT }}
+          GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
@@ -65,6 +66,7 @@ jobs:
                 PHX_SERVER=${PHX_SERVER} \
                 PHX_HOST=${PHX_HOST} \
                 PORT=${PORT} \
+                GATEWAY_URL=${GATEWAY_URL} \
                 BOT_MANAGER_PORT=${BOT_MANAGER_PORT} \
                 DATABASE_URL=${DATABASE_URL} \
                 SECRET_KEY_BASE=${SECRET_KEY_BASE} \

--- a/.github/workflows/loadtest-europe-server-deploy.yml
+++ b/.github/workflows/loadtest-europe-server-deploy.yml
@@ -48,6 +48,7 @@ jobs:
           PHX_SERVER: ${{ vars.PHX_SERVER }}
           PHX_HOST: ${{ vars.LOADTEST_SERVER_HOST }}
           PORT: ${{ vars.ARENA_PORT }}
+          GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
@@ -64,6 +65,7 @@ jobs:
                 PHX_SERVER=${PHX_SERVER} \
                 PHX_HOST=${PHX_HOST} \
                 PORT=${PORT} \
+                GATEWAY_URL=${GATEWAY_URL} \
                 BOT_MANAGER_PORT=${BOT_MANAGER_PORT} \
                 DATABASE_URL=${DATABASE_URL} \
                 SECRET_KEY_BASE=${SECRET_KEY_BASE} \


### PR DESCRIPTION
## Motivation

Loadtest servers run arena, but they don't work because they're missing the gateway's url var.

## Summary of changes

Add gateway_url var to deployments' workflows.

## How to test it?

Just deploy and run a match there (via loadtests or custom).

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
