### PR TITLE
Send kenzu skills to client

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -393,7 +393,8 @@ defmodule Arena.Entities do
        on_bush: entity.aditional_info.on_bush,
        forced_movement: entity.aditional_info.forced_movement,
        bounty_completed: entity.aditional_info.bounty_completed,
-       mana: entity.aditional_info.mana
+       mana: entity.aditional_info.mana,
+       current_basic_animation: entity.aditional_info.current_basic_animation
      }}
   end
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -65,7 +65,7 @@ defmodule Arena.Entities do
         bounties: [],
         selected_bounty: nil,
         bounty_completed: false,
-        current_basic_animation: 1
+        current_basic_animation: 0
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -64,7 +64,8 @@ defmodule Arena.Entities do
         on_bush: false,
         bounties: [],
         selected_bounty: nil,
-        bounty_completed: false
+        bounty_completed: false,
+        current_basic_animation: 1
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -571,7 +571,8 @@ defmodule Arena.Game.Player do
     game_state
   end
 
-  defp get_skill_animation(skill_name) when skill_name in ["kenzu_quickslash_second", "kenzu_quickslash_third"], do: 2
+  defp get_skill_animation("kenzu_quickslash_second"), do: 2
+  defp get_skill_animation("kenzu_quickslash_third"), do: 3
 
   defp get_skill_animation(_skill_name), do: 1
 end

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -501,11 +501,11 @@ defmodule Arena.Game.Player do
     player = put_in(player, [:aditional_info, :last_combo_timestamp], now)
 
     if combo_time_ms > skill.reset_combo_ms do
-      put_in(player, [:aditional_info, :current_basic_animation], 1)
+      player = put_in(player, [:aditional_info, :current_basic_animation], 1)
 
       {player, Map.get(skill, :first_skill, skill)}
     else
-      put_in(player, [:aditional_info, :current_basic_animation], get_skill_animation(skill.name))
+      player = put_in(player, [:aditional_info, :current_basic_animation], get_skill_animation(skill.name))
 
       {player, skill}
     end
@@ -522,7 +522,6 @@ defmodule Arena.Game.Player do
       next_skill = skill.next_skill |> Map.put(:first_skill, first_skill)
 
       put_in(player, [:aditional_info, :skills, skill_key], next_skill)
-      |> put_in([:aditional_info, :current_basic_animation], 2)
     end
   end
 

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -501,8 +501,12 @@ defmodule Arena.Game.Player do
     player = put_in(player, [:aditional_info, :last_combo_timestamp], now)
 
     if combo_time_ms > skill.reset_combo_ms do
+      put_in(player, [:aditional_info, :current_basic_animation], 1)
+
       {player, Map.get(skill, :first_skill, skill)}
     else
+      put_in(player, [:aditional_info, :current_basic_animation], get_skill_animation(skill.name))
+
       {player, skill}
     end
   end
@@ -516,7 +520,9 @@ defmodule Arena.Game.Player do
       put_in(player, [:aditional_info, :skills, skill_key], first_skill)
     else
       next_skill = skill.next_skill |> Map.put(:first_skill, first_skill)
+
       put_in(player, [:aditional_info, :skills, skill_key], next_skill)
+      |> put_in([:aditional_info, :current_basic_animation], 2)
     end
   end
 
@@ -565,4 +571,8 @@ defmodule Arena.Game.Player do
   defp maybe_make_player_invincible(game_state, _, _) do
     game_state
   end
+
+  defp get_skill_animation(skill_name) when skill_name in ["kenzu_quickslash_second", "kenzu_quickslash_third"], do: 2
+
+  defp get_skill_animation(_skill_name), do: 1
 end

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -203,7 +203,8 @@ defmodule Arena.GameSocketHandler do
       targetting_radius: mechanic[:radius],
       targetting_angle: mechanic[:angle],
       targetting_range: mechanic[:range],
-      targetting_offset: mechanic[:offset] || mechanic[:projectile_offset]
+      targetting_offset: mechanic[:offset] || mechanic[:projectile_offset],
+      is_combo: skill.is_combo?
     }
 
     {key, Map.merge(skill, extra_params)}

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -301,6 +301,7 @@ defmodule Arena.Serialization.ConfigSkill do
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
   field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
   field(:mana_cost, 9, type: :uint64, json_name: "manaCost")
+  field(:is_combo, 10, type: :bool, json_name: "isCombo")
 end
 
 defmodule Arena.Serialization.GameState.PlayersEntry do

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -540,6 +540,7 @@ defmodule Arena.Serialization.Player do
   field(:forced_movement, 15, type: :bool, json_name: "forcedMovement")
   field(:bounty_completed, 16, type: :bool, json_name: "bountyCompleted")
   field(:mana, 17, type: :uint64)
+  field(:current_basic_animation, 18, type: :uint32, json_name: "currentBasicAnimation")
 end
 
 defmodule Arena.Serialization.Effect do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -594,6 +594,7 @@ defmodule ArenaLoadTest.Serialization.Player do
   field(:forced_movement, 15, type: :bool, json_name: "forcedMovement")
   field(:bounty_completed, 16, type: :bool, json_name: "bountyCompleted")
   field(:mana, 17, type: :uint64)
