### PR TITLE
Add workflow to deploy to multiple environments in the same server

### DIFF
--- a/.github/workflows/arena-brazil-testing-deploys.yml
+++ b/.github/workflows/arena-brazil-testing-deploys.yml
@@ -1,0 +1,90 @@
+name: "Deploy to Brazil Arena testing multiple envs"
+on:
+  workflow_dispatch:
+    inputs:
+      sub_env:
+        description: "Select testing sub-environment to deploy:"
+        type: "choice"
+        options:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+
+jobs:
+  build-deploy:
+    name: Build and deploy to Brazil testing
+    runs-on: ubuntu-latest
+    environment:
+      name: testing-brazil
+      url: "${{ vars.TESTING_BRAZIL_HOST }}:400${{ inputs.sub_env }}"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Create ssh private key file from env var
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST: ${{ vars.TS_ARENA_HOST }}
+        run: |
+          set -ex
+          mkdir -p ~/.ssh/
+          sed -E 's/(-+(BEGIN|END) OPENSSH PRIVATE KEY-+) *| +/\1\n/g' <<< "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+          retries=5; until ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts || [ $retries -eq 0 ]; do ((retries--)); sleep 5; done
+
+      - name: Copy deploy script
+        env:
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          SSH_HOST: ${{ vars.TS_ARENA_HOST }}
+        run: |
+          set -ex
+          rsync -avz --mkpath devops/deploy.sh ${SSH_USERNAME}@${SSH_HOST}:/home/${SSH_USERNAME}/deploy-script/
+
+      - name: Execute deploy script
+        env:
+          SSH_HOST: ${{ vars.TS_ARENA_HOST }}
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          MIX_ENV: ${{ vars.MIX_ENV }}
+          RELEASE: arena
+          PHX_SERVER: ${{ vars.PHX_SERVER }}
+          PHX_HOST: ${{ vars.HOST }}
+          PORT: "400${{ inputs.sub_env }}"
+          GATEWAY_URL: ${{ vars.GATEWAY_URL }}
+          BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
+          BOT_MANAGER_HOST: ${{ vars.LOADTEST_CLIENT_HOST }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME }}
+          NEWRELIC_KEY: ${{ secrets.NEWRELIC_KEY }}
+          DBUS_SESSION_BUS_ADDRESS: ${{ vars.DBUS_SESSION_BUS_ADDRESS }}
+          XDG_RUNTIME_DIR: ${{ vars.XDG_RUNTIME_DIR }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -ex
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+                BRANCH_NAME=${BRANCH_NAME} \
+                MIX_ENV=${MIX_ENV} \
+                RELEASE=${RELEASE} \
+                PHX_SERVER=${PHX_SERVER} \
+                PHX_HOST=${PHX_HOST} \
+                BOT_MANAGER_HOST=${BOT_MANAGER_HOST} \
+                PORT=${PORT} \
+                _SERVICE_SUFFIX=${PORT} \
+                GATEWAY_URL=${GATEWAY_URL} \
+                BOT_MANAGER_PORT=${BOT_MANAGER_PORT} \
+                DATABASE_URL=${DATABASE_URL} \
+                SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+                NEWRELIC_APP_NAME=${NEWRELIC_APP_NAME} \
+                NEWRELIC_KEY=${NEWRELIC_KEY} \
+                DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS} \
+                XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} \
+                /home/${SSH_USERNAME}/deploy-script/deploy.sh

--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -2,13 +2,13 @@
 . "$HOME/.cargo/env"
 set -ex
 
-if [ -d "/tmp/mirra_backend" ]; then
-	rm -rf /tmp/mirra_backend
+if [ -d "/tmp/mirra_backend${_SERVICE_SUFFIX}" ]; then
+	rm -rf /tmp/mirra_backend${_SERVICE_SUFFIX}
 fi
 
 cd /tmp
-git clone https://github.com/lambdaclass/mirra_backend.git --branch ${BRANCH_NAME}
-cd mirra_backend/
+git clone https://github.com/lambdaclass/mirra_backend.git --branch ${BRANCH_NAME} mirra_backend${_SERVICE_SUFFIX}
+cd mirra_backend${_SERVICE_SUFFIX}
 
 chmod +x devops/entrypoint.sh
 
@@ -23,31 +23,31 @@ if [ ${RELEASE} == "central_backend" ]; then
 	mix ecto.migrate
 fi
 
-rm -rf $HOME/mirra_backend
-mv /tmp/mirra_backend $HOME/
+rm -rf $HOME/mirra_backend${_SERVICE_SUFFIX}
+mv /tmp/mirra_backend${_SERVICE_SUFFIX} $HOME/
 
 mkdir -p $HOME/.config/systemd/user/
 
-cat <<EOF >$HOME/.config/systemd/user/${RELEASE}.service
+cat <<EOF >$HOME/.config/systemd/user/${RELEASE}${_SERVICE_SUFFIX}.service
 [Unit]
 Description=$RELEASE
 
 [Service]
-WorkingDirectory=$HOME/mirra_backend
+WorkingDirectory=$HOME/mirra_backend${_SERVICE_SUFFIX}
 Restart=on-failure
 ExecStart=$HOME/mirra_backend/devops/entrypoint.sh
 ExecReload=/bin/kill -HUP
 KillSignal=SIGTERM
-EnvironmentFile=$HOME/.env
+EnvironmentFile=$HOME/.env${_SERVICE_SUFFIX}
 LimitNOFILE=100000
 
 [Install]
 WantedBy=default.target
 EOF
 
-systemctl --user enable $RELEASE
+systemctl --user enable ${RELEASE}${_SERVICE_SUFFIX}
 
-cat <<EOF >$HOME/.env
+cat <<EOF >$HOME/.env${_SERVICE_SUFFIX}
 PHX_HOST=${PHX_HOST}
 DATABASE_URL=${DATABASE_URL}
 PHX_SERVER=${PHX_SERVER}
@@ -66,7 +66,7 @@ LOADTEST_EUROPE_HOST=${LOADTEST_EUROPE_HOST}
 LOADTEST_BRAZIL_HOST=${LOADTEST_BRAZIL_HOST}
 EOF
 
-systemctl --user stop $RELEASE
+systemctl --user stop ${RELEASE}${_SERVICE_SUFFIX}
 
 systemctl --user daemon-reload
-systemctl --user start $RELEASE
+systemctl --user start ${RELEASE}${_SERVICE_SUFFIX}


### PR DESCRIPTION
* `sub_env` GitHub input works as port suffix and deployment "id"
* `_SERVICE_SUFFIX` env var (set equal as the port number) works as a suffix to keep backwards compatibility with the older deployments (if env var is not set, it will work exactly the same as the older deploy script)