### PR TITLE
Multiple matchmaking queues

### DIFF
--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -14,7 +14,7 @@ defmodule Arena.Application do
       # Start the Finch HTTP client for sending emails
       {Finch, name: Arena.Finch},
       # Start game launcher genserver
-      Arena.GameLauncher,
+      Arena.Matchmaking.GameLauncher,
       Arena.GameBountiesFetcher,
       Arena.GameTracker,
       Arena.Authentication.GatewaySigner,

--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -15,6 +15,7 @@ defmodule Arena.Application do
       {Finch, name: Arena.Finch},
       # Start game launcher genserver
       Arena.Matchmaking.GameLauncher,
+      Arena.Matchmaking.PairMode,
       Arena.GameBountiesFetcher,
       Arena.GameTracker,
       Arena.Authentication.GatewaySigner,

--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -16,6 +16,7 @@ defmodule Arena.Application do
       # Start game launcher genserver
       Arena.Matchmaking.GameLauncher,
       Arena.Matchmaking.PairMode,
+      Arena.Matchmaking.QuickGameMode,
       Arena.GameBountiesFetcher,
       Arena.GameTracker,
       Arena.Authentication.GatewaySigner,

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -3,7 +3,7 @@ defmodule Arena.Matchmaking do
   Module that handles matchmaking queues
   """
 
-  def get_queue("battle-royal"), do: Arena.Matchmaking.GameLauncher
+  def get_queue("battle-royale"), do: Arena.Matchmaking.GameLauncher
   def get_queue("pair"), do: Arena.Matchmaking.PairMode
   def get_queue("quick-game"), do: Arena.Matchmaking.QuickGameMode
   def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -4,5 +4,6 @@ defmodule Arena.Matchmaking do
   """
 
   def get_queue("battle-royal"), do: Arena.Matchmaking.GameLauncher
+  def get_queue("pair"), do: Arena.Matchmaking.PairMode
   def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher
 end

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -5,5 +5,6 @@ defmodule Arena.Matchmaking do
 
   def get_queue("battle-royal"), do: Arena.Matchmaking.GameLauncher
   def get_queue("pair"), do: Arena.Matchmaking.PairMode
