### PR TITLE
Fix over defense bug

### DIFF
--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -87,7 +87,9 @@ defmodule Arena.Game.Effect do
   end
 
   defp apply_stat_modifier(player, {:defense_change, defense_change}) do
-    update_in(player, [:aditional_info, :bonus_defense], fn bonus_defense -> bonus_defense + defense_change.modifier end)
+    update_in(player, [:aditional_info, :bonus_defense], fn bonus_defense ->
+      min(1.0, bonus_defense + defense_change.modifier)
+    end)
   end
 
   defp apply_stat_modifier(player, {:reduce_stamina_interval, reduce_stamina_interval}) do


### PR DESCRIPTION
## Motivation

When you play as kenzu and used both your ultimate and a gaint fruit you defense turned into 1.25 wich causes the damage to heal which broke the damage logic

## Summary of changes

Capped defense 

## How to test it?

Play as kenzu and use your ultimate and a giant fruit and then receive damage. That shouldn't break

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
