### PR TITLE
[GH-767] Fix items and power ups spawning outside of the map

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1552,24 +1552,15 @@ defmodule Arena.GameUpdater do
       name: "Circle 1"
     }
 
-    entities_to_collide_with =
+    static_obstacles =
       Map.filter(obstacles, fn {_obstacle_id, obstacle} -> obstacle.aditional_info.type == "static" end)
-      |> Map.merge(%{external_wall.id => external_wall})
 
-    external_wall_id = external_wall.id
-
-    case Physics.check_collisions(circle, entities_to_collide_with) do
-      [^external_wall_id | []] ->
-        circle.position
-
-      _ ->
-        Physics.get_closest_available_position(
-          circle.position,
-          circle,
-          external_wall,
-          entities_to_collide_with
-        )
-    end
+    Physics.get_closest_available_position(
+      circle.position,
+      circle,
+      external_wall,
+      static_obstacles
+    )
   end
 
   defp update_visible_players(%{players: players, bushes: bushes} = game_state, game_config) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1553,7 +1553,7 @@ defmodule Arena.GameUpdater do
     }
 
     static_obstacles =
-      Map.filter(obstacles, fn {_obstacle_id, obstacle} -> obstacle.aditional_info.type == "static" end)
+      Map.filter(obstacles, fn {_obstacle_id, obstacle} -> obstacle.aditional_info.collisionable end)
 
     Physics.get_closest_available_position(
       circle.position,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1552,14 +1552,14 @@ defmodule Arena.GameUpdater do
       name: "Circle 1"
     }
 
-    static_obstacles =
+    collisionable_obstacles =
       Map.filter(obstacles, fn {_obstacle_id, obstacle} -> obstacle.aditional_info.collisionable end)
 
     Physics.get_closest_available_position(
       circle.position,
       circle,
       external_wall,
-      static_obstacles
+      collisionable_obstacles
     )
   end
 


### PR DESCRIPTION
## Motivation

When we spawned an item or a power up they could spawn a little bit outside of the map boundaries so you can't pick them up.
This was due to our random position generation solving the position only if it's outside of the map, even if the majority of the area is outside of it 

Closes #767

## Summary of changes

- Always resolver collision when generating random positions instead of checking map inclussion

## How to test it?

Start a match and kill some players close to the map boundaries, every power up should spawn in a pickupeable position, the same should happen to items

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
