### PR TITLE
Add new gateway url to servers

### DIFF
--- a/.github/workflows/central-europe-testing-deploy.yml
+++ b/.github/workflows/central-europe-testing-deploy.yml
@@ -1,4 +1,4 @@
-name: "[CENTRAL-EUROPE] Deploy to Europe Central testing"
+name: "[CENTRAL-TESTING] Deploy to Europe Central testing"
 on:
   workflow_dispatch:
 

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_html/arena_server_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_html/arena_server_form.html.heex
@@ -6,6 +6,16 @@
   <.input field={f[:ip]} type="text" label="Ip" />
   <.input field={f[:url]} type="text" label="Url" />
   <.input
+    field={f[:gateway_url]}
+    type="select"
+    label="Gateway Url"
+    prompt="Choose a value"
+    options={[
+      "https://central-europe-testing.championsofmirra.com",
+      "https://central-europe-staging.championsofmirra.com"
+    ]}
+  />
+  <.input
     field={f[:status]}
     type="select"
     label="Status"

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_html/index.html.heex
@@ -11,6 +11,7 @@
   <:col :let={arena_server} label="Name"><%= arena_server.name %></:col>
   <:col :let={arena_server} label="Ip"><%= arena_server.ip %></:col>
   <:col :let={arena_server} label="Url"><%= arena_server.url %></:col>
+  <:col :let={arena_server} label="Gateway Url"><%= arena_server.gateway_url %></:col>
   <:col :let={arena_server} label="Status"><%= arena_server.status %></:col>
   <:col :let={arena_server} label="Environment"><%= arena_server.environment %></:col>
   <:action :let={arena_server}>

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_html/show.html.heex
@@ -12,6 +12,7 @@
   <:item title="Name"><%= @arena_server.name %></:item>
   <:item title="Ip"><%= @arena_server.ip %></:item>
   <:item title="Url"><%= @arena_server.url %></:item>
+  <:item title="Gateway Url"><%= @arena_server.gateway_url %></:item>
   <:item title="Status"><%= @arena_server.status %></:item>
   <:item title="Environment"><%= @arena_server.environment %></:item>
 </.list>

--- a/apps/configurator/test/configurator/configuration_test.exs
+++ b/apps/configurator/test/configurator/configuration_test.exs
@@ -82,7 +82,14 @@ defmodule Configurator.ConfigurationTest do
     end
 
     test "create_arena_server/1 with valid data creates a arena_server" do
-      valid_attrs = %{name: "some name", ip: "some ip", url: "some url", status: :active, environment: :production}
+      valid_attrs = %{
+        name: "some name",
+        ip: "some ip",
+        url: "some url",
+        gateway_url: "some GATEWAY url",
+        status: :active,
+        environment: :production
+      }
 
       assert {:ok, %ArenaServer{} = arena_server} = Configuration.create_arena_server(valid_attrs)
       assert arena_server.name == "some name"

--- a/apps/configurator/test/configurator_web/controllers/arena_server_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/arena_server_controller_test.exs
@@ -7,7 +7,14 @@ defmodule ConfiguratorWeb.ArenaServerControllerTest do
 
   setup [:create_authenticated_conn]
 
-  @create_attrs %{name: "some name", ip: "some ip", url: "some url", gateway_url: "some gateway url", status: :active, environment: :production}
+  @create_attrs %{
+    name: "some name",
+    ip: "some ip",
+    url: "some url",
+    gateway_url: "some gateway url",
+    status: :active,
+    environment: :production
+  }
   @update_attrs %{
     name: "some updated name",
     ip: "some updated ip",

--- a/apps/configurator/test/configurator_web/controllers/arena_server_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/arena_server_controller_test.exs
@@ -7,11 +7,12 @@ defmodule ConfiguratorWeb.ArenaServerControllerTest do
 
   setup [:create_authenticated_conn]
 
-  @create_attrs %{name: "some name", ip: "some ip", url: "some url", status: :active, environment: :production}
+  @create_attrs %{name: "some name", ip: "some ip", url: "some url", gateway_url: "some gateway url", status: :active, environment: :production}
   @update_attrs %{
     name: "some updated name",
     ip: "some updated ip",
     url: "some updated url",
+    gateway_url: "some updated GATEWAY url",
     status: :inactive,
     environment: :development
   }

--- a/apps/configurator/test/support/fixtures/configuration_fixtures.ex
+++ b/apps/configurator/test/support/fixtures/configuration_fixtures.ex
@@ -64,6 +64,7 @@ defmodule Configurator.ConfigurationFixtures do
         ip: "some ip",
         name: "some name",
         url: "some url",
+        gateway_url: "some GATEWAY url",
         status: :active,
         environment: :production
       })

--- a/apps/game_backend/lib/game_backend/arena_servers/arena_server.ex
+++ b/apps/game_backend/lib/game_backend/arena_servers/arena_server.ex
@@ -5,7 +5,7 @@ defmodule GameBackend.ArenaServers.ArenaServer do
   use GameBackend.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:name, :ip, :url, :status, :environment]}
