### PR TITLE
[GH-814] Add quests missing information

### DIFF
--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -297,10 +297,9 @@ defmodule GameBackend.CurseOfMirra.Quests do
 
   def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta} = meta_quest}, _arena_match_results, user) do
     user.user_quests
-    |> Enum.filter(fn %UserQuest{} = user_quest ->
+    |> Enum.count(fn %UserQuest{} = user_quest ->
       NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed"
     end)
-    |> Enum.count()
   end
 
   def get_user_quest_progress(%UserQuest{quest: %Quest{} = quest} = user_quest, arena_match_results, _user) do

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -298,7 +298,8 @@ defmodule GameBackend.CurseOfMirra.Quests do
   def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta} = meta_quest}, _arena_match_results, user) do
     user.user_quests
     |> Enum.count(fn %UserQuest{} = user_quest ->
-      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed"
+      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed" &&
+        user_quest.quest.type == "daily"
     end)
   end
 

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -295,10 +295,11 @@ defmodule GameBackend.CurseOfMirra.Quests do
     |> Repo.transaction()
   end
 
-  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta} = meta_quest}, user) do
+  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :milestone} = milestone_quest}, user) do
     user.user_quests
     |> Enum.count(fn %UserQuest{} = user_quest ->
-      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 and user_quest.status == "completed" and
+      NaiveDateTime.diff(user_quest.inserted_at, milestone_quest.inserted_at, :day) == 0 and
+        user_quest.status == "completed" and
         user_quest.quest.type == :daily
     end)
   end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -298,7 +298,7 @@ defmodule GameBackend.CurseOfMirra.Quests do
   def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta} = meta_quest}, user) do
     user.user_quests
     |> Enum.count(fn %UserQuest{} = user_quest ->
-      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed" &&
+      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 and user_quest.status == "completed" and
         user_quest.quest.type == :daily
     end)
   end
@@ -341,7 +341,7 @@ defmodule GameBackend.CurseOfMirra.Quests do
 
     Multi.new()
     |> Multi.run(:check_quest_completed, fn _, _ ->
-      if user_quest.status == "available" && Quests.completed_quest?(user_quest, user) do
+      if user_quest.status == "available" and Quests.completed_quest?(user_quest, user) do
         {:ok, :quest_completed}
       else
         {:error, :unfinished_quest}

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -299,7 +299,7 @@ defmodule GameBackend.CurseOfMirra.Quests do
     user.user_quests
     |> Enum.count(fn %UserQuest{} = user_quest ->
       NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed" &&
-        user_quest.quest.type == "daily"
+        user_quest.quest.type == :daily
     end)
   end
 

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -295,12 +295,10 @@ defmodule GameBackend.CurseOfMirra.Quests do
     |> Repo.transaction()
   end
 
-  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta}}, _arena_match_results, user) do
-    naive_today = NaiveDateTime.utc_now()
-
+  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :meta} = meta_quest}, _arena_match_results, user) do
     user.user_quests
     |> Enum.filter(fn %UserQuest{} = user_quest ->
-      NaiveDateTime.diff(user_quest.inserted_at, naive_today, :day) == 0 && user_quest.status == "completed"
+      NaiveDateTime.diff(user_quest.inserted_at, meta_quest.inserted_at, :day) == 0 && user_quest.status == "completed"
     end)
     |> Enum.count()
   end

--- a/apps/game_backend/lib/game_backend/quests/quest.ex
+++ b/apps/game_backend/lib/game_backend/quests/quest.ex
@@ -11,7 +11,7 @@ defmodule GameBackend.Quests.Quest do
   @derive {Jason.Encoder, only: [:description, :conditions, :objective, :id, :reward, :type]}
   schema "quests" do
     field(:description, :string)
-    field(:type, Ecto.Enum, values: [:daily, :bounty, :weekly, :meta])
+    field(:type, Ecto.Enum, values: [:daily, :bounty, :weekly, :milestone])
     field(:objective, :map)
     field(:reward, :map)
     field(:config_id, :integer)