+  def get_queue("quick-game"), do: Arena.Matchmaking.QuickGameMode
   def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher
 end

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -3,6 +3,6 @@ defmodule Arena.Matchmaking do
   Module that handles matchmaking queues
   """
 
-  def get_queue("battle-royal"), do: Arena.GameLauncher
-  def get_queue(:undefined), do: Arena.GameLauncher
+  def get_queue("battle-royal"), do: Arena.Matchmaking.GameLauncher
+  def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher
 end

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -1,0 +1,8 @@
+defmodule Arena.Matchmaking do
+  @moduledoc """
+  Module that handles matchmaking queues
+  """
+
+  def get_queue("battle-royal"), do: Arena.GameLauncher
+  def get_queue(:undefined), do: Arena.GameLauncher
+end

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -1,4 +1,4 @@
-defmodule Arena.GameLauncher do
+defmodule Arena.Matchmaking.GameLauncher do
   @moduledoc false
   alias Arena.Utils
   alias Ecto.UUID

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -31,10 +31,6 @@ defmodule Arena.Matchmaking.GameLauncher do
     GenServer.call(__MODULE__, {:join, client_id, character_name, player_name})
   end
 
-  def join_quick_game(client_id, character_name, player_name) do
-    GenServer.call(__MODULE__, {:join_quick_game, client_id, character_name, player_name})
-  end
-
   def leave(client_id) do
     GenServer.call(__MODULE__, {:leave, client_id})
   end
@@ -61,16 +57,6 @@ defmodule Arena.Matchmaking.GameLauncher do
   def handle_call({:leave, client_id}, _, state) do
     clients = Enum.reject(state.clients, fn {id, _, _, _} -> id == client_id end)
     {:reply, :ok, %{state | clients: clients}}
-  end
-
-  @impl true
-  def handle_call({:join_quick_game, client_id, character_name, player_name}, {from_pid, _}, state) do
-    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{
-      bots_enabled: false,
-      zone_enabled: false
-    })
-
-    {:reply, :ok, state}
   end
 
   @impl true

--- a/apps/arena/lib/arena/matchmaking/pair_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/pair_mode.ex
@@ -1,0 +1,158 @@
+defmodule Arena.Matchmaking.PairMode do
+  @moduledoc false
+  alias Arena.Utils
+  alias Ecto.UUID
+
+  use GenServer
+
+  # Time to wait to start game with any amount of clients
+  @start_timeout_ms 10_000
+  # The available names for bots to enter a match, we should change this in the future
+  @bot_names [
+    "TheBlackSwordman",
+    "SlashJava",
+    "SteelBallRun",
+    "Jeff",
+    "Messi",
+    "Stone Ocean",
+    "Jeepers Creepers",
+    "Bob",
+    "El javo",
+    "Alberso",
+    "Thomas"
+  ]
+
+  # API
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def join(client_id, character_name, player_name) do
+    GenServer.call(__MODULE__, {:join, client_id, character_name, player_name})
+  end
+
+  def join_quick_game(client_id, character_name, player_name) do
+    GenServer.call(__MODULE__, {:join_quick_game, client_id, character_name, player_name})
+  end
+
+  def leave(client_id) do
+    GenServer.call(__MODULE__, {:leave, client_id})
+  end
+
+  # Callbacks
+  @impl true
+  def init(_) do
+    Process.send_after(self(), :launch_game?, 300)
+    {:ok, %{clients: [], batch_start_at: 0}}
+  end
+
+  @impl true
+  def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, %{clients: clients} = state) do
+    batch_start_at = maybe_make_batch_start_at(state.clients, state.batch_start_at)
+
+    {:reply, :ok,
+     %{
+       state
+       | batch_start_at: batch_start_at,
+         clients: clients ++ [{client_id, character_name, player_name, from_pid}]
+     }}
+  end
+
+  def handle_call({:leave, client_id}, _, state) do
+    clients = Enum.reject(state.clients, fn {id, _, _, _} -> id == client_id end)
+    {:reply, :ok, %{state | clients: clients}}
+  end
+
+  @impl true
+  def handle_call({:join_quick_game, client_id, character_name, player_name}, {from_pid, _}, state) do
+    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{
+      bots_enabled: false,
+      zone_enabled: false
+    })
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:launch_game?, %{clients: clients} = state) do
+    Process.send_after(self(), :launch_game?, 300)
+    diff = System.monotonic_time(:millisecond) - state.batch_start_at
+
+    if length(clients) >= Application.get_env(:arena, :players_needed_in_match) or
+         (diff >= @start_timeout_ms and length(clients) > 0) do
+      send(self(), :start_game)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(:start_game, state) do
+    {game_clients, remaining_clients} = Enum.split(state.clients, Application.get_env(:arena, :players_needed_in_match))
+    create_game_for_clients(game_clients)
+
+    {:noreply, %{state | clients: remaining_clients}}
+  end
+
+  def handle_info({:spawn_bot_for_player, bot_client, game_id}, state) do
+    spawn(fn ->
+      Finch.build(:get, Utils.get_bot_connection_url(game_id, bot_client))
+      |> Finch.request(Arena.Finch)
+    end)
+
+    {:noreply, state}
+  end
+
+  defp maybe_make_batch_start_at([], _) do
+    System.monotonic_time(:millisecond)
+  end
+
+  defp maybe_make_batch_start_at([_ | _], batch_start_at) do
+    batch_start_at
+  end
+
+  defp get_bot_clients(missing_clients) do
+    characters =
+      Arena.Configuration.get_game_config()
+      |> Map.get(:characters)
+      |> Enum.filter(fn character -> character.active end)
+
+    Enum.map(1..missing_clients//1, fn i ->
+      client_id = UUID.generate()
+
+      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+    end)
+  end
+
+  defp spawn_bot_for_player(bot_clients, game_id) do
+    Enum.each(bot_clients, fn {bot_client, _, _, _} ->
+      send(self(), {:spawn_bot_for_player, bot_client, game_id})
+    end)
+  end
+
+  # Receives a list of clients.
+  # Fills the given list with bots clients, creates a game and tells every client to join that game.
+  defp create_game_for_clients(clients, game_params \\ %{}) do
+    bot_clients =
+      if Application.get_env(:arena, :spawn_bots) do
+        get_bot_clients(Application.get_env(:arena, :players_needed_in_match) - Enum.count(clients))
+      else
+        []
+      end
+
+    {:ok, game_pid} =
+      GenServer.start(Arena.GameUpdater, %{
+        clients: clients,
+        bot_clients: bot_clients,
+        game_params: game_params
+      })
+
+    game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()
+
+    spawn_bot_for_player(bot_clients, game_id)
+
+    Enum.each(clients, fn {_client_id, _character_name, _player_name, from_pid} ->
+      Process.send(from_pid, {:join_game, game_id}, [])
+      Process.send(from_pid, :leave_waiting_game, [])
+    end)
+  end
+end

--- a/apps/arena/lib/arena/matchmaking/pair_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/pair_mode.ex
@@ -31,10 +31,6 @@ defmodule Arena.Matchmaking.PairMode do
     GenServer.call(__MODULE__, {:join, client_id, character_name, player_name})
   end
 
-  def join_quick_game(client_id, character_name, player_name) do
-    GenServer.call(__MODULE__, {:join_quick_game, client_id, character_name, player_name})
-  end
-
   def leave(client_id) do
     GenServer.call(__MODULE__, {:leave, client_id})
   end
@@ -61,16 +57,6 @@ defmodule Arena.Matchmaking.PairMode do
   def handle_call({:leave, client_id}, _, state) do
     clients = Enum.reject(state.clients, fn {id, _, _, _} -> id == client_id end)
     {:reply, :ok, %{state | clients: clients}}
-  end
-
-  @impl true
-  def handle_call({:join_quick_game, client_id, character_name, player_name}, {from_pid, _}, state) do
-    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{
-      bots_enabled: false,
-      zone_enabled: false
-    })
-
-    {:reply, :ok, state}
   end
 
   @impl true

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -1,0 +1,111 @@
+defmodule Arena.Matchmaking.QuickGameMode do
+  @moduledoc false
+  alias Arena.Utils
+  alias Ecto.UUID
+
+  use GenServer
+
+  # The available names for bots to enter a match, we should change this in the future
+  @bot_names [
+    "TheBlackSwordman",
+    "SlashJava",
+    "SteelBallRun",
+    "Jeff",
+    "Messi",
+    "Stone Ocean",
+    "Jeepers Creepers",
+    "Bob",
+    "El javo",
+    "Alberso",
+    "Thomas"
+  ]
+
+  # API
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def join(client_id, character_name, player_name) do
+    GenServer.call(__MODULE__, {:join, client_id, character_name, player_name})
+  end
+
+  def leave(_client_id) do
+    :noop
+  end
+
+  # Callbacks
+  @impl true
+  def init(_) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, state) do
+    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{bots_enabled: false, zone_enabled: false})
+    {:reply, :ok, state}
+  end
+
+
+  def handle_info(:start_game, state) do
+    {game_clients, remaining_clients} = Enum.split(state.clients, Application.get_env(:arena, :players_needed_in_match))
+    create_game_for_clients(game_clients)
+
+    {:noreply, %{state | clients: remaining_clients}}
+  end
+
+  @impl true
+  def handle_info({:spawn_bot_for_player, bot_client, game_id}, state) do
+    spawn(fn ->
+      Finch.build(:get, Utils.get_bot_connection_url(game_id, bot_client))
+      |> Finch.request(Arena.Finch)
+    end)
+
+    {:noreply, state}
+  end
+
+  defp get_bot_clients(missing_clients) do
+    characters =
+      Arena.Configuration.get_game_config()
+      |> Map.get(:characters)
+      |> Enum.filter(fn character -> character.active end)
+
+    Enum.map(1..missing_clients//1, fn i ->
+      client_id = UUID.generate()
+
+      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+    end)
+  end
+
+  defp spawn_bot_for_player(bot_clients, game_id) do
+    Enum.each(bot_clients, fn {bot_client, _, _, _} ->
+      send(self(), {:spawn_bot_for_player, bot_client, game_id})
+    end)
+  end
+
+  # Receives a list of clients.
+  # Fills the given list with bots clients, creates a game and tells every client to join that game.
+  defp create_game_for_clients(clients, game_params \\ %{}) do
+    bot_clients =
+      if Application.get_env(:arena, :spawn_bots) do
+        get_bot_clients(Application.get_env(:arena, :players_needed_in_match) - Enum.count(clients))
+      else
+        []
+      end
+
+    {:ok, game_pid} =
+      GenServer.start(Arena.GameUpdater, %{
+        clients: clients,
+        bot_clients: bot_clients,
+        game_params: game_params
+      })
+
+    game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()
+
+    spawn_bot_for_player(bot_clients, game_id)
+
+    Enum.each(clients, fn {_client_id, _character_name, _player_name, from_pid} ->
+      Process.send(from_pid, {:join_game, game_id}, [])
+      Process.send(from_pid, :leave_waiting_game, [])
+    end)
+  end
+end

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -41,10 +41,13 @@ defmodule Arena.Matchmaking.QuickGameMode do
 
   @impl true
   def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, state) do
-    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{bots_enabled: false, zone_enabled: false})
+    create_game_for_clients([{client_id, character_name, player_name, from_pid}], %{
+      bots_enabled: false,
+      zone_enabled: false
+    })
+
     {:reply, :ok, state}
   end
-
 
   def handle_info(:start_game, state) do
     {game_clients, remaining_clients} = Enum.split(state.clients, Application.get_env(:arena, :players_needed_in_match))

--- a/apps/arena/lib/arena/quick_game_handler.ex
+++ b/apps/arena/lib/arena/quick_game_handler.ex
@@ -4,7 +4,7 @@ defmodule Arena.QuickGameHandler do
   """
   alias Arena.Authentication.GatewayTokenManager
   alias Arena.Authentication.GatewaySigner