+  field(:current_basic_animation, 18, type: :uint32, json_name: "currentBasicAnimation")
 end
 
 defmodule ArenaLoadTest.Serialization.Effect do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -319,6 +319,7 @@ defmodule ArenaLoadTest.Serialization.ConfigSkill do
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
   field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
   field(:mana_cost, 9, type: :uint64, json_name: "manaCost")
+  field(:is_combo, 10, type: :bool, json_name: "isCombo")
 end
 
 defmodule ArenaLoadTest.Serialization.GameState.PlayersEntry do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -301,6 +301,7 @@ defmodule BotManager.Protobuf.ConfigSkill do
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
   field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
   field(:mana_cost, 9, type: :uint64, json_name: "manaCost")
+  field(:is_combo, 10, type: :bool, json_name: "isCombo")
 end
 
 defmodule BotManager.Protobuf.GameState.PlayersEntry do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -540,6 +540,7 @@ defmodule BotManager.Protobuf.Player do
   field(:forced_movement, 15, type: :bool, json_name: "forcedMovement")
   field(:bounty_completed, 16, type: :bool, json_name: "bountyCompleted")
   field(:mana, 17, type: :uint64)
+  field(:current_basic_animation, 18, type: :uint32, json_name: "currentBasicAnimation")
 end
 
 defmodule BotManager.Protobuf.Effect do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -4802,7 +4802,8 @@ proto.ConfigSkill.toObject = function(includeInstance, msg) {
     targettingRange: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
     staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0),
     targettingOffset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0),
