### PR TITLE
[GH-807] - Add name to map's configurations

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -147,6 +147,10 @@ defmodule Arena.Configuration do
   ## The not so small problem we have is that our code expects floats so we still need to parse
   ## the strings, but end up with regular floats
   defp parse_map_config(map_config) do
+    IO.inspect(map_config)
+    ## We're looking to play in random maps
+    map_config = Enum.random(map_config)
+
     %{
       map_config
       | radius: maybe_to_float(map_config.radius),

--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -147,7 +147,6 @@ defmodule Arena.Configuration do
   ## The not so small problem we have is that our code expects floats so we still need to parse
   ## the strings, but end up with regular floats
   defp parse_map_config(map_config) do
-    IO.inspect(map_config)
     ## We're looking to play in random maps
     map_config = Enum.random(map_config)
 

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -211,6 +211,7 @@ defmodule Arena.Serialization.ConfigMap do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
+  field(:name, 2, type: :string)
 end
 
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -226,6 +226,7 @@ defmodule ArenaLoadTest.Serialization.ConfigMap do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
+  field(:name, 2, type: :string)
 end
 
 defmodule ArenaLoadTest.Serialization.ConfigCharacter.SkillsEntry do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -211,6 +211,7 @@ defmodule BotManager.Protobuf.ConfigMap do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
+  field(:name, 2, type: :string)
 end
 
 defmodule BotManager.Protobuf.ConfigCharacter.SkillsEntry do

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
@@ -8,6 +8,7 @@
 </.header>
 
 <.table id="map_configurations" rows={@map_configurations}>
+  <:col :let={map_configuration} label="name"><%= map_configuration.name %></:col>
   <:col :let={map_configuration} label="Radius"><%= map_configuration.radius %></:col>
   <:col :let={map_configuration} label="Initial positions">
     <%= if (Enum.empty?(map_configuration.initial_positions)) do %>

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
@@ -2,6 +2,7 @@
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
+  <.input field={f[:name]} type="text" label="Name" step="any" />
   <.input field={f[:radius]} type="number" label="Radius" step="any" />
   <.input
     field={f[:initial_positions]}

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
@@ -2,7 +2,7 @@
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
-  <.input field={f[:name]} type="text" label="Name" step="any" />
+  <.input field={f[:name]} type="text" label="Name" />
   <.input field={f[:radius]} type="number" label="Radius" step="any" />
   <.input
     field={f[:initial_positions]}

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Map configuration <%= @map_configuration.id %>
+  Map configuration <%= @map_configuration.name %>
   <:subtitle>This is a Map Configuration record from your database.</:subtitle>
   <:actions>
     <.link href={~p"/map_configurations/#{@map_configuration}/edit"}>

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
@@ -10,6 +10,10 @@
 
 <div class="flex flex-col gap-5">
   <div class="flex gap-5 py-4 border-b-2 items-center">
+    <dt>Map name</dt>
+    <dd><%= @map_configuration.name %></dd>
+  </div>
+  <div class="flex gap-5 py-4 border-b-2 items-center">
     <dt>Map Radius</dt>
     <dd><%= @map_configuration.radius %></dd>
   </div>

--- a/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
@@ -5,9 +5,9 @@ defmodule ConfiguratorWeb.MapConfigurationControllerTest do
   import Configurator.AccountsFixtures
   setup [:create_authenticated_conn]
 
-  @create_attrs %{radius: "120.5", initial_positions: "", obstacles: "", bushes: ""}
-  @update_attrs %{radius: "456.7", initial_positions: "", obstacles: "", bushes: ""}
-  @invalid_attrs %{radius: nil, initial_positions: nil, obstacles: nil, bushes: nil}
+  @create_attrs %{name: "some_map", radius: "120.5", initial_positions: "", obstacles: "", bushes: ""}
+  @update_attrs %{name: "another_map", radius: "456.7", initial_positions: "", obstacles: "", bushes: ""}
+  @invalid_attrs %{name: nil, radius: nil, initial_positions: nil, obstacles: nil, bushes: nil}
 
   describe "index" do
     test "lists all map_configurations", %{conn: conn} do
@@ -31,7 +31,7 @@ defmodule ConfiguratorWeb.MapConfigurationControllerTest do
       assert redirected_to(conn) == ~p"/map_configurations/#{id}"
 
       conn = get(conn, ~p"/map_configurations/#{id}")
-      assert html_response(conn, 200) =~ "Map configuration #{id}"
+      assert html_response(conn, 200) =~ "Map configuration #{@create_attrs.name}"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do

--- a/apps/game_backend/lib/game_backend/configuration.ex
+++ b/apps/game_backend/lib/game_backend/configuration.ex
@@ -206,14 +206,4 @@ defmodule GameBackend.Configuration do
   def change_map_configuration(%MapConfiguration{} = map_configuration, attrs \\ %{}) do
     MapConfiguration.changeset(map_configuration, attrs)
   end
-
-  @doc """
-  Gets the latest map configuration
-  ## Examples
-      iex> get_latest_map_configuration()
-      %MapConfiguration{}
-  """
-  def get_latest_map_configuration do
-    Repo.one(from(m in MapConfiguration, order_by: [desc: m.inserted_at], limit: 1))
-  end
 end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
@@ -5,8 +5,9 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
   use GameBackend.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:radius, :initial_positions, :obstacles, :bushes]}
