### PR TITLE
Deathmatch mode (reviving players)

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -44,6 +44,8 @@ defmodule Arena.Entities do
         skills: character.skills,
         current_actions: [],
         kill_count: 0,
+        death_count: 0,
+        last_death_at: nil,
         available_stamina: character.base_stamina,
         max_stamina: character.base_stamina,
         stamina_interval: character.stamina_interval,

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -3,6 +3,7 @@ defmodule Arena.Game.Player do
   Module for interacting with Player entity
   """
 
+  alias Arena.Entities
   alias Arena.Game.Crate
   alias Arena.GameUpdater
   alias Arena.GameTracker
@@ -62,6 +63,23 @@ defmodule Arena.Game.Player do
         | health: 0
       }
     end)
+  end
+
+  def revive(player, config) do
+    params = %{
+      id: player.id,
+      team: player.aditional_info.team,
+      player_name: player.name,
+      position:  Enum.random(config.map.initial_positions),
+      direction: %{x: 0.0, y: 0.0},
+      character_name: player.aditional_info.character_name,
+      config: config,
+      now: System.monotonic_time(:millisecond)
+    }
+
+    Entities.new_player(params)
+    ## TODO: check if this is needed or can be removed
+    |> put_in([:aditional_info, :kill_count], player.aditional_info.kill_count)
   end
 
   def trigger_natural_healings(players) do

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -70,7 +70,7 @@ defmodule Arena.Game.Player do
       id: player.id,
       team: player.aditional_info.team,
       player_name: player.name,
-      position:  Enum.random(config.map.initial_positions),
+      position: Enum.random(config.map.initial_positions),
       direction: %{x: 0.0, y: 0.0},
       character_name: player.aditional_info.character_name,
       config: config,

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -65,7 +65,7 @@ defmodule Arena.Game.Player do
     end)
   end
 
-  def revive(player, config) do
+  def respawn(player, config) do
     params = %{
       id: player.id,
       team: player.aditional_info.team,

--- a/apps/arena/lib/arena/game_tracker.ex
+++ b/apps/arena/lib/arena/game_tracker.ex
@@ -85,7 +85,8 @@ defmodule Arena.GameTracker do
 
   def handle_call({:get_player_result, player_id}, {match_pid, _}, state) do
     match_data = get_in(state, [:matches, match_pid])
-    ## FIXME: instead of generating actual results generate some intermediate state
+    ## TODO: instead of generating actual results generate some intermediate state
+    ## https://github.com/lambdaclass/mirra_backend/issues/848
     result = generate_player_result(match_data, player_id, %{})
 
     {:reply, result, state}
@@ -184,7 +185,8 @@ defmodule Arena.GameTracker do
       damage_taken: player_data.damage_taken,
       damage_done: player_data.damage_done,
       health_healed: player_data.health_healed,
-      ## FIXME: This is not correct for the reviving mode, but maybe we can simply not have this or keep it as is
+      ## TODO: This is not correct for the reviving mode, for now it will be nil in for that case
+      ## https://github.com/lambdaclass/mirra_backend/issues/848
       killed_by: List.first(player_data.deaths, nil),
       killed_by_bot: player_data.killed_by_bot,
       duration_ms: duration,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -502,7 +502,7 @@ defmodule Arena.GameUpdater do
 
     broadcast_player_dead(state.game_state.game_id, victim_id)
     ## FIXME: properly do this
-    Process.send_after(self(), {:revive_player, victim_id}, 3000)##game_config.game.revive_time_ms)
+    # Process.send_after(self(), {:revive_player, victim_id}, 3000)##game_config.game.revive_time_ms)
 
     {:noreply, %{state | game_state: game_state}}
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -506,6 +506,9 @@ defmodule Arena.GameUpdater do
       |> put_player_position(victim_id)
 
     broadcast_player_dead(state.game_state.game_id, victim_id)
+    Process.send_after(self(), {:revive_player, victim_id}, 3000)##game_config.game.revive_time_ms)
+
+    {:noreply, %{state | game_state: game_state}}
 
     case Map.get(game_state.players, killer_id) do
       nil ->
@@ -520,6 +523,11 @@ defmodule Arena.GameUpdater do
     end
 
     {:noreply, %{state | game_state: game_state}}
+  end
+
+  def handle_info({:revive_player, player_id}, state) do
+    state = update_in(state, [:game_state, :players, player_id], fn player -> Player.revive(player, state.game_config) end)
+    {:noreply, state}
   end
 
   def handle_info({:recharge_stamina, player_id}, state) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -339,7 +339,7 @@ defmodule Arena.GameUpdater do
         ## sending messages, this way we give some time before making them crash
         ## (sending to inexistant process will cause them to crash)
         Process.send_after(self(), :game_ended, state.game_config.game.shutdown_game_wait_ms)
-   end
+    end
 
     {:noreply, state}
   end
@@ -721,11 +721,12 @@ defmodule Arena.GameUpdater do
 
   defp broadcast_game_ended(game_id, players, standings) do
     ## This is only for backwards compatibility until actual modes are introduced
-    winner = Enum.find_value(standings, fn {player_id, position} ->
-      if position == 1 do
-        Map.get(players, player_id)
-      end
-    end)
+    winner =
+      Enum.find_value(standings, fn {player_id, position} ->
+        if position == 1 do
+          Map.get(players, player_id)
+        end
+      end)
 
     game_state = %GameFinished{
       winner: complete_entity(winner),
@@ -1399,6 +1400,7 @@ defmodule Arena.GameUpdater do
   defp check_game_ended(game_state, %{game: %{mode: "solo_deathmatch"}} = config) do
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
     time_since_start = now - game_state.start_game_timestamp
+
     case time_since_start >= config.game.match_duration_ms do
       true -> :ended
       false -> :ongoing
@@ -1859,7 +1861,8 @@ defmodule Arena.GameUpdater do
   defp respawn_players(game_state, %{game: %{mode: "solo_deathmatch"}} = config) do
     Enum.reduce(game_state.players, game_state, fn {_, player}, game_state_acc ->
       now = System.monotonic_time(:millisecond)
-      if not Player.alive?(player) and (now - player.aditional_info.last_death_at) >= config.game.respawn_time_ms do
+
+      if not Player.alive?(player) and now - player.aditional_info.last_death_at >= config.game.respawn_time_ms do
         update_in(game_state_acc, [:players, player.id], fn player -> Player.respawn(player, config) end)
       else
         game_state_acc

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -8,7 +8,9 @@
     options={Enum.map(GameBackend.Configuration.list_versions(), fn version -> {version.name, version.id} end)}
     label="Version"
   />
+  <.input field={f[:mode]} type="select" label="Mode" prompt="Choose a value" options={Ecto.Enum.values(GameBackend.CurseOfMirra.GameConfiguration, :mode)}/>
   <.input field={f[:tick_rate_ms]} type="number" label="Tick rate ms" />
+  <.input field={f[:respawn_time_ms]} type="number" label="Respawn interval ms" />
   <.input field={f[:bounty_pick_time_ms]} type="number" label="Bounty pick time ms" />
   <.input field={f[:start_game_time_ms]} type="number" label="Start game time ms" />
   <.input field={f[:end_game_interval_ms]} type="number" label="End game interval ms" />

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -8,7 +8,13 @@
     options={Enum.map(GameBackend.Configuration.list_versions(), fn version -> {version.name, version.id} end)}
     label="Version"
   />
-  <.input field={f[:mode]} type="select" label="Mode" prompt="Choose a value" options={Ecto.Enum.values(GameBackend.CurseOfMirra.GameConfiguration, :mode)}/>
+  <.input
+    field={f[:mode]}
+    type="select"
+    label="Mode"
+    prompt="Choose a value"
+    options={Ecto.Enum.values(GameBackend.CurseOfMirra.GameConfiguration, :mode)}
+  />
   <.input field={f[:tick_rate_ms]} type="number" label="Tick rate ms" />
   <.input field={f[:respawn_time_ms]} type="number" label="Respawn interval ms" />
   <.input field={f[:match_duration_ms]} type="number" label="Duration of the match ms" />

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -11,6 +11,7 @@
   <.input field={f[:mode]} type="select" label="Mode" prompt="Choose a value" options={Ecto.Enum.values(GameBackend.CurseOfMirra.GameConfiguration, :mode)}/>
   <.input field={f[:tick_rate_ms]} type="number" label="Tick rate ms" />
   <.input field={f[:respawn_time_ms]} type="number" label="Respawn interval ms" />
+  <.input field={f[:match_duration_ms]} type="number" label="Duration of the match ms" />
   <.input field={f[:bounty_pick_time_ms]} type="number" label="Bounty pick time ms" />
   <.input field={f[:start_game_time_ms]} type="number" label="Start game time ms" />
   <.input field={f[:end_game_interval_ms]} type="number" label="End game interval ms" />

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
@@ -8,7 +8,9 @@
 </.header>
 
 <.table id="game_configurations" rows={@game_configurations} row_click={&JS.navigate(~p"/game_configurations/#{&1}")}>
+  <:col :let={game_configuration} label="Mode"><%= game_configuration.mode %></:col>
   <:col :let={game_configuration} label="Tick rate ms"><%= game_configuration.tick_rate_ms %></:col>
+  <:col :let={game_configuration} label="Respawn interval ms"><%= game_configuration.respawn_time_ms %></:col>
   <:col :let={game_configuration} label="Bounty pick time ms"><%= game_configuration.bounty_pick_time_ms %></:col>
   <:col :let={game_configuration} label="Start game time ms"><%= game_configuration.start_game_time_ms %></:col>
   <:col :let={game_configuration} label="End game interval ms"><%= game_configuration.end_game_interval_ms %></:col>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/index.html.heex
@@ -11,6 +11,7 @@
   <:col :let={game_configuration} label="Mode"><%= game_configuration.mode %></:col>
   <:col :let={game_configuration} label="Tick rate ms"><%= game_configuration.tick_rate_ms %></:col>
   <:col :let={game_configuration} label="Respawn interval ms"><%= game_configuration.respawn_time_ms %></:col>
+  <:col :let={game_configuration} label="Duration of the match"><%= game_configuration.match_duration_ms %></:col>
   <:col :let={game_configuration} label="Bounty pick time ms"><%= game_configuration.bounty_pick_time_ms %></:col>
   <:col :let={game_configuration} label="Start game time ms"><%= game_configuration.start_game_time_ms %></:col>
   <:col :let={game_configuration} label="End game interval ms"><%= game_configuration.end_game_interval_ms %></:col>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
@@ -9,7 +9,9 @@
 </.header>
 
 <.list>
+  <:item title="Mode"><%= @game_configuration.mode %></:item>
   <:item title="Tick rate ms"><%= @game_configuration.tick_rate_ms %></:item>
+  <:item title="Respawn interval ms"><%= @game_configuration.respawn_time_ms %></:item>
   <:item title="Bounty pick time ms"><%= @game_configuration.bounty_pick_time_ms %></:item>
   <:item title="Start game time ms"><%= @game_configuration.start_game_time_ms %></:item>
   <:item title="End game interval ms"><%= @game_configuration.end_game_interval_ms %></:item>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
@@ -12,6 +12,7 @@
   <:item title="Mode"><%= @game_configuration.mode %></:item>
   <:item title="Tick rate ms"><%= @game_configuration.tick_rate_ms %></:item>
   <:item title="Respawn interval ms"><%= @game_configuration.respawn_time_ms %></:item>
+  <:item title="Duration of the match"><%= @game_configuration.match_duration_ms %></:item>
   <:item title="Bounty pick time ms"><%= @game_configuration.bounty_pick_time_ms %></:item>
   <:item title="Start game time ms"><%= @game_configuration.start_game_time_ms %></:item>
   <:item title="End game interval ms"><%= @game_configuration.end_game_interval_ms %></:item>

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
@@ -32,7 +32,7 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     :version_id
   ]
 
-  @permitted @required ++ [:respawn_time_ms]
+  @permitted @required ++ [:respawn_time_ms, :match_duration_ms]
 
   @derive {Jason.Encoder, only: @permitted}
   schema "game_configurations" do
@@ -58,6 +58,7 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     field(:time_visible_in_bush_after_skill, :integer)
     field(:mode, Ecto.Enum, values: [:battle_royale, :solo_deathmatch])
     field(:respawn_time_ms, :integer)
+    field(:match_duration_ms, :integer)
 
     belongs_to(:version, Version)
 
@@ -77,8 +78,9 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
       :battle_royale ->
         changeset
       :solo_deathmatch ->
-        validate_required(changeset, [:respawn_time_ms])
+        validate_required(changeset, [:respawn_time_ms, :match_duration_ms])
         |> validate_number(:respawn_time_ms, greater_than: 0)
+        |> validate_number(:match_duration_ms, greater_than: 0)
       _ ->
         changeset
     end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
@@ -77,10 +77,12 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     case get_field(changeset, :mode) do
       :battle_royale ->
         changeset
+
       :solo_deathmatch ->
         validate_required(changeset, [:respawn_time_ms, :match_duration_ms])
         |> validate_number(:respawn_time_ms, greater_than: 0)
         |> validate_number(:match_duration_ms, greater_than: 0)
+
       _ ->
         changeset
     end

--- a/apps/game_backend/priv/repo/migrations/20240808183758_add_game_mode_configurations.exs
+++ b/apps/game_backend/priv/repo/migrations/20240808183758_add_game_mode_configurations.exs
@@ -5,6 +5,7 @@ defmodule GameBackend.Repo.Migrations.AddGameModeConfigurations do
     alter table(:game_configurations) do
       add :mode, :string
       add :respawn_time_ms, :integer
+      add :match_duration_ms, :integer
     end
 
     execute("UPDATE game_configurations SET mode = 'battle_royale'", "")

--- a/apps/game_backend/priv/repo/migrations/20240808183758_add_game_mode_configurations.exs
+++ b/apps/game_backend/priv/repo/migrations/20240808183758_add_game_mode_configurations.exs
@@ -1,0 +1,12 @@
+defmodule GameBackend.Repo.Migrations.AddGameModeConfigurations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:game_configurations) do
+      add :mode, :string
+      add :respawn_time_ms, :integer
+    end
+
+    execute("UPDATE game_configurations SET mode = 'battle_royale'", "")
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -797,6 +797,7 @@ kenzu_params = %{
 end)
 
 game_configuration_1 = %{
+  mode: "battle_royale",
   tick_rate_ms: 30,
   bounty_pick_time_ms: 5000,
   start_game_time_ms: 10000,


### PR DESCRIPTION
Closes #917

## Motivation

https://www.notion.so/lambdaclass/Deathmatch-mode-96266708db9847ae83c39e0dae5c2122

## Summary of changes

- Add new attributes to players to keep track of deaths and last time they died
- Add functionality to respawn a player after some given time
- Add game configuration for `mode` and specific attributes for `solo_deathmatch` mode (`respawn_time_ms` and `match_duration_ms`)
-  GameUpdater now has different ways to determine if a game has ended or not based on game mode, same for calculating the final standings
- Reworked how GameTracker kept track of things and now uses a standings map (player_id => position) when setting the match result

## How to test it?

Best to play in Unity
1. In Configurator change game configuration to use mode `solo_deathmatch` and set some values for `respawn_time_ms` and `match_duration_ms` (personally if testing in quick game I recommend 5000 and 60000)
2. Play a game, after you kill a player and respawn time passes you will see the player counter go back up to 7 (or whatever it was before)

Pro tip: If you play a quick game with bots disabled from the start and go around killing each one eventually you will likely get 2 or more kills at the same time cause players respawn on those some spots

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
