### PR TITLE
[GH-842] Users screen information

### DIFF
--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -20,7 +20,7 @@ defmodule GameBackend.Users.User do
     Unlock
   }
 
-  @derive {Jason.Encoder, only: [:username, :currencies, :prestige]}
+  @derive {Jason.Encoder, only: [:username, :currencies, :prestige, :most_played_character, :total_kills, :won_matches]}
   schema "users" do
     field(:game_id, :integer)
     field(:username, :string)

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -31,7 +31,7 @@ defmodule GameBackend.Users.User do
     field(:last_kaline_afk_reward_claim, :utc_datetime)
     field(:last_dungeon_afk_reward_claim, :utc_datetime)
     field(:profile_picture, :string)
-    field(:prestige, :integer, virtual: true)
+    field(:highest_historical_prestige, :integer)
 
     belongs_to(:dungeon_settlement_level, DungeonSettlementLevel)
     belongs_to(:kaline_tree_level, KalineTreeLevel)
@@ -47,6 +47,12 @@ defmodule GameBackend.Users.User do
     has_many(:currency_caps, UserCurrencyCap)
 
     timestamps()
+
+    # Virtual fields for client rendering
+    field(:prestige, :integer, virtual: true)
+    field(:most_played_character, :string, virtual: true)
+    field(:total_kills, :integer, virtual: true)
+    field(:won_matches, :integer, virtual: true)
   end
 
   @doc false

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -20,7 +20,16 @@ defmodule GameBackend.Users.User do
     Unlock
   }
 
-  @derive {Jason.Encoder, only: [:username, :currencies, :prestige, :most_played_character, :total_kills, :won_matches]}
+  @derive {Jason.Encoder,
+           only: [
+             :username,
+             :currencies,
+             :prestige,
+             :most_played_character,
+             :total_kills,
+             :won_matches,
+             :highest_historical_prestige
+           ]}
   schema "users" do
     field(:game_id, :integer)
     field(:username, :string)
@@ -70,7 +79,8 @@ defmodule GameBackend.Users.User do
       :level,
       :experience,
       :profile_picture,
-      :google_user_id
+      :google_user_id,
+      :highest_historical_prestige
     ])
     |> cast_assoc(:unlocks)
     |> assoc_constraint(:google_user)

--- a/apps/game_backend/priv/repo/migrations/20240807215104_add_highest_historical_prestige_to_user.exs
+++ b/apps/game_backend/priv/repo/migrations/20240807215104_add_highest_historical_prestige_to_user.exs
@@ -1,0 +1,15 @@
+defmodule GameBackend.Repo.Migrations.AddHighestHistoricalPrestigeToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :highest_historical_prestige, :integer, default: 0
+    end
+
+    execute("""
+      UPDATE users u
+      SET highest_historical_prestige = (select sum(prestige) from units unit where unit.user_id = u.id)
+      where highest_historical_prestige = 0;
+    """, "")
+  end
+end


### PR DESCRIPTION
## Motivation

The client needed some information from the backend

Closes #842

## Summary of changes

- Fixed prestige count multiplying the actual prestige by the amount of matches that the user played
- Added `highest_historical_prestige` field to users and refactor `matches.ex` logic to update it after every match
- Added several virtual fields to fill and communicate them to the client in the `user` schema

## How to test it?

- Enter the game as a guest in Unity and copy the user_id:
<img width="664" alt="Captura de pantalla 2024-07-24 a la(s) 5 10 15 p  m" src="https://github.com/user-attachments/assets/bef03a34-20ce-4220-8227-5b1f11ac6d03">

- Run get through the terminal to see the user information
`curl -X GET  http://localhost:4001/curse/users/user_id`
- Play matches and check that this information is being updated correctly

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
