### PR TITLE
Add bush struct to map configuration

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -151,7 +151,8 @@ defmodule Arena.Configuration do
       map_config
       | radius: maybe_to_float(map_config.radius),
         initial_positions: Enum.map(map_config.initial_positions, &parse_position/1),
-        obstacles: Enum.map(map_config.obstacles, &parse_obstacle/1)
+        obstacles: Enum.map(map_config.obstacles, &parse_obstacle/1),
+        bushes: Enum.map(map_config.bushes, &parse_bush/1)
     }
   end
 
@@ -162,6 +163,15 @@ defmodule Arena.Configuration do
         vertices: Enum.map(obstacle.vertices, &parse_position/1),
         radius: maybe_to_float(obstacle.radius),
         statuses_cycle: parse_status_cycle(obstacle.statuses_cycle)
+    }
+  end
+
+  defp parse_bush(bush) do
+    %{
+      bush
+      | position: parse_position(bush.position),
+        vertices: Enum.map(bush.vertices, &parse_position/1),
+        radius: maybe_to_float(bush.radius)
     }
   end
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -40,6 +40,7 @@ defmodule Arena.Entities do
         natural_healing_interval: character.natural_healing_interval,
         last_damage_received: now,
         last_skill_triggered: now,
+        last_skill_triggered_inside_bush: now,
         natural_healing_damage_interval: character.natural_healing_damage_interval,
         character_name: character.name,
         forced_movement: false,

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -237,6 +237,13 @@ defmodule Arena.Game.Player do
           |> apply_skill_cooldown(skill_key, skill)
           |> maybe_face_player_towards_direction(skill_direction, skill.block_movement)
           |> put_in([:aditional_info, :last_skill_triggered], System.monotonic_time(:millisecond))
+          |> update_in([:aditional_info, :last_skill_triggered_inside_bush], fn last_skill_triggered_inside_bush ->
+            if player.aditional_info.on_bush do
+              System.monotonic_time(:millisecond)
+            else
+              last_skill_triggered_inside_bush
+            end
+          end)
 
         put_in(game_state, [:players, player.id], player)
         |> maybe_make_player_invincible(player.id, skill)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1643,6 +1643,8 @@ defmodule Arena.GameUpdater do
   end
 
   defp update_visible_players(%{players: players, bushes: bushes} = game_state, game_config) do
+    now = System.monotonic_time(:millisecond)
+
     Enum.reduce(players, game_state, fn {player_id, player}, game_state ->
       bush_collisions =
         Enum.filter(player.collides_with, fn collided_id ->
@@ -1664,7 +1666,12 @@ defmodule Arena.GameUpdater do
             Physics.distance_between_entities(player, candidate_player) <=
               game_config.game.field_of_view_inside_bush
 
-          if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) do
+          enough_time_since_last_skill? =
+            now - candidate_player.aditional_info.last_skill_triggered_inside_bush <
+              game_config.game.time_visible_in_bush_after_skill
+
+          if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) or
+               enough_time_since_last_skill? do
             [candicandidate_player_id | acc]
           else
             acc

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -21,6 +21,7 @@
   <.input field={f[:bots_enabled]} type="checkbox" label="Bots enabled" />
   <.input field={f[:zone_enabled]} type="checkbox" label="Zone enabled" />
   <.input field={f[:field_of_view_inside_bush]} type="number" label="Field of view inside bush" />
+  <.input field={f[:time_visible_in_bush_after_skill]} type="number" label="Field of view inside bush" />
 
   <:actions>
     <.button>Save Game configuration</.button>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
@@ -35,6 +35,9 @@
   <:col :let={game_configuration} label="Field of view inside bush">
     <%= game_configuration.field_of_view_inside_bush %>
   </:col>
+  <:col :let={game_configuration} label="Time Visible After performing skill inside of bush">
+    <%= game_configuration.time_visible_in_bush_after_skill %>
+  </:col>
 
   <:action :let={game_configuration}>
     <div class="sr-only">

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
@@ -28,6 +28,9 @@
   <:item title="Bounties options amount"><%= @game_configuration.bounties_options_amount %></:item>
   <:item title="Match timeout ms"><%= @game_configuration.match_timeout_ms %></:item>
   <:item title="Field of view inside bush"><%= @game_configuration.field_of_view_inside_bush %></:item>
+  <:item title="Time Visible After performing skill inside of bush">
+    <%= @game_configuration.time_visible_in_bush_after_skill %>
+  </:item>
 </.list>
 
 <.back navigate={~p"/game_configurations"}>Back to game_configurations</.back>

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
@@ -24,7 +24,8 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     :zone_enabled,
     :bounties_options_amount,
     :match_timeout_ms,
-    :field_of_view_inside_bush
+    :field_of_view_inside_bush,
+    :time_visible_in_bush_after_skill
   ]
 
   @derive {Jason.Encoder, only: @required}