--- a/apps/game_backend/lib/game_backend/quests/quest.ex
+++ b/apps/game_backend/lib/game_backend/quests/quest.ex
@@ -11,7 +11,7 @@ defmodule GameBackend.Quests.Quest do
   @derive {Jason.Encoder, only: [:description, :conditions, :objective, :id, :reward]}
   schema "quests" do
     field(:description, :string)
-    field(:type, Ecto.Enum, values: [:daily, :bounty, :weekly])
+    field(:type, Ecto.Enum, values: [:daily, :bounty, :weekly, :meta])
     field(:objective, :map)
     field(:reward, :map)
     field(:config_id, :integer)

--- a/apps/game_backend/lib/game_backend/quests/quest.ex
+++ b/apps/game_backend/lib/game_backend/quests/quest.ex
@@ -8,7 +8,7 @@ defmodule GameBackend.Quests.Quest do
   use GameBackend.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:description, :conditions, :objective, :id, :reward]}
+  @derive {Jason.Encoder, only: [:description, :conditions, :objective, :id, :reward, :type]}
   schema "quests" do
     field(:description, :string)
     field(:type, Ecto.Enum, values: [:daily, :bounty, :weekly, :meta])

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -625,7 +625,7 @@ defmodule GameBackend.Users do
     updated_quests =
       Enum.map(user.user_quests, fn user_quest ->
         quest_progress =
-          Quests.get_user_quest_progress(user_quest, user.arena_match_results, user)
+          Quests.get_user_quest_progress(user_quest, user)
 
         Map.put(user_quest, :progress, quest_progress)
         |> Map.put(:goal, user_quest.quest.objective["value"])

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -635,13 +635,13 @@ defmodule GameBackend.Users do
       Enum.map(Date.range(start_of_week, end_of_week), fn date ->
         completed_quests_amount =
           Enum.count(user.user_quests, fn user_quest ->
-            user_quest.status == "completed" && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0 &&
+            user_quest.status == "completed" and Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0 and
               user_quest.quest.type == :daily
           end)
 
         meta_quest_value =
           Enum.find(user.user_quests, fn user_quest ->
-            user_quest.quest.type == :meta && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
+            user_quest.quest.type == :meta and Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
           end)
           |> case do
             nil ->
@@ -734,8 +734,7 @@ defmodule GameBackend.Users do
 
     meta_quest_params =
       Quests.get_user_missing_quests_by_type(user.id, "meta")
-      |> Enum.shuffle()
-      |> hd()
+      |> Enum.random()
 
     attrs = %{
       user_id: user.id,

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -635,7 +635,8 @@ defmodule GameBackend.Users do
       Enum.map(Date.range(start_of_week, end_of_week), fn date ->
         completed_quests_amount =
           Enum.count(user.user_quests, fn user_quest ->
-            user_quest.status == "completed" && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
+            user_quest.status == "completed" && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0 &&
+              user_quest.quest.type == :daily
           end)
 
         %{

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -641,7 +641,7 @@ defmodule GameBackend.Users do
 
         meta_quest_value =
           Enum.find(user.user_quests, fn user_quest ->
-            user_quest.quest.type == :daily && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
+            user_quest.quest.type == :meta && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
           end)
           |> case do
             nil ->

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -639,11 +639,23 @@ defmodule GameBackend.Users do
               user_quest.quest.type == :daily
           end)
 
+        meta_quest_value =
+          Enum.find(user.user_quests, fn user_quest ->
+            user_quest.quest.type == :daily && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0
+          end)
+          |> case do
+            nil ->
+              # We'll hardcore this value for the time being since we don't have any spec for the specific amount, that's
+              # described in the meta quest but we could have more than one in the future
+              6
+
+            meta_quest ->
+              meta_quest.quest.objective["value"]
+          end
+
         %{
           completed_quests_amount: completed_quests_amount,
-          # We'll hardcore this value for the time being since we don't have any spec for the specific amount, that's
-          # described in the meta quest but we could have more than one in the future
-          target_quests_amount: 6,
+          target_quests_amount: meta_quest_value,
           date: date
         }
       end)

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -620,6 +620,7 @@ defmodule GameBackend.Users do
   defp add_quest_progress_and_goal(%User{} = user) do
     today = Date.utc_today()
     start_of_week = Date.beginning_of_week(today, :sunday)
+    end_of_week = Date.add(start_of_week, 6)
 
     updated_quests =
       Enum.map(user.user_quests, fn user_quest ->
@@ -631,7 +632,7 @@ defmodule GameBackend.Users do
       end)
 
     daily_quests_week_progress =
-      Enum.map(Date.range(start_of_week, today), fn date ->
+      Enum.map(Date.range(start_of_week, end_of_week), fn date ->
         completed_quests_amount =
           Enum.count(user.user_quests, fn user_quest ->
             user_quest.status == "completed" && Date.diff(date, NaiveDateTime.to_date(user_quest.inserted_at)) == 0

--- a/apps/game_backend/lib/game_backend/users/user.ex
+++ b/apps/game_backend/lib/game_backend/users/user.ex
@@ -30,7 +30,8 @@ defmodule GameBackend.Users.User do
              :won_matches,
              :highest_historical_prestige,
              :user_quests,
-             :quest_refresh_at
+             :quest_refresh_at,
+             :daily_quests_week_progress
            ]}
   schema "users" do
     field(:game_id, :integer)
@@ -66,6 +67,7 @@ defmodule GameBackend.Users.User do
     field(:total_kills, :integer, virtual: true)
     field(:won_matches, :integer, virtual: true)
     field(:quest_refresh_at, :any, virtual: true)
+    field(:daily_quests_week_progress, :any, virtual: true)
   end
 
   @doc false

--- a/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
+++ b/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
@@ -256,7 +256,7 @@
         "type": "meta",
         "objective": {
             "match_tracking_field": "quest",
-            "value": 2,
+            "value": 6,
             "comparison": "greater_or_equal",
             "scope": "match"
         },

--- a/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
+++ b/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
@@ -253,7 +253,7 @@
     {
         "config_id": 13,
         "description": "Complete 6 Daily Quests",
-        "type": "meta",
+        "type": "milestone",
         "objective": {
             "match_tracking_field": "quest",
             "value": 6,

--- a/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
+++ b/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
@@ -249,5 +249,21 @@
             "currency": "Gold",
             "amount": 444
         }
+    },
+    {
+        "config_id": 13,
+        "description": "Complete 6 Daily Quests",
+        "type": "meta",
+        "objective": {
+            "match_tracking_field": "quest",
+            "value": 2,
+            "comparison": "greater_or_equal",
+            "scope": "match"
+        },
+        "conditions": [],
+        "reward": {
+            "currency": "Gold",
+            "amount": 10000
+        }
     }
 ]


### PR DESCRIPTION
> [!warning]
> Test with [This client branch](https://github.com/lambdaclass/champions_of_mirra/pull/2069)
> This pr can be merged without the client pr

## Motivation

We need to include a new kind of quest called "meta", the progress for this quest isn't accumulated by matches but by completed quests in the same day as the date of creation of the meta quest

Also we need to send the player how many quests the user has completed in the week starting from sunday all the way to saturday. With the max that would be the meta quest objective value

Closes #814

## Summary of changes

- Added  "meta" quest type
- Generate meta quests alongside daily quests
- Change `get_user_quest_progress` to handle meta quests differently
- Add `daily_quests_week_progress` to users to send the daily quest progress to the client

## How to test it?

- Enter the game as a guest in Unity and copy the user_id:
<img width="664" alt="Captura de pantalla 2024-07-24 a la(s) 5 10 15 p  m" src="https://github.com/user-attachments/assets/bef03a34-20ce-4220-8227-5b1f11ac6d03">

- Get to see if he has any quest
`curl -X GET  http://localhost:4001/curse/users/user_id`

- Play a match in unity and lose 

- if you run the get endpoint again you should see that the quest has some progress depending on your actions in the match, there's a quest that you need to lose a match to complete, copy that quest "id" field and run the following command:
`curl -X GET  http://localhost:4001/curse/users/user_id/quest/quest_id/complete_quest`

- Get the user and check that the quest is finished and a new quest turn actives, this means that it has a value in `activated_at`
`curl -X GET  http://localhost:4001/curse/users/user_id`

The meta quest should have some progress

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
