### PR TITLE
[GH-852] Configurator: Migrate power up config

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -35,6 +35,9 @@ defmodule Arena.Configuration do
     |> Map.update!(:characters, fn characters ->
       parse_characters_config(characters)
     end)
+    |> Map.update!(:game, fn game ->
+      parse_game_config(game)
+    end)
   end
 
   defp get_client_config() do
@@ -211,6 +214,15 @@ defmodule Arena.Configuration do
 
   defp parse_position(%{x: x, y: y}) do
     %{x: maybe_to_float(x), y: maybe_to_float(y)}
+  end
+
+  defp parse_game_config(game_config) do
+    %{
+      game_config
+      | power_up_damage_modifier: maybe_to_float(game_config.power_up_damage_modifier),
+        power_up_health_modifier: maybe_to_float(game_config.power_up_health_modifier),
+        power_up_radius: maybe_to_float(game_config.power_up_radius)
+    }
   end
 
   defp maybe_to_float(nil), do: nil

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -104,14 +104,14 @@ defmodule Arena.Entities do
     }
   end
 
-  def new_power_up(id, position, direction, owner_id, power_up) do
+  def new_power_up(id, position, direction, owner_id, game_config) do
     %{
       id: id,
       category: :power_up,
       shape: :circle,
       name: "Power Up" <> Integer.to_string(id),
       position: position,
-      radius: power_up.radius,
+      radius: game_config.power_up_radius,
       vertices: [],
       speed: 0.0,
       direction: direction,
@@ -121,8 +121,8 @@ defmodule Arena.Entities do
         status: :UNAVAILABLE,
         remove_on_collision: true,
         pull_immunity: true,
-        power_up_damage_modifier: power_up.power_up_damage_modifier,
-        power_up_health_modifier: power_up.power_up_health_modifier
+        power_up_damage_modifier: game_config.power_up_damage_modifier,
+        power_up_health_modifier: game_config.power_up_health_modifier
       }
     }
   end

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -52,7 +52,7 @@ defmodule Arena.Entities do
         character_name: character.name,
         forced_movement: false,
         power_ups: 0,
-        power_up_damage_modifier: config.power_ups.power_up.power_up_damage_modifier,
+        power_up_damage_modifier: config.game.power_up_damage_modifier,
         inventory: nil,
         damage_immunity: false,
         pull_immunity: false,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -492,7 +492,7 @@ defmodule Arena.GameUpdater do
       ) do
     entry = %{killer_id: killer_id, victim_id: victim_id}
     victim = Map.get(game_state.players, victim_id)
-    amount_of_power_ups = get_amount_of_power_ups(victim, game_config.power_ups.power_ups_per_kill)
+    amount_of_power_ups = get_amount_of_power_ups(victim, game_config.game.power_ups_per_kill)
 
     game_state =
       game_state
@@ -1544,12 +1544,12 @@ defmodule Arena.GameUpdater do
          victim,
          amount
        ) do
