### PR TITLE
Replace unachivable in game bounty

### DIFF
--- a/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
+++ b/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
@@ -100,13 +100,13 @@
     },
     {
         "config_id": 6,
-        "description": "Receive less than 200 damage",
+        "description": "Heal more than 200 hp",
         "type": "bounty",
         "objective": {
             "type": "damage",
-            "match_tracking_field": "damage_taken",
+            "match_tracking_field": "health_healed",
             "value": 200,
-            "comparison": "lesser_or_equal",
+            "comparison": "greater_or_equal",
             "scope": "day"
         },
         "conditions": [],


### PR DESCRIPTION
## Motivation

The bounty "Receive less than 200 damage" was wrong since it can't be achieve inside of a match, and we want to be able to display a notification when you completed a bounty in game so we'll replace it

## Summary of changes

- Replaced bounty and created other one

## How to test it?

- Start the backend with `make start` or run `GameBackend.CurseOfMirra.Config.import_quest_descriptions_config` so you get the bounties updated
- Start a match and pick that bounty
- Complete the bounty
- Your user should receive some currencies

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
