### PR TITLE
Fix collisionable entities initialization inside enum reduce.

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1201,12 +1201,12 @@ defmodule Arena.GameUpdater do
 
         collided_entity = decide_collided_entity(projectile, collides_with, external_wall.id, players_acc, crates_acc)
 
-        collsionable_entities =
-          Map.merge(players, crates)
+        collisionable_entities =
+          Map.merge(players_acc, crates_acc)
 
         process_projectile_collision(
           projectile,
-          Map.get(collsionable_entities, collided_entity),
+          Map.get(collisionable_entities, collided_entity),
           Map.get(obstacles, collided_entity),
           collided_entity == external_wall.id,
           accs


### PR DESCRIPTION
Also fix typo.

## Motivation

Projectiles are hitting once instead of three when you shoot from close.

## Summary of changes

Change the initialization of colliding entities.

## How to test it?

Shot close of a crate or a player with H4ck. You should hit with all of your projectiles now.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
