### PR TITLE
Fix matches not being registered if there's a kenzu in the match

### DIFF
--- a/apps/game_backend/lib/game_backend/matches/arena_match_result.ex
+++ b/apps/game_backend/lib/game_backend/matches/arena_match_result.ex
@@ -54,8 +54,8 @@ defmodule GameBackend.Matches.ArenaMatchResult do
     |> validate_inclusion(:result, ["win", "loss", "abandon"])
     ## TODO: This enums should actually be read from config
     ##    https://github.com/lambdaclass/mirra_backend/issues/601
-    |> validate_inclusion(:character, ["h4ck", "muflus", "uma", "valtimer", "otix"])
-    |> validate_inclusion(:killed_by, ["h4ck", "muflus", "uma", "valtimer", "otix", "zone"])
+    |> validate_inclusion(:character, ["h4ck", "muflus", "uma", "valtimer", "kenzu", "otix"])
+    |> validate_inclusion(:killed_by, ["h4ck", "muflus", "uma", "valtimer", "kenzu", "otix", "zone"])
     |> foreign_key_constraint(:user_id)
   end
 end


### PR DESCRIPTION
## Motivation

The matches were not being registered in the backend. This was due to a validation in the GameBackend.Matches.ArenaMatchResult schema that check the character name

## Summary of changes

Add kenzu to the valid players to be registered

## How to test it?

Play as kenzu and the match should be registered

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
