### PR TITLE
Fix ping message for game client

### DIFF
--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -102,11 +102,7 @@ defmodule GameClientWeb.BoardLive.Show do
     {:noreply, assign(socket, game_status: :finished, winner_id: finished_event.winner.id)}
   end
 
-  defp handle_game_event({:ping, ping_event}, socket) do
-    {:noreply, assign(socket, :ping_latency, ping_event.latency)}
-  end
-
-  defp handle_game_event({noop_event, _}, socket) when noop_event in [:toggle_bots] do
+  defp handle_game_event({noop_event, _}, socket) when noop_event in [:toggle_bots, :ping, :ping_update] do
     {:noreply, socket}
   end
 


### PR DESCRIPTION
## Motivation

After the merge of https://github.com/lambdaclass/mirra_backend/pull/792 the game client broke since we were expecting another kind of message in the :ping message, we'll simply ignore it since we don't use the ping info in the game client

## Summary of changes

Add ping and ping_update message to the noop_message list

## How to test it?

Go to [This link](http://localhost:3000/) and play a match

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