@@ -48,6 +49,7 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     field(:bounties_options_amount, :integer)
     field(:match_timeout_ms, :integer)
     field(:field_of_view_inside_bush, :integer)
+    field(:time_visible_in_bush_after_skill, :integer)
 
     timestamps()
   end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
@@ -11,7 +11,7 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
 
     embeds_many(:initial_positions, __MODULE__.Position, on_replace: :delete)
     embeds_many(:obstacles, __MODULE__.Obstacle, on_replace: :delete)
-    embeds_many(:bushes, __MODULE__.Position, on_replace: :delete)
+    embeds_many(:bushes, __MODULE__.Bush, on_replace: :delete)
 
     timestamps(type: :utc_datetime)
   end
@@ -69,6 +69,30 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
       |> cast_embed(:position)
       |> cast_embed(:vertices)
       |> validate_required([:name, :position, :radius, :shape, :type])
+    end
+  end
+
+  defmodule Bush do
+    @moduledoc """
+    Bush embedded schema to be used by MapConfiguration
+    """
+    use GameBackend.Schema
+
+    @derive {Jason.Encoder, only: [:name, :position, :radius, :shape, :vertices]}
+    embedded_schema do
+      field(:name, :string)
+      field(:radius, :decimal)
+      field(:shape, :string)
+      embeds_one(:position, Position)
+      embeds_many(:vertices, Position)
+    end
+
+    def changeset(position, attrs) do
+      position
+      |> cast(attrs, [:name, :radius, :shape])
+      |> cast_embed(:position)
+      |> cast_embed(:vertices)
+      |> validate_required([:name, :position, :radius, :shape])
     end
   end
 end

--- a/apps/game_backend/priv/repo/migrations/20240802143236_add_time_visible_in_bush_after_skill.exs
+++ b/apps/game_backend/priv/repo/migrations/20240802143236_add_time_visible_in_bush_after_skill.exs
@@ -1,0 +1,11 @@
+defmodule GameBackend.Repo.Migrations.AddTimeVisibleInBushAfterSkill do
+  use Ecto.Migration
+
+  def change do
+    alter table(:game_configurations) do
+      add :time_visible_in_bush_after_skill, :integer
+    end
+
+    execute("UPDATE game_configurations SET time_visible_in_bush_after_skill = 2000 WHERE time_visible_in_bush_after_skill IS NULL ",   "")
+  end
+end

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -102,11 +102,7 @@ defmodule GameClientWeb.BoardLive.Show do
     {:noreply, assign(socket, game_status: :finished, winner_id: finished_event.winner.id)}
   end
 
-  defp handle_game_event({:ping, ping_event}, socket) do
-    {:noreply, assign(socket, :ping_latency, ping_event.latency)}
-  end
-
-  defp handle_game_event({noop_event, _}, socket) when noop_event in [:toggle_bots] do
+  defp handle_game_event({noop_event, _}, socket) when noop_event in [:toggle_bots, :ping, :ping_update] do
     {:noreply, socket}
   end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1871,7 +1871,93 @@ map_config = %{
       ]
     }
   ],
-  bushes: []
+  bushes: [
+    # %{
+    #   name: "central bush",
+    #   position: %{
+    #     x: 0.0,
+    #     y: 0.0
+    #   },
+    #   vertices: [
+    #     %{
+    #       x: 0.0,
+    #       y: 1000.0
+    #     },
+    #     %{
+    #       x: 1000.0,
+    #       y: 0.0
+    #     },
+    #     %{
+    #       x: 0.0,
+    #       y: -1000.0
+    #     },
+    #     %{
+    #       x: -1000.0,
+    #       y: 0.0
+    #     }
+    #   ],
+    #   radius: 0.0,
+    #   shape: "polygon"
+    # },
+    %{
+      name: "bottom left cave bushes",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      vertices: [
+        %{
+          x: -1975.0,
+          y: -2015.0
+        },
+        %{
+          x: -2858.0,
+          y: -2023.0
+        },
+        %{
+          x: -3427.0,
+          y: -1306.0
+        },
+        %{
+          x: -3423.0,
+          y: -204.0
+        },
+        %{
+          x: -3170.0,
+          y: 7.0
+        }
+      ],
+      radius: 0.0,
+      shape: "polygon"
+    },
+    %{
+      name: "top right cave bushes",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      vertices: [
+        %{
+          x: 951.0,
+          y: 2881.0
+        },
+        %{
+          x: 1791.0,
+          y: 3176.0
+        },
+        %{
+          x: 2806.0,
+          y: 2050.0
+        },
+        %{
+          x: 2550.0,
+          y: 1384.0
+        },
+      ],
+      radius: 0.0,
+      shape: "polygon"
+    }
+  ]
 }
 
 {:ok, _map_configuration_1} = GameBackend.Configuration.create_map_configuration(map_config)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -639,7 +639,8 @@ game_configuration_1 = %{
   zone_enabled: true,
   bounties_options_amount: 3,
   match_timeout_ms: 300_000,
-  field_of_view_inside_bush: 500
+  field_of_view_inside_bush: 500,
+  time_visible_in_bush_after_skill: 2000
 }
 
 {:ok, _game_configuration_1} =

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1873,66 +1873,7 @@ map_config = %{
       ]
     }
   ],
