### PR TITLE
[GH-851] Add square map to seeds

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -29,7 +29,11 @@ defmodule Arena.Configuration do
 
     Jason.decode!(payload.body, [{:keys, :atoms}])
     |> Map.update!(:map, fn maps ->
-      map = Enum.random(maps)
+      map =
+        maps
+        |> Enum.filter(fn map -> map.active end)
+        |> Enum.random()
+
       parse_map_config(map)
     end)
     |> Map.update!(:characters, fn characters ->

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
@@ -2,6 +2,7 @@
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
+  <.input field={f[:active]} type="checkbox" label="Active" />
   <.input
     field={f[:version_id]}
     type="select"
@@ -9,7 +10,6 @@
     label="Version"
   /> <.input field={f[:name]} type="text" label="Name" />
   <.input field={f[:radius]} type="number" label="Radius" step="any" />
-  <.input field={f[:active]} type="select" options={[true, false]} label="Active" />
   <.input
     field={f[:initial_positions]}
     type="textarea"

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
@@ -9,6 +9,7 @@
     label="Version"
   /> <.input field={f[:name]} type="text" label="Name" />
   <.input field={f[:radius]} type="number" label="Radius" step="any" />
+  <.input field={f[:active]} type="select" options={[true, false]} label="Active" />
   <.input
     field={f[:initial_positions]}
     type="textarea"

--- a/apps/configurator/test/configurator/configuration_test.exs
+++ b/apps/configurator/test/configurator/configuration_test.exs
@@ -8,7 +8,7 @@ defmodule Configurator.ConfigurationTest do
 
     import Configurator.ConfigurationFixtures
 
-    @invalid_attrs %{radius: nil, initial_positions: nil, obstacles: nil, bushes: nil}
+    @invalid_attrs %{radius: nil, initial_positions: nil, obstacles: nil, bushes: nil, active: nil}
 
     test "get_map_configuration!/1 returns the map_configuration with given id" do
       map_configuration = map_configuration_fixture()
@@ -17,7 +17,15 @@ defmodule Configurator.ConfigurationTest do
 
     test "create_map_configuration/1 with valid data creates a map_configuration" do
       version = version_fixture()
-      valid_attrs = %{radius: "120.5", initial_positions: [], obstacles: [], bushes: [], version_id: version.id}
+
+      valid_attrs = %{
+        radius: "120.5",
+        initial_positions: [],
+        obstacles: [],
+        bushes: [],
+        version_id: version.id,
+        active: true
+      }
 
       assert {:ok, %MapConfiguration{} = map_configuration} = Configuration.create_map_configuration(valid_attrs)
       assert map_configuration.radius == Decimal.new("120.5")

--- a/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
@@ -5,9 +5,25 @@ defmodule ConfiguratorWeb.MapConfigurationControllerTest do
   import Configurator.AccountsFixtures
   setup [:create_authenticated_conn]
 
-  @create_attrs %{name: "some_map", radius: "120.5", initial_positions: "", obstacles: "", bushes: "", pools: ""}
-  @update_attrs %{name: "another_map", radius: "456.7", initial_positions: "", obstacles: "", bushes: "", pools: ""}
-  @invalid_attrs %{name: nil, radius: nil, initial_positions: nil, obstacles: nil, bushes: nil, pools: nil}
+  @create_attrs %{
+    name: "some_map",
+    radius: "120.5",
+    initial_positions: "",
+    obstacles: "",
+    bushes: "",
+    pools: "",
+    active: true
+  }
+  @update_attrs %{
+    name: "another_map",
+    radius: "456.7",
+    initial_positions: "",
+    obstacles: "",
+    bushes: "",
+    pools: "",
+    active: false
+  }
+  @invalid_attrs %{name: nil, radius: nil, initial_positions: nil, obstacles: nil, bushes: nil, pools: nil, active: nil}
 
   describe "index" do
     test "lists all map_configurations", %{conn: conn} do

--- a/apps/configurator/test/support/fixtures/configuration_fixtures.ex
+++ b/apps/configurator/test/support/fixtures/configuration_fixtures.ex
@@ -46,7 +46,8 @@ defmodule Configurator.ConfigurationFixtures do
         initial_positions: [],
         obstacles: [],
         radius: "120.5",
-        version_id: version.id
+        version_id: version.id,
+        active: true
       })
       |> GameBackend.Configuration.create_map_configuration()
 

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
@@ -6,10 +6,11 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
   import Ecto.Changeset
   alias GameBackend.Configuration.Version
 
-  @derive {Jason.Encoder, only: [:name, :radius, :initial_positions, :obstacles, :bushes, :pools]}
+  @derive {Jason.Encoder, only: [:name, :radius, :initial_positions, :obstacles, :bushes, :pools, :active]}
   schema "map_configurations" do
     field(:name, :string)
     field(:radius, :decimal)
+    field(:active, :boolean)
 
     embeds_many(:initial_positions, __MODULE__.Position, on_replace: :delete)
     embeds_many(:obstacles, __MODULE__.Obstacle, on_replace: :delete)
@@ -24,8 +25,8 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
   @doc false
   def changeset(map_configuration, attrs) do
     map_configuration
