### PR TITLE
[GH-816] Add polymorph item

### DIFF
--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -506,12 +506,7 @@
       "duration_ms": 9000,
       "remove_on_action": true,
       "one_time_application": true,
-      "effect_mechanics": {
-        "polymorph": {
-          "execute_multiple_times": true,
-          "effect_delay_ms": 0
-        }
-      }
+      "effect_mechanics": {}
     }
   ],
   "crates": [

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -500,6 +500,18 @@
           "execute_multiple_times": true
         }
       }
+    },
+    {
+      "name": "polymorph_effect",
+      "duration_ms": 9000,
+      "remove_on_action": true,
+      "one_time_application": true,
+      "effect_mechanics": {
+        "polymorph": {
+          "execute_multiple_times": true,
+          "effect_delay_ms": 0
+        }
+      }
     }
   ],
   "crates": [

--- a/apps/configurator/lib/configurator_web/live/consumable_items/form.html.heex
+++ b/apps/configurator/lib/configurator_web/live/consumable_items/form.html.heex
@@ -9,7 +9,7 @@
     field={f[:effects]}
     type="select"
     multiple
-    options={["golden_clock_effect", "magic_boots_effect", "mirra_blessing_effect", "giant_effect"]}
+    options={["golden_clock_effect", "magic_boots_effect", "mirra_blessing_effect", "giant_effect", "polymorph_effect"]}
   />
   <:actions>
     <.button>Save Consumable item</.button>

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -1,4 +1,4 @@
-import { Application, Container, Graphics } from "pixi.js";
+import { Application, Container, Graphics, Text } from "pixi.js";
 
 function Entity({ id, name, shape, category, x, y, coords, radius }) {
   this.id = id;
@@ -81,6 +81,7 @@ export const BoardGame = function () {
           }
           let entity = entities.get(backEntity.id);
           this.updateEntityColor(entity, backEntity.is_colliding, backEntity);
+          this.updateEntityText(entity, backEntity);
 
           this.updateEntityPosition(entity, backEntity.x, backEntity.y);
         } else if (entities.has(backEntity.id)) {
@@ -89,6 +90,29 @@ export const BoardGame = function () {
           entities.delete(backEntity.id)
         }
       });
+    });
+
+    window.addEventListener("phx:debug_mode", (e) => {
+      for (const [_, entity] of entities.entries()) {
+        if (entity.category == "player") {
+
+          if (entity.debugText) {
+            app.stage.removeChild(entity.debugText)
+            entity.debugText = null
+          } else {
+            debugText = new Text('[]', {
+              style: {
+                fontFamily: 'Arial',
+                fontSize: 24,
+                fill: 0xff1010,
+                align: 'center',
+              },
+            });
+            app.stage.addChild(debugText);
+            entity.debugText = debugText;
+          }
+        }
+      }
     });
 
     app.ticker.add(() => {
@@ -263,5 +287,14 @@ export const BoardGame = function () {
         }
       }
       entity.boardObject.tint = color;
+    }),
+    (this.updateEntityText = function (entity, backEntity) {
+      if (entity.category == "player" && entity.debugText) {
+        entity.debugText.text = "health: " + backEntity.health + "\n";
+        entity.debugText.text += "Position: x:" + (backEntity.x).toFixed(2) + " y: " + (backEntity.y).toFixed(2) + "\n";
+        entity.debugText.text += "Effects: [" + backEntity.effects.join('\n') + "]" + "\n";
+        entity.debugText.x = entity.x
+        entity.debugText.y = entity.y + 25
+      }
     })
 };

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -291,7 +291,7 @@ export const BoardGame = function () {
     (this.updateEntityText = function (entity, backEntity) {
       if (entity.category == "player" && entity.debugText) {
         entity.debugText.text = "health: " + backEntity.health + "\n";
-        entity.debugText.text += "Position: x:" + (backEntity.x).toFixed(2) + " y: " + (backEntity.y).toFixed(2) + "\n";
+        entity.debugText.text += "Position: x:" + (backEntity.back_x).toFixed(2) + " y: " + (backEntity.back_y).toFixed(2) + "\n";
         entity.debugText.text += "Effects: [" + backEntity.effects.join('\n') + "]" + "\n";
         entity.debugText.x = entity.x
         entity.debugText.y = entity.y + 25

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -146,6 +146,8 @@ defmodule GameClientWeb.BoardLive.Show do
       name: entity.name,
       x: entity.position.x / back_size_to_front_ratio + backend_board_size / 10,
       y: entity.position.y / back_size_to_front_ratio + backend_board_size / 10,
+      back_x: entity.position.x,
+      back_y: entity.position.y,
       radius: entity.radius / back_size_to_front_ratio,
       coords: entity.vertices |> Enum.map(fn vertex -> [vertex.x / 5, vertex.y / 5] end),
       is_colliding: entity.collides_with |> Enum.any?(),

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.ex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.ex
@@ -70,6 +70,10 @@ defmodule GameClientWeb.BoardLive.Show do
     {:noreply, socket}
   end
 
+  def handle_event("debug_mode", _, socket) do
+    {:noreply, push_event(socket, "debug_mode", %{})}
+  end
+
   defp player_name(player_id), do: "P#{player_id}"
 
   defp handle_game_event({:joined, joined_info}, socket) do
@@ -145,7 +149,9 @@ defmodule GameClientWeb.BoardLive.Show do
       radius: entity.radius / back_size_to_front_ratio,
       coords: entity.vertices |> Enum.map(fn vertex -> [vertex.x / 5, vertex.y / 5] end),
       is_colliding: entity.collides_with |> Enum.any?(),
-      visible_players: aditional_info.visible_players
+      visible_players: aditional_info.visible_players,
+      effects: Enum.map(aditional_info.effects, fn effect -> effect.name end),
+      health: aditional_info.health
     }
   end
 

--- a/apps/game_client/lib/game_client_web/live/pages/board/show.html.heex
+++ b/apps/game_client/lib/game_client_web/live/pages/board/show.html.heex
@@ -12,6 +12,9 @@
         <li>
           <button phx-click="toggle_bots">Toggle bots</button>
         </li>
+        <li>
+          <button phx-click="debug_mode">Debug mode</button>
+        </li>
       </ul>
     </div>
     <div>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -690,7 +690,7 @@ giant_fruit_params = %{
   GameBackend.Items.create_consumable_item(giant_fruit_params)
 
 polymorph_params = %{
-  active: true,
+  active: false,
   name: "polymorph",
   radius: 200.0,
   mechanics: %{},

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -689,6 +689,17 @@ giant_fruit_params = %{
 {:ok, giant_fruit} =
   GameBackend.Items.create_consumable_item(giant_fruit_params)
 
+polymorph_params = %{
+  active: true,
+  name: "polymorph",
+  radius: 200.0,
+  mechanics: %{},
+  effects: ["polymorph_effect"]
+}
+
+{:ok, polymorph} =
+  GameBackend.Items.create_consumable_item(polymorph_params)
+
 map_config = %{
   radius: 5520.0,
   initial_positions: [


### PR DESCRIPTION
## Motivation

We need an item that only applies an effect in the backend, with no gameplay change whatsoever, this is for the game client to apply a visual change in the character models

Closes #816

## Summary of changes

- Added new effect to config.json
- Added new effect to `consumable_item` form
- Added debug mode to game_client, this is a new button on top of the game client map

## How to test it?

For easy testing you can comment every other `consumable_item` in the `seeds.ex` file and start a fresh db, the go to the game client and pick up an use an item, to do so use the "L" key

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
