### PR TITLE
Fix central ssh host for testing deployment

### DIFF
--- a/.github/workflows/central-europe-testing-deploy.yml
+++ b/.github/workflows/central-europe-testing-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create ssh private key file from env var
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_HOST: ${{ vars.TS_CENTRAL_HOST }}
+          SSH_HOST: ${{ vars.TS_CENTRAL_TESTING_HOST }}
         run: |
           set -ex
           mkdir -p ~/.ssh/
@@ -34,14 +34,14 @@ jobs:
       - name: Copy deploy script
         env:
           SSH_USERNAME: ${{ vars.SSH_USERNAME }}
-          SSH_HOST: ${{ vars.TS_CENTRAL_HOST }}
+          SSH_HOST: ${{ vars.TS_CENTRAL_TESTING_HOST }}
         run: |
           set -ex
           rsync -avz --mkpath devops/deploy.sh ${SSH_USERNAME}@${SSH_HOST}:/home/${SSH_USERNAME}/deploy-script/
 
       - name: Execute deploy script
         env:
-          SSH_HOST: ${{ vars.TS_CENTRAL_HOST }}
+          SSH_HOST: ${{ vars.TS_CENTRAL_TESTING_HOST }}
           SSH_USERNAME: ${{ vars.SSH_USERNAME }}
           MIX_ENV: ${{ vars.MIX_ENV }}
           RELEASE: central_backend


### PR DESCRIPTION
## Motivation

Central testing deployment was deploying staging instead.

## Summary of changes

[Fix central ssh host for testing deployment](https://github.com/lambdaclass/mirra_backend/pull/884/commits/41eb6203712667185448ba9eaf04b7d1698bb6fc)

## How to test it?

Deploy testing central, it should deploy testing central.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