-    |> cast(attrs, [:radius, :name, :version_id])
-    |> validate_required([:radius, :version_id])
+    |> cast(attrs, [:radius, :name, :version_id, :active])
+    |> validate_required([:radius, :version_id, :active])
     |> cast_embed(:initial_positions)
     |> cast_embed(:obstacles)
     |> cast_embed(:bushes)

--- a/apps/game_backend/priv/repo/migrations/20240812135550_add_active_to_map_config.exs
+++ b/apps/game_backend/priv/repo/migrations/20240812135550_add_active_to_map_config.exs
@@ -1,0 +1,9 @@
+defmodule GameBackend.Repo.Migrations.AddActiveToMapConfig do
+  use Ecto.Migration
+
+  def change do
+    alter table(:map_configurations) do
+      add :active, :boolean, default: :false
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -882,9 +882,10 @@ polymorph_params = %{
 {:ok, _polymorph} =
   GameBackend.Items.create_consumable_item(polymorph_params)
 
-map_config = %{
+araban_map_config = %{
   name: "Araban",
   radius: 5520.0,
+  active: true,
   initial_positions: [
     %{
       x: 5360.0,
@@ -2503,7 +2504,172 @@ map_config = %{
   version_id: version.id
 }
 
-{:ok, _map_configuration_1} = GameBackend.Configuration.create_map_configuration(map_config)
+merliot_map_config = %{
+  name: "Merliot",
+  radius: 10000.0,
+  active: false,
+  initial_positions: [
+    %{
+      x: 5360.0,
+      y: -540.0
+    },
+    %{
+      x: -5130.0,
+      y: -920.0
+    },
+    %{
+      x: 555.0,
+      y: 4314.0
+    },
+    %{
+      x: 2750.0,
+      y: -4200.0
+    },
+    %{
+      x: -3700.0,
+      y: 2700.0
+    },
+    %{
+      x: 4250.0,
+      y: 3000.0
+    },
+    %{
+      x: -1842.0,
+      y: -4505.0
+    }
+  ],
+  obstacles: [
+    %{
+      name: "East wall",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      radius: 0.0,
+      shape: "polygon",
+      type: "static",
+      base_status: "",
+      statuses_cycle: %{},
+      vertices: [
+        %{
+          x: 6400.0,
+          y: 6800.0
+        },
+        %{
+          x: 6800.0,
+          y: 6800.0
+        },
+        %{
+          x: 6800.0,
+          y: -6800.0
+        },
+        %{
+          x: 6400.0,
+          y: -6800.0
+        }
+      ]
+    },
+    %{
+      name: "North wall",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      radius: 0.0,
+      shape: "polygon",
+      type: "static",
+      base_status: "",
+      statuses_cycle: %{},
+      vertices: [
+        %{
+          x: 6400.0,
+          y: 6400.0
+        },
+        %{
+          x: 6400.0,
+          y: 6800.0
+        },
+        %{
+          x: -6400.0,
+          y: 6800.0
+        },
+        %{
+          x: -6400.0,
+          y: 6400.0
+        }
+      ]
+    },
+    %{
+      name: "West wall",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      radius: 0.0,
+      shape: "polygon",
+      type: "static",
+      base_status: "",
+      statuses_cycle: %{},
+      vertices: [
+        %{
+          x: -6400.0,
+          y: 6800.0
+        },
+        %{
+          x: -6800.0,
+          y: 6800.0
+        },
+        %{
+          x: -6800.0,
+          y: -6800.0
+        },
+        %{
+          x: -6400.0,
+          y: -6800.0
+        }
+      ]
+    },
+    %{
+      name: "South wall",
+      position: %{
+        x: 0.0,
+        y: 0.0
+      },
+      radius: 0.0,
+      shape: "polygon",
+      type: "static",
+      base_status: "",
+      statuses_cycle: %{},
+      vertices: [
+        %{
+          x: -6400.0,
+          y: -6400.0
+        },
+        %{
+          x: 6400.0,
+          y: -6400.0
+        },
+        %{
+          x: 6400.0,
+          y: -6800.0
+        },
+        %{
+          x: -6400.0,
+          y: -6800.0
+        }
+      ]
+    }
+  ],
+  bushes: [],
+  pools: [],
+  version_id: version.id
+}
+
+{:ok, _araban_map_configuration} =
+  GameBackend.Configuration.create_map_configuration(araban_map_config)
+
+{:ok, _merliot_map_configuration} =
+  GameBackend.Configuration.create_map_configuration(merliot_map_config)
 
 GameBackend.CurseOfMirra.Config.import_quest_descriptions_config()
 


### PR DESCRIPTION
## Motivation

We are creating a new map and we need to create the seeds for it, also since we're picking a map at random we need a way to deactivate this new map since it stills in development

closes #851

## Summary of changes

- Added merliot map to seeds
- Added `active` field to map configs
- Filter `active` maps when creating a game

## How to test it?

Run the seeds and in the game configurator edit the `Merliot` map configuration `active` field to true, if you play in the game client you should sometimes encounter a square map

Test with this client branch and see if it works too: `merliot-map`

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