-  alias Arena.GameLauncher
+  alias Arena.Matchmaking.GameLauncher
   alias Arena.Serialization.GameState
   alias Arena.Serialization.JoinedLobby
   alias Arena.Serialization.LobbyEvent

--- a/apps/arena/lib/arena/quick_game_handler.ex
+++ b/apps/arena/lib/arena/quick_game_handler.ex
@@ -2,9 +2,9 @@ defmodule Arena.QuickGameHandler do
   @moduledoc """
   Module that handles cowboy websocket requests
   """
-  alias Arena.Authentication.GatewayTokenManager
   alias Arena.Authentication.GatewaySigner
-  alias Arena.Matchmaking.GameLauncher
+  alias Arena.Authentication.GatewayTokenManager
+  alias Arena.Matchmaking.QuickGameMode
   alias Arena.Serialization.GameState
   alias Arena.Serialization.JoinedLobby
   alias Arena.Serialization.LobbyEvent
@@ -23,7 +23,7 @@ defmodule Arena.QuickGameHandler do
 
   @impl true
   def websocket_init(state) do
-    GameLauncher.join_quick_game(state.client_id, state.character_name, state.player_name)
+    QuickGameMode.join(state.client_id, state.character_name, state.player_name)
 
     joined_msg = LobbyEvent.encode(%LobbyEvent{event: {:joined, %JoinedLobby{}}})
     {:reply, {:binary, joined_msg}, state}

