### PR TITLE
Send offset from skills

### DIFF
--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -197,7 +197,6 @@ defmodule Arena.GameSocketHandler do
         targetting_range: params[:range],
         offset: params[:offset] || params[:projectile_offset]
       }
-      |> IO.inspect(label: :wea)
 
     {key, Map.merge(skill, extra_params)}
   end

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -190,11 +190,14 @@ defmodule Arena.GameSocketHandler do
     ##   we can use this "shortcut" and deal with it when the time comes
     [{_mechanic, params}] = skill.mechanics
 
-    extra_params = %{
-      targetting_radius: params[:radius],
-      targetting_angle: params[:angle],
-      targetting_range: params[:range]
-    }
+    extra_params =
+      %{
+        targetting_radius: params[:radius],
+        targetting_angle: params[:angle],
+        targetting_range: params[:range],
+        offset: params[:offset] || params[:projectile_offset]
+      }
+      |> IO.inspect(label: :wea)
 
     {key, Map.merge(skill, extra_params)}
   end

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -195,7 +195,7 @@ defmodule Arena.GameSocketHandler do
         targetting_radius: params[:radius],
         targetting_angle: params[:angle],
         targetting_range: params[:range],
-        offset: params[:offset] || params[:projectile_offset]
+        targetting_offset: params[:offset] || params[:projectile_offset]
       }
 
     {key, Map.merge(skill, extra_params)}

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -273,7 +273,7 @@ defmodule Arena.Serialization.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
-  field(:offset, 8, type: :float)
+  field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -273,6 +273,7 @@ defmodule Arena.Serialization.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
+  field(:offset, 8, type: :float)
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -285,7 +285,7 @@ defmodule ArenaLoadTest.Serialization.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
-  field(:offset, 8, type: :float)
+  field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
 end
 
 defmodule ArenaLoadTest.Serialization.GameState.PlayersEntry do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -285,6 +285,7 @@ defmodule ArenaLoadTest.Serialization.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
+  field(:offset, 8, type: :float)
 end
 
 defmodule ArenaLoadTest.Serialization.GameState.PlayersEntry do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -273,7 +273,7 @@ defmodule BotManager.Protobuf.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
-  field(:offset, 8, type: :float)
+  field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
 end
 
 defmodule BotManager.Protobuf.GameState.PlayersEntry do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -273,6 +273,7 @@ defmodule BotManager.Protobuf.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
+  field(:offset, 8, type: :float)
 end
 
 defmodule BotManager.Protobuf.GameState.PlayersEntry do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -4290,7 +4290,7 @@ proto.ConfigSkill.toObject = function(includeInstance, msg) {
     targettingAngle: jspb.Message.getFloatingPointFieldWithDefault(msg, 5, 0.0),
     targettingRange: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
     staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0),
-    offset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0)
+    targettingOffset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0)
   };
 
   if (includeInstance) {
@@ -4357,7 +4357,7 @@ proto.ConfigSkill.deserializeBinaryFromReader = function(msg, reader) {
       break;
     case 8:
       var value = /** @type {number} */ (reader.readFloat());
-      msg.setOffset(value);
+      msg.setTargettingOffset(value);
       break;
     default:
       reader.skipField();
@@ -4437,7 +4437,7 @@ proto.ConfigSkill.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
-  f = message.getOffset();
+  f = message.getTargettingOffset();
   if (f !== 0.0) {
     writer.writeFloat(
       8,
@@ -4574,10 +4574,10 @@ proto.ConfigSkill.prototype.setStaminaCost = function(value) {
 
 
 /**
- * optional float offset = 8;
+ * optional float targetting_offset = 8;
  * @return {number}
  */
-proto.ConfigSkill.prototype.getOffset = function() {
+proto.ConfigSkill.prototype.getTargettingOffset = function() {
   return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 8, 0.0));
 };
 
@@ -4586,7 +4586,7 @@ proto.ConfigSkill.prototype.getOffset = function() {
  * @param {number} value
  * @return {!proto.ConfigSkill} returns this
  */
-proto.ConfigSkill.prototype.setOffset = function(value) {
+proto.ConfigSkill.prototype.setTargettingOffset = function(value) {
   return jspb.Message.setProto3FloatField(this, 8, value);
 };
 

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -4289,7 +4289,8 @@ proto.ConfigSkill.toObject = function(includeInstance, msg) {
     targettingRadius: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
     targettingAngle: jspb.Message.getFloatingPointFieldWithDefault(msg, 5, 0.0),
     targettingRange: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
-    staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0)
+    staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0),
+    offset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0)
   };
 
   if (includeInstance) {
@@ -4353,6 +4354,10 @@ proto.ConfigSkill.deserializeBinaryFromReader = function(msg, reader) {
     case 7:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setStaminaCost(value);
+      break;
+    case 8:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setOffset(value);
       break;
     default:
       reader.skipField();
@@ -4429,6 +4434,13 @@ proto.ConfigSkill.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeUint64(
       7,
+      f
+    );
+  }
+  f = message.getOffset();
+  if (f !== 0.0) {
+    writer.writeFloat(
+      8,
       f
     );
   }
@@ -4558,6 +4570,24 @@ proto.ConfigSkill.prototype.getStaminaCost = function() {
  */
 proto.ConfigSkill.prototype.setStaminaCost = function(value) {
   return jspb.Message.setProto3IntField(this, 7, value);
+};
+
+
+/**
+ * optional float offset = 8;
+ * @return {number}
+ */
+proto.ConfigSkill.prototype.getOffset = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 8, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.ConfigSkill} returns this
+ */
+proto.ConfigSkill.prototype.setOffset = function(value) {
+  return jspb.Message.setProto3FloatField(this, 8, value);
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -273,6 +273,7 @@ defmodule GameClient.Protobuf.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
+  field(:offset, 8, type: :float)
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -273,7 +273,7 @@ defmodule GameClient.Protobuf.ConfigSkill do
   field(:targetting_angle, 5, type: :float, json_name: "targettingAngle")
   field(:targetting_range, 6, type: :float, json_name: "targettingRange")
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
-  field(:offset, 8, type: :float)
+  field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -106,7 +106,7 @@ message ConfigSkill {
   float targetting_angle = 5;
   float targetting_range = 6;
   uint64 stamina_cost = 7;
-  float offset = 8;
+  float targetting_offset = 8;
 }
 
 

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -106,6 +106,7 @@ message ConfigSkill {
   float targetting_angle = 5;
   float targetting_range = 6;
   uint64 stamina_cost = 7;
+  float offset = 8;
 }
 
 


### PR DESCRIPTION
>[!warning]
> This PR should be tested and merged along side [Champions of Mirra #1898](https://github.com/lambdaclass/champions_of_mirra/pull/1898)
  
## Motivation

Send the offset that some skills have before landing a hit. They will be used in the new skill indicators

## Summary of changes

- Added a new attribute to the `ConfigSkill` message in `messages.proto`
- Send the offset in `to_broadcast_skill`
## How to test it?

- Test it with the PR written above check that the offset is being sent (or wail until the feature gets completed)

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
