### PR TITLE
Fix version current change failing to change if no former version available

### DIFF
--- a/apps/game_backend/lib/game_backend/configuration.ex
+++ b/apps/game_backend/lib/game_backend/configuration.ex
@@ -399,7 +399,14 @@ defmodule GameBackend.Configuration do
         {:ok, version}
       end
     end)
-    |> Multi.update(:former_version, Ecto.Changeset.change(former_version, %{current: false}))
+    |> Multi.run(:update_previous_version, fn _, _ ->
+      if former_version do
+        Ecto.Changeset.change(former_version, %{current: false})
+        |> Repo.update()
+      else
+        {:ok, :no_former_version}
+      end
+    end)
     |> Multi.update(:version, Ecto.Changeset.change(version, %{current: true}))
     |> Repo.transaction()
   end

--- a/apps/game_backend/lib/game_backend/configuration/version.ex
+++ b/apps/game_backend/lib/game_backend/configuration/version.ex
@@ -13,7 +13,7 @@ defmodule GameBackend.Configuration.Version do
 
   schema "versions" do
     field(:name, :string)
-    field(:current, :boolean)
+    field(:current, :boolean, default: false)
 
     has_many(:characters, Character)
     has_many(:consumable_items, ConsumableItem)

--- a/apps/game_backend/priv/repo/migrations/20240806205202_add_default_for_version_current.exs
+++ b/apps/game_backend/priv/repo/migrations/20240806205202_add_default_for_version_current.exs
@@ -1,0 +1,9 @@
+defmodule GameBackend.Repo.Migrations.AddDefaultForVersionCurrent do
+  use Ecto.Migration
+
+  def change do
+    alter table(:versions) do
+      modify :current, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

If you didn't have any version and it causes crashes when you wanted to set one as true

## Summary of changes

Add a handler for no former version

## How to test it?

Start with a db without any version and create a new one, you should be able to set that version as current

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