+  @derive {Jason.Encoder, only: [:name, :ip, :url, :gateway_url, :status, :environment]}
   schema "arena_servers" do
     field(:name, :string)
     field(:ip, :string)

--- a/apps/game_backend/lib/game_backend/arena_servers/arena_server.ex
+++ b/apps/game_backend/lib/game_backend/arena_servers/arena_server.ex
@@ -10,6 +10,7 @@ defmodule GameBackend.ArenaServers.ArenaServer do
     field(:name, :string)
     field(:ip, :string)
     field(:url, :string)
+    field(:gateway_url, :string)
     field(:status, Ecto.Enum, values: [:active, :inactive])
     field(:environment, Ecto.Enum, values: [:production, :development, :staging])
 
@@ -19,7 +20,7 @@ defmodule GameBackend.ArenaServers.ArenaServer do
   @doc false
   def changeset(arena_server, attrs) do
     arena_server
-    |> cast(attrs, [:name, :ip, :url, :status, :environment])
-    |> validate_required([:name, :url, :status, :environment])
+    |> cast(attrs, [:name, :ip, :url, :status, :environment, :gateway_url])
+    |> validate_required([:name, :url, :status, :environment, :gateway_url])
   end
 end

--- a/apps/game_backend/priv/repo/migrations/20240801203531_create_arena_servers.exs
+++ b/apps/game_backend/priv/repo/migrations/20240801203531_create_arena_servers.exs
@@ -1,4 +1,4 @@
-defmodule Configurator.Repo.Migrations.CreateArenaServers do
+defmodule GameBackend.Repo.Migrations.CreateArenaServers do
   use Ecto.Migration
 
   def change do

--- a/apps/game_backend/priv/repo/migrations/20240823152743_add_gateway_url_field_to_arena_servers.exs
+++ b/apps/game_backend/priv/repo/migrations/20240823152743_add_gateway_url_field_to_arena_servers.exs
@@ -1,0 +1,9 @@
+defmodule GameBackend.Repo.Migrations.AddGatewayUrlFieldToArenaServers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:arena_servers) do
+      add :gateway_url, :string
+    end
+  end
+end

--- a/apps/game_backend/priv/repo/migrations/20240823152743_add_gateway_url_field_to_arena_servers.exs
+++ b/apps/game_backend/priv/repo/migrations/20240823152743_add_gateway_url_field_to_arena_servers.exs
@@ -5,5 +5,10 @@ defmodule GameBackend.Repo.Migrations.AddGatewayUrlFieldToArenaServers do
     alter table(:arena_servers) do
       add :gateway_url, :string
     end
+
+    execute("""
+    UPDATE arena_servers arena_server
+    SET gateway_url = 'https://central-europe-staging.championsofmirra.com';
+    """, "")
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -3068,6 +3068,7 @@ brazil_arena_server =
     name: "BRAZIL",
     ip: "",
     url: "arena-brazil-staging.championsofmirra.com",
+    gateway_url: "https://central-europe-staging.championsofmirra.com",
     status: "active",
     environment: "production"
   }
@@ -3079,6 +3080,7 @@ europe_arena_server =
     name: "EUROPE",
     ip: "",
     url: "arena-europe-testing.championsofmirra.com",
+    gateway_url: "https://central-europe-staging.championsofmirra.com",
     status: "active",
     environment: "production"
   }


### PR DESCRIPTION
>[!Warning]
> Merge with https://github.com/lambdaclass/champions_of_mirra/pull/2065

## Motivation

We need a way to link Arena servers and Central ones.

## Summary of changes

- [Rename central testing workflow](https://github.com/lambdaclass/mirra_backend/pull/879/commits/5245fde14ed94e472049114d70015567a46e0bee)
- [Add new gateway_url field to servers](https://github.com/lambdaclass/mirra_backend/pull/879/commits/51497d71ff1b97c0f46c402208198490b453721a)
- [Add new gateway_url field to html templates](https://github.com/lambdaclass/mirra_backend/pull/879/commits/033fd1f10fa034f939106b5469bde976f002e45b)
- [Rename wrongly named module migration](https://github.com/lambdaclass/mirra_backend/pull/879/commits/da6ca4a230a66cffcdd9077ff1343a8a740f6bbc)
- [Set gateway_url for existing servers](https://github.com/lambdaclass/mirra_backend/pull/879/commits/3c3a08862a2999e8f01d37550aefed91f772625b)
- [Add gateway url to JSON encoder](https://github.com/lambdaclass/mirra_backend/pull/879/commits/a3eb277a888ac5c216253f84c3747812bcbe66ef)
- [Fix configurator tests](https://github.com/lambdaclass/mirra_backend/pull/879/commits/9aff414f48931fbba9353ea423b2efdeab8e6fb7)
- [Fix seeds](https://github.com/lambdaclass/mirra_backend/pull/879/commits/ede8bb71d4cd3a774c61871e4cd90e3fa916c0eb)

## How to test it?

Change gateway_url in configurator (or localhost:4001) for arena servers.
Both testing and staging gateway_url's should work fine.
Use the following client branch -> https://github.com/lambdaclass/champions_of_mirra/pull/2065

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
