### PR TITLE
[GH-820] Add kenzu dash and basic skill mechanics

### DIFF
--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -7,6 +7,10 @@ defmodule Arena.Game.Skill do
   alias Arena.{Entities, Utils}
   alias Arena.Game.{Player, Crate}
 
+  def do_mechanic(game_state, _entity, nil, _skill_params) do
+    game_state
+  end
+
   def do_mechanic(game_state, entity, mechanics, skill_params) when is_list(mechanics) do
     Enum.reduce(mechanics, game_state, fn mechanic, game_state_acc ->
       do_mechanic(game_state_acc, entity, mechanic, skill_params)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -633,6 +633,30 @@ skills = [
       "whirlwind"
     ],
     "version_id" => version.id
+  },
+  %{
+    "name" => "kenzu_pounce",
+    "type" => "dash",
+    "cooldown_mechanism" => "time",
+    "cooldown_ms" => 5000,
+    "execution_duration_ms" => 250,
+    "activation_delay_ms" => 0,
+    "is_passive" => false,
+    "autoaim" => true,
+    "max_autoaim_range" => 1300,
+    "can_pick_destination" => true,
+    "block_movement" => true,
+    "mechanics" => [
+      %{
+        "type" => "leap",
+        "range" => 1300.0,
+        "speed" => 1.7,
+        "radius" => 600,
+        "on_arrival_mechanic" => %{}
+      }
+    ],
+    "effects_to_apply" => [],
+    "version_id" => version.id
   }
 ]
 
@@ -739,7 +763,7 @@ kenzu_params = %{
   natural_healing_damage_interval: 3500,
   basic_skill_id: skills["kenzu_quickslash"],
   ultimate_skill_id: skills["kenzu_whirlwind"],
-  dash_skill_id: skills["valt_warp"],
+  dash_skill_id: skills["kenzu_pounce"],
   version_id: version.id
 }
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -288,6 +288,13 @@ simple_shoot = %{
   }
 }
 
+quickslash = %{
+  "type" => "circle_hit",
+  "damage" => 60,
+  "range" => 350.0,
+  "offset" => 400
+}
+
 ## Skills
 skills = [
   %{
@@ -559,15 +566,15 @@ skills = [
     "cooldown_mechanism" => "stamina",
     "reset_combo_ms" => 0,
     "is_combo?" => true,
-    "execution_duration_ms" => 100,
-    "activation_delay_ms" => 0,
+    "execution_duration_ms" => 750,
+    "activation_delay_ms" => 150,
     "is_passive" => false,
     "autoaim" => true,
-    "max_autoaim_range" => 1600,
+    "max_autoaim_range" => 700,
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [simple_shoot],
+    "mechanics" => [quickslash],
     "effects_to_apply" => [],
     "version_id" => version.id
   },
@@ -577,15 +584,15 @@ skills = [
     "cooldown_mechanism" => "stamina",
     "reset_combo_ms" => 2500,
     "is_combo?" => true,
-    "execution_duration_ms" => 450,
-    "activation_delay_ms" => 0,
+    "execution_duration_ms" => 500,
+    "activation_delay_ms" => 100,
     "is_passive" => false,
     "autoaim" => true,
-    "max_autoaim_range" => 1600,
+    "max_autoaim_range" => 700,
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [multi_shoot],
+    "mechanics" => [quickslash],
     "effects_to_apply" => [],
     "version_id" => version.id
   },
@@ -595,15 +602,15 @@ skills = [
     "cooldown_mechanism" => "stamina",
     "reset_combo_ms" => 2500,
     "is_combo?" => true,
-    "execution_duration_ms" => 450,
-    "activation_delay_ms" => 0,
+    "execution_duration_ms" => 500,
+    "activation_delay_ms" => 100,
     "is_passive" => false,
     "autoaim" => true,
-    "max_autoaim_range" => 1600,
+    "max_autoaim_range" => 700,
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [singularity],
+    "mechanics" => [quickslash],
     "effects_to_apply" => [],
     "version_id" => version.id
   },


### PR DESCRIPTION
## Motivation

Kenzu basic was using testing mechanics. -> [Notion link](https://www.notion.so/lambdaclass/Quickslash-428d10e916a44566af3f00cd54569a43?pvs=4)
Kenzu dash skill wasn't implemented. -> [Notion link](https://www.notion.so/lambdaclass/Pounce-86a5bb7716ae47e9997ff6da550c7422?pvs=4)
Closes #820 

## Summary of changes

- [Add Kenzu's dash skill](https://github.com/lambdaclass/mirra_backend/commit/24c93f66c8d6eb9bc9e5faee0eb0a885dc47f831)
- [Add Kenzu's basic skill quickslashes' mechanics](https://github.com/lambdaclass/mirra_backend/commit/81af2650bdfeeb66d990c78f29577a7325f83ab8)

## How to test it?

1. Play a match using Kenzu in the game client.
2. Assign Kenzu's basic and dash to any other character, reset the DB and run the seeds. Then play a match in Unity.
* You have to delete Kenzu from the characters list for Unity to work.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
