### PR TITLE
Active Valtimer in seeds

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -282,7 +282,7 @@ uma_params = %{
 
 valtimer_params = %{
   name: "valtimer",
-  active: false,
+  active: true,
   base_speed: 0.68,
   base_size: 100.0,
   base_health: 400,


### PR DESCRIPTION
## Motivation

Bots weren't choosing Valtimer in local matches.

## Summary of changes

[Active Valtimer in seeds](https://github.com/lambdaclass/mirra_backend/commit/edde555ce16c12c82ae5003fc4f01664a2a1e709)

## How to test it?

Reset the DB then play a match in localhost. Bots should be able to pick Valtimer.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
