### PR TITLE
Only display visible players in game client

### DIFF
--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -54,17 +54,25 @@ export const BoardGame = function () {
 
     window.addEventListener("phx:updateEntities", (e) => {
       // Updates every entity's info and position, and creates it if it doesn't exist
+      let selfBackEntity = Array.from(e.detail.entities).find((backEntity) => backEntity.id == e.detail.player_id)
+
       Array.from(e.detail.entities).forEach((backEntity) => {
-        if (!entities.has(backEntity.id)) {
-          let newEntity = this.createEntity(backEntity);
+        if (Array.from(selfBackEntity.visible_players).includes(backEntity.id) || backEntity.category != "player" || backEntity.id == e.detail.player_id) {
+          if (!entities.has(backEntity.id)) {
+            let newEntity = this.createEntity(backEntity);
 
-          container.addChild(newEntity.boardObject);
-          entities.set(backEntity.id, newEntity);
+            container.addChild(newEntity.boardObject);
+            entities.set(backEntity.id, newEntity);
+          }
+          let entity = entities.get(backEntity.id);
+          this.updateEntityColor(entity, backEntity.is_colliding, backEntity);
+
+          this.updateEntityPosition(entity, backEntity.x, backEntity.y);
+        } else {
+          let toRemoveEntity = entities.get(backEntity.id)
+          container.removeChild(toRemoveEntity.boardObject)
+          entities.delete(backEntity.id)
         }
-        let entity = entities.get(backEntity.id);
-        this.updateEntityColor(entity, backEntity.is_colliding, backEntity);
-
-        this.updateEntityPosition(entity, backEntity.x, backEntity.y);
       });
     });
 

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -57,7 +57,7 @@ export const BoardGame = function () {
       let selfBackEntity = Array.from(e.detail.entities).find((backEntity) => backEntity.id == e.detail.player_id)
 
       Array.from(e.detail.entities).forEach((backEntity) => {
-        if (Array.from(selfBackEntity.visible_players).includes(backEntity.id) || backEntity.category != "player" || backEntity.id == e.detail.player_id) {
+        if (Array.from(selfBackEntity.visible_players).includes(backEntity.id) || backEntity.category != "player" || backEntity.id === e.detail.player_id) {
           if (!entities.has(backEntity.id)) {
             let newEntity = this.createEntity(backEntity);
 
@@ -68,7 +68,7 @@ export const BoardGame = function () {
           this.updateEntityColor(entity, backEntity.is_colliding, backEntity);
 
           this.updateEntityPosition(entity, backEntity.x, backEntity.y);
-        } else {
+        } else if (entities.has(backEntity.id)) {
           let toRemoveEntity = entities.get(backEntity.id)
           container.removeChild(toRemoveEntity.boardObject)
           entities.delete(backEntity.id)
@@ -240,6 +240,9 @@ export const BoardGame = function () {
             color = colors.crate;
             break;
           case "trap":
+            color = colors.trap;
+            break;
+          case "bush":
             color = colors.trap;
             break;
         }

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -25,7 +25,8 @@ export const BoardGame = function () {
     projectile: 0x0000ff,
     item: 0x238636,
     trap: 0x6600cc,
-    crate: 0xcc9900
+    crate: 0xcc9900,
+    bush: 0x9DE7CA
   };
   let player_id;
 
@@ -243,7 +244,7 @@ export const BoardGame = function () {
             color = colors.trap;
             break;
           case "bush":
-            color = colors.trap;
+            color = colors.bush;
             break;
         }
       }

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -70,7 +70,13 @@ defmodule GameClientWeb.BoardLive.Show do
 
   defp player_name(player_id), do: "P#{player_id}"
 
-  defp handle_game_event({:joined, _joined_info}, socket) do
+  defp handle_game_event({:joined, joined_info}, socket) do
+    socket =
+      assign(
+        socket,
+        game_player_id: joined_info.player_id
+      )
+
     {:noreply, socket}
   end
 
@@ -88,7 +94,7 @@ defmodule GameClientWeb.BoardLive.Show do
       ])
       |> Enum.map(&transform_entity_entry/1)
 
-    {:noreply, push_event(socket, "updateEntities", %{entities: entities})}
+    {:noreply, push_event(socket, "updateEntities", %{entities: entities, player_id: socket.assigns.game_player_id})}
   end
 
   defp handle_game_event({:finished, finished_event}, socket) do
@@ -118,6 +124,23 @@ defmodule GameClientWeb.BoardLive.Show do
       coords: entity.vertices |> Enum.map(fn vertex -> [vertex.x / 5, vertex.y / 5] end),
       is_colliding: entity.collides_with |> Enum.any?(),
       status: aditional_info.status
+    }
+  end
+
+  defp transform_entity_entry({_entity_id, %{category: "player"} = entity}) do
+    {_, aditional_info} = entity.aditional_info
+
+    %{
+      id: entity.id,
+      category: entity.category,
+      shape: entity.shape,
+      name: entity.name,
+      x: entity.position.x / 5 + 1000,
+      y: entity.position.y / 5 + 1000,
+      radius: entity.radius / 5,
+      coords: entity.vertices |> Enum.map(fn vertex -> [vertex.x / 5, vertex.y / 5] end),
+      is_colliding: entity.collides_with |> Enum.any?(),
+      visible_players: aditional_info.visible_players
     }
   end
 


### PR DESCRIPTION
## Motivation

We already have the bushes feature developed in the backend but we don't have a visual representation of it, making debug them really hard, this pr will change the browser game client to hide players when they are inside bush and the conditions for them to be invisible are met.
If you want to read about the bush behavior in depth you can read the description of #414 

## Summary of changes

- Only display visible players in game client

## How to test it?

Follow the how to test on this pr #414 , but this time instead of an inspect check the game client

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