+  @derive {Jason.Encoder, only: [:name, :radius, :initial_positions, :obstacles, :bushes]}
   schema "map_configurations" do
+    field(:name, :string)
     field(:radius, :decimal)
 
     embeds_many(:initial_positions, __MODULE__.Position, on_replace: :delete)
@@ -19,7 +20,7 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
   @doc false
   def changeset(map_configuration, attrs) do
     map_configuration
-    |> cast(attrs, [:radius])
+    |> cast(attrs, [:radius, :name])
     |> validate_required([:radius])
     |> cast_embed(:initial_positions)
     |> cast_embed(:obstacles)

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
@@ -25,6 +25,7 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
     |> cast_embed(:initial_positions)
     |> cast_embed(:obstacles)
     |> cast_embed(:bushes)
+    |> unique_constraint(:name)
   end
 
   defmodule Position do

--- a/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
+++ b/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
@@ -5,5 +5,7 @@ defmodule GameBackend.Repo.Migrations.AddNameToTheMap do
     alter table(:map_configurations) do
       add :name, :string
     end
+
+    execute("UPDATE map_configurations SET name = 'Araban'")
   end
 end

--- a/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
+++ b/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
@@ -6,6 +6,6 @@ defmodule GameBackend.Repo.Migrations.AddNameToTheMap do
       add :name, :string
     end
 
-    execute("UPDATE map_configurations SET name = 'Araban'")
+    execute("UPDATE map_configurations SET name = 'Araban'",   "")
   end
 end