--- a/apps/arena/lib/arena/socket_handler.ex
+++ b/apps/arena/lib/arena/socket_handler.ex
@@ -32,7 +32,14 @@ defmodule Arena.SocketHandler do
     matchmaking_queue = Matchmaking.get_queue(:cowboy_req.binding(:mode, req))
     character_name = :cowboy_req.binding(:character_name, req)
     player_name = :cowboy_req.binding(:player_name, req)
-    {:cowboy_websocket, req, %{client_id: user_id, matchmaking_queue: matchmaking_queue, character_name: character_name, player_name: player_name}}
+
+    {:cowboy_websocket, req,
+     %{
+       client_id: user_id,
+       matchmaking_queue: matchmaking_queue,
+       character_name: character_name,
+       player_name: player_name
+     }}
   end
 
   @impl true

--- a/apps/game_client/assets/js/hooks/game_queue.js
+++ b/apps/game_client/assets/js/hooks/game_queue.js
@@ -22,7 +22,7 @@ export const GameQueue = function () {
 function getQueueSocketUrl(gateway_jwt, player_id, character, player_name, game_mode) {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const host = getHost()
-    return `${protocol}//${host}/${game_mode}/${player_id}/${character}/${player_name}?gateway_jwt=${gateway_jwt}`
+    return `${protocol}//${host}/join/${game_mode}/${player_id}/${character}/${player_name}?gateway_jwt=${gateway_jwt}`
 }
 
 // TODO: This will work for while the Arena is using the default wss port and

--- a/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
+++ b/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
@@ -2,8 +2,9 @@
   <.form :let={f} for={%{}} action={~p"/"}>
     <.input field={f[:character]} name="character" label="Select a Character" type="select" options={["muflus", "h4ck", "uma", "valtimer"]} value=""/>
     <.input field={f[:user_id]} name="user_id" type="hidden" value={assigns[:user_id]}/>
-    <.button type="submit" name="game_mode" value="join">Play</.button>
-    <.button type="submit" name="game_mode" value="quick_game">Quick Game</.button>
+    <.button type="submit" name="game_mode" value="battle-royal">Play Battle Royal</.button>
+    <.button type="submit" name="game_mode" value="pair">Play Pair</.button>
+    <.button type="submit" name="game_mode" value="quick-game">Quick Game</.button>
   </.form>
 
   <p>Logged in as user_id: <%= @current_user_id %></p>

--- a/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
+++ b/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
@@ -2,7 +2,7 @@
   <.form :let={f} for={%{}} action={~p"/"}>
     <.input field={f[:character]} name="character" label="Select a Character" type="select" options={["muflus", "h4ck", "uma", "valtimer"]} value=""/>
     <.input field={f[:user_id]} name="user_id" type="hidden" value={assigns[:user_id]}/>
-    <.button type="submit" name="game_mode" value="battle-royal">Play Battle Royal</.button>
+    <.button type="submit" name="game_mode" value="battle-royale">Play Battle Royal</.button>
     <.button type="submit" name="game_mode" value="pair">Play Pair</.button>
     <.button type="submit" name="game_mode" value="quick-game">Quick Game</.button>
   </.form>

--- a/config/config.exs
+++ b/config/config.exs
@@ -88,9 +88,10 @@ config :joken,
 dispatch = [
   _: [
     {"/play/:game_id/:client_id", Arena.GameSocketHandler, []},
-    {"/join/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
     {"/join/:mode/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
     ## TODO: This can be removed after all clients move to using /join/:mode
+    {"/join/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
+    ## TODO: This and Arena.QuickGameHandler can be removed after all clients move to using /join/:mode
     {"/quick_game/:client_id/:character_name/:player_name", Arena.QuickGameHandler, []},
     {:_, Plug.Cowboy.Handler, {ArenaWeb.Endpoint, []}}
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -90,6 +90,7 @@ dispatch = [
     {"/play/:game_id/:client_id", Arena.GameSocketHandler, []},
     {"/join/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
     {"/join/:mode/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
+    ## TODO: This can be removed after all clients move to using /join/:mode
     {"/quick_game/:client_id/:character_name/:player_name", Arena.QuickGameHandler, []},
     {:_, Plug.Cowboy.Handler, {ArenaWeb.Endpoint, []}}
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -89,6 +89,7 @@ dispatch = [
   _: [
     {"/play/:game_id/:client_id", Arena.GameSocketHandler, []},
     {"/join/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
+    {"/join/:mode/:client_id/:character_name/:player_name", Arena.SocketHandler, []},
     {"/quick_game/:client_id/:character_name/:player_name", Arena.QuickGameHandler, []},
     {:_, Plug.Cowboy.Handler, {ArenaWeb.Endpoint, []}}
   ]


### PR DESCRIPTION
## Motivation

Base to have multiple matchmaking queues

## Summary of changes

- Create `Matchmaking` module to give the module to use for matchmaking (in essence the queue). In a near future we can define the matchmaking behaviour in it to simplify the logic in the others 
- Create 3 different matchmaking queues
  - `BattleRoyalMode` for the regular matchmaking we currently have
  - `QuickGameMode` for matchmaking quick games, only bot matches for testing purposes
  - `PairMode` more an example model, but could be the one we use for 2v2v2... (if we decide on that mode). For now a copy&paste of `BattleRoyalMode`

Important to note that the changes are backwards compatible, so we don't need a PR on the client to be merged at the time. We will use a fallback to go through `BattleRoyalMode` or `QuickGameMode`. After a PR on client side we will be able to remove this fallbacks and the `quick_game_handler.ex` (finally! Only one matchmaking socket implementation)

## How to test it?

Try playing regular and quick games, nothing should change

Try playing some games in Unity and some in game_client, but this time in game_client chose `Play Pair` and notice that you end up in a different match than Unity players playing regular matchmaking

## Checklist
- [x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