-    manaCost: jspb.Message.getFieldWithDefault(msg, 9, 0)
+    manaCost: jspb.Message.getFieldWithDefault(msg, 9, 0),
+    isCombo: jspb.Message.getBooleanFieldWithDefault(msg, 10, false)
   };
 
   if (includeInstance) {
@@ -4874,6 +4875,10 @@ proto.ConfigSkill.deserializeBinaryFromReader = function(msg, reader) {
     case 9:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setManaCost(value);
+      break;
+    case 10:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setIsCombo(value);
       break;
     default:
       reader.skipField();
@@ -4964,6 +4969,13 @@ proto.ConfigSkill.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeUint64(
       9,
+      f
+    );
+  }
+  f = message.getIsCombo();
+  if (f) {
+    writer.writeBool(
+      10,
       f
     );
   }
@@ -5129,6 +5141,24 @@ proto.ConfigSkill.prototype.getManaCost = function() {
  */
 proto.ConfigSkill.prototype.setManaCost = function(value) {
   return jspb.Message.setProto3IntField(this, 9, value);
+};
+
+
+/**
+ * optional bool is_combo = 10;
+ * @return {boolean}
+ */
+proto.ConfigSkill.prototype.getIsCombo = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 10, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.ConfigSkill} returns this
+ */
+proto.ConfigSkill.prototype.setIsCombo = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 10, value);
 };
 
 

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -6994,7 +6994,8 @@ proto.Player.toObject = function(includeInstance, msg) {
     onBush: jspb.Message.getBooleanFieldWithDefault(msg, 14, false),
     forcedMovement: jspb.Message.getBooleanFieldWithDefault(msg, 15, false),
     bountyCompleted: jspb.Message.getBooleanFieldWithDefault(msg, 16, false),
-    mana: jspb.Message.getFieldWithDefault(msg, 17, 0)
+    mana: jspb.Message.getFieldWithDefault(msg, 17, 0),
+    currentBasicAnimation: jspb.Message.getFieldWithDefault(msg, 18, 0)
   };
 
   if (includeInstance) {
@@ -7105,6 +7106,10 @@ proto.Player.deserializeBinaryFromReader = function(msg, reader) {
     case 17:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setMana(value);
+      break;
+    case 18:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setCurrentBasicAnimation(value);
       break;
     default:
       reader.skipField();
@@ -7251,6 +7256,13 @@ proto.Player.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeUint64(
       17,
+      f
+    );
+  }
+  f = message.getCurrentBasicAnimation();
+  if (f !== 0) {
+    writer.writeUint32(
+      18,
       f
     );
   }
@@ -7643,6 +7655,24 @@ proto.Player.prototype.getMana = function() {
  */
 proto.Player.prototype.setMana = function(value) {
   return jspb.Message.setProto3IntField(this, 17, value);
+};
+
+
+/**
+ * optional uint32 current_basic_animation = 18;
+ * @return {number}
+ */
+proto.Player.prototype.getCurrentBasicAnimation = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 18, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.setCurrentBasicAnimation = function(value) {
+  return jspb.Message.setProto3IntField(this, 18, value);
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -540,6 +540,7 @@ defmodule GameClient.Protobuf.Player do
   field(:forced_movement, 15, type: :bool, json_name: "forcedMovement")
   field(:bounty_completed, 16, type: :bool, json_name: "bountyCompleted")
   field(:mana, 17, type: :uint64)
+  field(:current_basic_animation, 18, type: :uint32, json_name: "currentBasicAnimation")
 end
 
 defmodule GameClient.Protobuf.Effect do

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -301,6 +301,7 @@ defmodule GameClient.Protobuf.ConfigSkill do
   field(:stamina_cost, 7, type: :uint64, json_name: "staminaCost")
   field(:targetting_offset, 8, type: :float, json_name: "targettingOffset")
   field(:mana_cost, 9, type: :uint64, json_name: "manaCost")
+  field(:is_combo, 10, type: :bool, json_name: "isCombo")
 end
 
 defmodule GameClient.Protobuf.GameState.PlayersEntry do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -120,6 +120,7 @@ message ConfigSkill {
   uint64 stamina_cost = 7;
   float targetting_offset = 8;
   uint64 mana_cost = 9;
+  bool is_combo = 10;
 }
 
 

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -212,6 +212,7 @@ message Player {
   bool forced_movement = 15;
   bool bounty_completed = 16;
   uint64 mana = 17;
+  uint32 current_basic_animation = 18;
 }
 
 message Effect {

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -288,9 +288,23 @@ simple_shoot = %{
   }
 }
 
-quickslash = %{
+quickslash_1 = %{
   "type" => "circle_hit",
   "damage" => 60,
+  "range" => 350.0,
+  "offset" => 400
+}
+
+quickslash_2 = %{
+  "type" => "circle_hit",
+  "damage" => 65,
+  "range" => 350.0,
+  "offset" => 400
+}
+
+quickslash_3 = %{
+  "type" => "circle_hit",
+  "damage" => 80,
   "range" => 350.0,
   "offset" => 400
 }
@@ -566,7 +580,7 @@ skills = [
     "cooldown_mechanism" => "stamina",
     "reset_combo_ms" => 0,
     "is_combo?" => true,
-    "execution_duration_ms" => 750,
+    "execution_duration_ms" => 350,
     "activation_delay_ms" => 150,
     "is_passive" => false,
     "autoaim" => true,
@@ -574,7 +588,7 @@ skills = [
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [quickslash],
+    "mechanics" => [quickslash_1],
     "effects_to_apply" => [],
     "version_id" => version.id
   },
@@ -582,9 +596,9 @@ skills = [
     "name" => "kenzu_quickslash_second",
     "type" => "basic",
     "cooldown_mechanism" => "stamina",
-    "reset_combo_ms" => 2500,
+    "reset_combo_ms" => 800,
     "is_combo?" => true,
-    "execution_duration_ms" => 500,
+    "execution_duration_ms" => 450,
     "activation_delay_ms" => 100,
     "is_passive" => false,
     "autoaim" => true,
@@ -592,7 +606,7 @@ skills = [
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [quickslash],
+    "mechanics" => [quickslash_2],
     "effects_to_apply" => [],
     "version_id" => version.id
   },
@@ -600,9 +614,9 @@ skills = [
     "name" => "kenzu_quickslash_third",
     "type" => "basic",
     "cooldown_mechanism" => "stamina",
-    "reset_combo_ms" => 2500,
+    "reset_combo_ms" => 800,
     "is_combo?" => true,
-    "execution_duration_ms" => 500,
+    "execution_duration_ms" => 800,
     "activation_delay_ms" => 100,
     "is_passive" => false,
     "autoaim" => true,
@@ -610,7 +624,7 @@ skills = [
     "stamina_cost" => 1,
     "can_pick_destination" => false,
     "block_movement" => true,
-    "mechanics" => [quickslash],
+    "mechanics" => [quickslash_3],
     "effects_to_apply" => [],
     "version_id" => version.id
   },


### PR DESCRIPTION
> [!WARNING]
> Merge with https://github.com/lambdaclass/champions_of_mirra/pull/2014
## Motivation

We need to send the combo sequence to the client to change its animation.

## Summary of changes

- [Add new current_basic_animation to player protos](https://github.com/lambdaclass/mirra_backend/pull/830/commits/7a7651342d1aaf575eb522351da2fc0c737e2efc)
- [Change current_basic_animation if skill is kenzu second or third basic](https://github.com/lambdaclass/mirra_backend/pull/830/commits/aaf3b737ba881a0d3f39315d871caf5d4f77734d)
- [Save player update](https://github.com/lambdaclass/mirra_backend/pull/830/commits/595c257230824e244ea24d24d8b7a46a6b7b3342)
- [Add new current_basic_animation to player complete_entities](https://github.com/lambdaclass/mirra_backend/pull/830/commits/6c6f17c26f59a9d670e139243951e4d79bcb459f)
- [Add new is_combo boolean to messages.proto](https://github.com/lambdaclass/mirra_backend/pull/830/commits/7cc86534f2568a16fdcce882c0797545657c5c54)
- [Differentiating each of Kenzu’s basic combo attacks](https://github.com/lambdaclass/mirra_backend/pull/830/commits/7a47fa870df0865ff3c71aedc4a6765c5a6e4f8b)

## How to test it?

Play a game with game client or unity with the following branch https://github.com/lambdaclass/champions_of_mirra/pull/2014

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