-  bushes: [
-    %{
-      name: "bottom left cave bushes",
-      position: %{
-        x: 0.0,
-        y: 0.0
-      },
-      vertices: [
-        %{
-          x: -1975.0,
-          y: -2015.0
-        },
-        %{
-          x: -2858.0,
-          y: -2023.0
-        },
-        %{
-          x: -3427.0,
-          y: -1306.0
-        },
-        %{
-          x: -3423.0,
-          y: -204.0
-        },
-        %{
-          x: -3170.0,
-          y: 7.0
-        }
-      ],
-      radius: 0.0,
-      shape: "polygon"
-    },
-    %{
-      name: "top right cave bushes",
-      position: %{
-        x: 0.0,
-        y: 0.0
-      },
-      vertices: [
-        %{
-          x: 951.0,
-          y: 2881.0
-        },
-        %{
-          x: 1791.0,
-          y: 3176.0
-        },
-        %{
-          x: 2806.0,
-          y: 2050.0
-        },
-        %{
-          x: 2550.0,
-          y: 1384.0
-        }
-      ],
-      radius: 0.0,
-      shape: "polygon"
-    }
-  ]
+  bushes: []
 }
 
 {:ok, _map_configuration_1} = GameBackend.Configuration.create_map_configuration(map_config)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1871,35 +1871,7 @@ map_config = %{
       ]
     }
   ],
-  bushes: [
-    %{
-      name: "Middle bush",
-      position: %{
-        x: 0.0,
-        y: 0.0
-      },
-      vertices: [
-        %{
-          x: 0.0,
-          y: 1000.0
-        },
-        %{
-          x: 1000.0,
-          y: 0.0
-        },
-        %{
-          x: 0.0,
-          y: -1000.0
-        },
-        %{
-          x: -1000.0,
-          y: 0.0
-        }
-      ],
-      radius: 0.0,
-      shape: "polygon"
-    }
-  ]
+  bushes: []
 }
 
 {:ok, _map_configuration_1} = GameBackend.Configuration.create_map_configuration(map_config)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1871,7 +1871,35 @@ map_config = %{
       ]
     }
   ],
-  bushes: []
+  bushes: [
+    %{
+      name: "Middle bush",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      vertices: [
+        %{
+          x: 0.0,
+          y: 1000.0
+        },
+        %{
+          x: 1000.0,
+          y: 0.0
+        },
+        %{
+          x: 0.0,
+          y: -1000.0
+        },
+        %{
+          x: -1000.0,
+          y: 0.0
+        }
+      ],
+      radius: 0.0,
+      shape: "polygon"
+    }
+  ]
 }
 
 {:ok, _map_configuration_1} = GameBackend.Configuration.create_map_configuration(map_config)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1872,33 +1872,6 @@ map_config = %{
     }
   ],
   bushes: [
-    # %{
-    #   name: "central bush",
-    #   position: %{
-    #     x: 0.0,
-    #     y: 0.0
-    #   },
-    #   vertices: [
-    #     %{
-    #       x: 0.0,
-    #       y: 1000.0
-    #     },
-    #     %{
-    #       x: 1000.0,
-    #       y: 0.0
-    #     },
-    #     %{
-    #       x: 0.0,
-    #       y: -1000.0
-    #     },
-    #     %{
-    #       x: -1000.0,
-    #       y: 0.0
-    #     }
-    #   ],
-    #   radius: 0.0,
-    #   shape: "polygon"
-    # },
     %{
       name: "bottom left cave bushes",
       position: %{
@@ -1952,7 +1925,7 @@ map_config = %{
         %{
           x: 2550.0,
           y: 1384.0
-        },
+        }
       ],
       radius: 0.0,
       shape: "polygon"


### PR DESCRIPTION
## Motivation

We need to define an schema for bushes since we can't add them otherwise
Also we have missing the bush parse in `configuration.ex`

Also we implement a logic to show player that attacks from a bush

## Summary of changes

Add `Bush` module in map_configuration
Parse bushes on config get

## How to test it?

Add this to you seeds.exs file:

```
%{
      name: "Middle bush",
      position: %{
        x: 0.0,
        y: 0.0
      },
      vertices: [
        %{
          x: 0.0,
          y: 1000.0
        },
        %{
          x: 1000.0,
          y: 0.0
        },
        %{
          x: 0.0,
          y: -1000.0
        },
        %{
          x: -1000.0,
          y: 0.0
        }
      ],
      radius: 0.0,
      shape: "polygon"
    }
```

Then go to [This link](http://localhost:3000/) and play a match

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