--- a/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
+++ b/apps/game_backend/priv/repo/migrations/20240725215038_add_name_to_the_map.exs
@@ -1,0 +1,9 @@
+defmodule GameBackend.Repo.Migrations.AddNameToTheMap do
+  use Ecto.Migration
+
+  def change do
+    alter table(:map_configurations) do
+      add :name, :string
+    end
+  end
+end

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -3634,7 +3634,8 @@ proto.ConfigMap.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigMap.toObject = function(includeInstance, msg) {
   var f, obj = {
-    radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0)
+    radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
+    name: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -3675,6 +3676,10 @@ proto.ConfigMap.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {number} */ (reader.readFloat());
       msg.setRadius(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setName(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3711,6 +3716,13 @@ proto.ConfigMap.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
+  f = message.getName();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
 };
 
 
@@ -3729,6 +3741,24 @@ proto.ConfigMap.prototype.getRadius = function() {
  */
 proto.ConfigMap.prototype.setRadius = function(value) {
   return jspb.Message.setProto3FloatField(this, 1, value);
+};
+
+
+/**
+ * optional string name = 2;
+ * @return {string}
+ */
+proto.ConfigMap.prototype.getName = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.ConfigMap} returns this
+ */
+proto.ConfigMap.prototype.setName = function(value) {
+  return jspb.Message.setProto3StringField(this, 2, value);
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -211,6 +211,7 @@ defmodule GameClient.Protobuf.ConfigMap do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field(:radius, 1, type: :float)
+  field(:name, 2, type: :string)
 end
 
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do

--- a/apps/gateway/lib/gateway/controllers/curse_of_mirra/configuration_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/curse_of_mirra/configuration_controller.ex
@@ -23,13 +23,14 @@ defmodule Gateway.Controllers.CurseOfMirra.ConfigurationController do
     end
   end
 
+  @spec get_game_configuration(Plug.Conn.t(), any()) :: Plug.Conn.t()
   def get_game_configuration(conn, _params) do
     game_configuration = Configuration.get_latest_game_configuration()
     send_resp(conn, 200, Jason.encode!(game_configuration))
   end
 
-  def get_map_configuration(conn, _params) do
-    map_configuration = Configuration.get_latest_map_configuration()
+  def get_map_configurations(conn, _params) do
+    map_configuration = Configuration.list_map_configurations()
     send_resp(conn, 200, Jason.encode!(map_configuration))
   end
 

--- a/apps/gateway/lib/gateway/router.ex
+++ b/apps/gateway/lib/gateway/router.ex
@@ -19,10 +19,7 @@ defmodule Gateway.Router do
       get "/game", ConfigurationController, :get_game_configuration
       get "/characters", ConfigurationController, :get_characters_configuration
       get "/consumable_items", ConfigurationController, :get_consumable_items_configuration
-    end
-
-    scope "/configuration" do
-      get "/map", ConfigurationController, :get_map_configuration
+      get "/map", ConfigurationController, :get_map_configurations
     end
 
     scope "/stores" do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -78,6 +78,7 @@ message ConfigGame {
 
 message ConfigMap {
   float radius = 1;
+  string name = 2;
 }
 
 message ConfigCharacter {

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -690,6 +690,7 @@ giant_fruit_params = %{
   GameBackend.Items.create_consumable_item(giant_fruit_params)
 
 map_config = %{
+  name: "Araban",
   radius: 5520.0,
   initial_positions: [
     %{


### PR DESCRIPTION
> [!warning]
> Merge alongside [this client PR](https://github.com/lambdaclass/champions_of_mirra/pull/1996)

## Motivation

Differentiate map's by name and pick a map random amongst them all.

Closes #807 

## Summary of changes

- [Add map's name to messages.proto](https://github.com/lambdaclass/mirra_backend/commit/eea9d24d11aa66fa9feef22d425a58435264ebad)
- [Add map's name to map schema](https://github.com/lambdaclass/mirra_backend/commit/65cf169878aae32abf2a274797777c8c7b552dd1)
- [Refactor configurator map endpoint's logic to return all maps since the client is going to pick a random one among them](https://github.com/lambdaclass/mirra_backend/commit/d0bb346922b73c7ec9378a4e879eb2ebcaf8397d)
- [Allow to edit and add name to map configurations. Also display map's name in views](https://github.com/lambdaclass/mirra_backend/pull/808/commits/db78739b5e228a842d22f568c8890bfeaf8e9214)
## How to test it?

Two ways:

1. Doing a Curl
    - `curl -X GET  http://localhost:4001/curse/configuration/map` And you'll receive a list of maps (ba dum tss)

2. Playing
   - Add this line of code `Debug.Log(GameServerConnectionManager.Instance.config.Map);` in `client/Assets/Scripts/CustomLevelManager.cs:50`
   - Start a game a you'll see in Unity's shell the map's name 

## Checklist
- [x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