-    distance_to_power_up = game_config.power_ups.power_up.distance_to_power_up
+    distance_to_power_up = game_config.game.distance_to_power_up
 
     Enum.reduce(1..amount//1, game_state, fn _, game_state ->
       random_position =
         random_position_in_map(
-          game_config.power_ups.power_up.radius,
+          game_config.game.power_up_radius,
           game_state.external_wall,
           game_state.obstacles,
           victim.position,
@@ -1564,10 +1564,10 @@ defmodule Arena.GameUpdater do
           random_position,
           victim.direction,
           victim.id,
-          game_config.power_ups.power_up
+          game_config.game
         )
 
-      Process.send_after(self(), {:activate_power_up, last_id}, game_config.power_ups.power_up.activation_delay_ms)
+      Process.send_after(self(), {:activate_power_up, last_id}, game_config.game.power_up_activation_delay_ms)
 
       game_state
       |> put_in([:power_ups, last_id], power_up)
@@ -1576,12 +1576,12 @@ defmodule Arena.GameUpdater do
   end
 
   defp get_amount_of_power_ups(%{aditional_info: %{power_ups: power_ups}}, power_ups_per_kill) do
-    Enum.sort_by(power_ups_per_kill, fn %{minimum_amount: minimum} -> minimum end, :desc)
-    |> Enum.find(fn %{minimum_amount: minimum} ->
+    Enum.sort_by(power_ups_per_kill, fn %{minimum_amount_of_power_ups: minimum} -> minimum end, :desc)
+    |> Enum.find(fn %{minimum_amount_of_power_ups: minimum} ->
       minimum <= power_ups
     end)
     |> case do
-      %{amount_of_drops: amount} -> amount
+      %{amount_of_power_ups_to_drop: amount} -> amount
       _ -> 0
     end
   end

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -1,27 +1,4 @@
 {
-  "power_ups": {
-    "power_ups_per_kill": [
-      {
-        "minimum_amount": 0,
-        "amount_of_drops": 1
-      },
-      {
-        "minimum_amount": 2,
-        "amount_of_drops": 2
-      },
-      {
-        "minimum_amount": 6,
-        "amount_of_drops": 3
-      }
-    ],
-    "power_up": {
-      "distance_to_power_up": 400,
-      "power_up_damage_modifier": 0.08,
-      "power_up_health_modifier": 0.08,
-      "radius": 200.0,
-      "activation_delay_ms": 500
-    }
-  },
   "effects": [
     {
       "name": "invisible",

--- a/apps/arena/priv/config.json
+++ b/apps/arena/priv/config.json
@@ -1,38 +1,4 @@
 {
-  "items": [
-    {
-      "name": "golden_clock",
-      "radius": 200.0,
-      "effects": [
-        "golden_clock_effect"
-      ],
-      "mechanics": {}
-    },
-    {
-      "name": "magic_boots",
-      "radius": 200.0,
-      "effects": [
-        "magic_boots_effect"
-      ],
-      "mechanics": {}
-    },
-    {
-      "name": "mirra_blessing",
-      "radius": 200.0,
-      "effects": [
-        "mirra_blessing_effect"
-      ],
-      "mechanics": {}
-    },
-    {
-      "name": "giant",
-      "radius": 200.0,
-      "effects": [
-        "giant_effect"
-      ],
-      "mechanics": {}
-    }
-  ],
   "power_ups": {
     "power_ups_per_kill": [
       {

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -41,7 +41,7 @@
         <.input
           field={power_ups_per_kill_f[:minimum_amount_of_power_ups]}
           type="number"
-          label="Minumim amount of power ups"
+          label="Minimum amount of power ups"
           step="any"
         />
       </div>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/game_configuration_form.html.heex
@@ -29,6 +29,33 @@
   <.input field={f[:field_of_view_inside_bush]} type="number" label="Field of view inside bush" />
   <.input field={f[:time_visible_in_bush_after_skill]} type="number" label="Field of view inside bush" />
 
+  <h2>Power Ups</h2>
+  <.input field={f[:distance_to_power_up]} type="number" label="Power Up spawn range" step="any" />
+  <.input field={f[:power_up_damage_modifier]} type="number" label="Power Up damage modifier" step="any" />
+  <.input field={f[:power_up_health_modifier]} type="number" label="Power Up health modifier" step="any" />
+  <.input field={f[:power_up_radius]} type="number" label="Power Up radius" step="any" />
+  <.input field={f[:power_up_activation_delay_ms]} type="number" label="Power Up activation delay" step="any" />
+  <.inputs_for :let={power_ups_per_kill_f} field={f[:power_ups_per_kill]}>
+    <div class=" w-full rounded overflow-hidden shadow-lg">
+      <div class="px-6 py-4">
+        <.input
+          field={power_ups_per_kill_f[:minimum_amount_of_power_ups]}
+          type="number"
+          label="Minumim amount of power ups"
+          step="any"
+        />
+      </div>
+      <div class="px-6 py-4">
+        <.input
+          field={power_ups_per_kill_f[:amount_of_power_ups_to_drop]}
+          type="number"
+          label="Amount of power ups to drop"
+          step="any"
+        />
+      </div>
+    </div>
+  </.inputs_for>
+
   <:actions>
     <.button>Save Game configuration</.button>
   </:actions>

--- a/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/game_configuration_html/show.html.heex
@@ -31,6 +31,24 @@
   <:item title="Time Visible After performing skill inside of bush">
     <%= @game_configuration.time_visible_in_bush_after_skill %>
   </:item>
+  <:item title="Power Up spawn range"><%= @game_configuration.distance_to_power_up %></:item>
+  <:item title="Power Up damage modifier"><%= @game_configuration.power_up_damage_modifier %></:item>
+  <:item title="Power Up health modifier"><%= @game_configuration.power_up_health_modifier %></:item>
+  <:item title="Power Up radius"><%= @game_configuration.power_up_radius %></:item>
+  <:item title="Power Up activation delay"><%= @game_configuration.power_up_activation_delay_ms %></:item>
 </.list>
+<.button type="button" phx-click={show_modal("show_power_ups_per_kill_config")}>Power up per kill config</.button>
+
+<.modal id="show_power_ups_per_kill_config">
+  <.header>
+    Power Up per kill config
+  </.header>
+  <%= for power_ups_per_kill <- @game_configuration.power_ups_per_kill do %>
+    <.list>
+      <:item title="Minimum amount of power ups"><%= power_ups_per_kill.minimum_amount_of_power_ups %></:item>
+      <:item title="Power ups to drop"><%= power_ups_per_kill.amount_of_power_ups_to_drop %></:item>
+    </.list>
+  <% end %>
+</.modal>
 
 <.back navigate={~p"/game_configurations"}>Back to game_configurations</.back>

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
@@ -28,7 +28,13 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     :match_timeout_ms,
     :field_of_view_inside_bush,
     :time_visible_in_bush_after_skill,
-    :version_id
+    :version_id,
+    :distance_to_power_up,
+    :power_up_damage_modifier,
+    :power_up_health_modifier,
+    :power_up_radius,
+    :power_up_activation_delay_ms,
+    :power_ups_per_kill
   ]
 
   @derive {Jason.Encoder, only: @required}
@@ -53,6 +59,13 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     field(:match_timeout_ms, :integer)
     field(:field_of_view_inside_bush, :integer)
     field(:time_visible_in_bush_after_skill, :integer)
+    field(:distance_to_power_up, :integer)
+    field(:power_up_damage_modifier, :float)
+    field(:power_up_health_modifier, :float)
+    field(:power_up_radius, :float)
+    field(:power_up_activation_delay_ms, :integer)
+
+    embeds_many(:power_ups_per_kill, __MODULE__.PowerUpPerKillAmount)
 
     belongs_to(:version, Version)
 
@@ -64,5 +77,25 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     game_configuration
     |> cast(attrs, @required)
     |> validate_required(@required)
+    |> cast_embed(:power_ups_per_kill)
+  end
+
+  defmodule PowerUpPerKillAmount do
+    @moduledoc """
+    Position embedded schema to be used by MapConfiguration
+    """
+    use GameBackend.Schema
+
+    @derive {Jason.Encoder, only: [:minimum_amount_of_power_ups, :amount_of_power_ups_to_drop]}
+    embedded_schema do
+      field(:minimum_amount_of_power_ups, :integer)
+      field(:amount_of_power_ups_to_drop, :integer)
+    end
+
+    def changeset(position, attrs) do
+      position
+      |> cast(attrs, [:minimum_amount_of_power_ups, :amount_of_power_ups_to_drop])
+      |> validate_required([:minimum_amount_of_power_ups, :amount_of_power_ups_to_drop])
+    end
   end
 end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/game_configuration.ex
@@ -33,11 +33,10 @@ defmodule GameBackend.CurseOfMirra.GameConfiguration do
     :power_up_damage_modifier,
     :power_up_health_modifier,
     :power_up_radius,
-    :power_up_activation_delay_ms,
-    :power_ups_per_kill
+    :power_up_activation_delay_ms
   ]
 
-  @derive {Jason.Encoder, only: @required}
+  @derive {Jason.Encoder, only: @required ++ [:power_ups_per_kill]}
   schema "game_configurations" do
     field(:tick_rate_ms, :integer)
     field(:bounty_pick_time_ms, :integer)

--- a/apps/game_backend/priv/repo/migrations/20240812142938_add_power_up_config_to_game_configuration.exs
+++ b/apps/game_backend/priv/repo/migrations/20240812142938_add_power_up_config_to_game_configuration.exs
@@ -1,0 +1,15 @@
+defmodule GameBackend.Repo.Migrations.AddPowerUpConfigToGameConfiguration do
+  use Ecto.Migration
+
+  def change do
+    alter table(:game_configurations) do
+      add :distance_to_power_up, :integer
+      add :power_up_damage_modifier, :float
+      add :power_up_health_modifier, :float
+      add :power_up_radius, :float
+      add :power_up_activation_delay_ms, :integer
+      add :power_ups_per_kill, :map
+    end
+
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -817,7 +817,26 @@ game_configuration_1 = %{
   match_timeout_ms: 300_000,
   field_of_view_inside_bush: 400,
   version_id: version.id,
-  time_visible_in_bush_after_skill: 2000
+  time_visible_in_bush_after_skill: 2000,
+  distance_to_power_up: 400,
+  power_up_damage_modifier: 0.08,
+  power_up_health_modifier: 0.08,
+  power_up_radius: 200.0,
+  power_up_activation_delay_ms: 500,
+  power_ups_per_kill: [
+    %{
+      minimum_amount_of_power_ups: 0,
+      amount_of_power_ups_to_drop: 1
+    },
+    %{
+      minimum_amount_of_power_ups: 2,
+      amount_of_power_ups_to_drop: 2
+    },
+    %{
+      minimum_amount_of_power_ups: 6,
+      amount_of_power_ups_to_drop: 3
+    }
+  ]
 }
 
 {:ok, _game_configuration_1} =


### PR DESCRIPTION
## Motivation

Keep migrating field from config.json to configurator app

Part of #852

## Summary of changes

- Created power up fields in game_configuration schema
- Added edit and update for these fields in configurator app
- Used game config instead of fields from json in game updater to spawn power ups


## How to test it?

Start a match and everything should keep working as before

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
