### PR TITLE
Fixes for players visibility on bushes 

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -65,7 +65,8 @@ defmodule Arena.Entities do
         bounties: [],
         selected_bounty: nil,
         bounty_completed: false,
-        current_basic_animation: 0
+        current_basic_animation: 0,
+        item_effect_duration: now
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -66,7 +66,7 @@ defmodule Arena.Entities do
         selected_bounty: nil,
         bounty_completed: false,
         current_basic_animation: 0,
-        item_effect_duration: now
+        item_effects_expires_at: now
       },
       collides_with: []
     }

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -417,6 +417,16 @@ defmodule Arena.Game.Player do
     |> Effect.apply_stat_effects()
   end
 
+  def player_executing_skill(player) do
+    Enum.any?(player.aditional_info.current_actions, fn current_action ->
+      Atom.to_string(current_action.action)
+      |> case do
+        "EXECUTING_SKILL" <> _number -> true
+        _ -> false
+      end
+    end)
+  end
+
   ####################
   # Internal helpers #
   ####################

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1735,8 +1735,17 @@ defmodule Arena.GameUpdater do
           player_has_item_effect? =
             candidate_player.aditional_info.item_effect_duration > now
 
+          player_is_executing_skill? =
+            Enum.any?(candidate_player.aditional_info.current_actions, fn current_action ->
+              Atom.to_string(current_action.action)
+              |> case do
+                "EXECUTING_SKILL" <> _number -> true
+                _ -> false
+              end
+            end)
+
           if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) or
-               enough_time_since_last_skill? or player_has_item_effect? do
+               enough_time_since_last_skill? or player_has_item_effect? or player_is_executing_skill? do
             [candicandidate_player_id | acc]
           else
             acc

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1733,9 +1733,9 @@ defmodule Arena.GameUpdater do
               game_config.game.time_visible_in_bush_after_skill
 
           player_has_item_effect? =
-            candidate_player.aditional_info.item_effect_duration > now
+            candidate_player.aditional_info.item_effects_expires_at > now
 
-          player_is_executing_skill? = Player.player_executing_skill(candidate_player)
+          player_is_executing_skill? = Player.player_executing_skill?(candidate_player)
 
           if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) or
                enough_time_since_last_skill? or player_has_item_effect? or player_is_executing_skill? do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1735,14 +1735,7 @@ defmodule Arena.GameUpdater do
           player_has_item_effect? =
             candidate_player.aditional_info.item_effect_duration > now
 
-          player_is_executing_skill? =
-            Enum.any?(candidate_player.aditional_info.current_actions, fn current_action ->
-              Atom.to_string(current_action.action)
-              |> case do
-                "EXECUTING_SKILL" <> _number -> true
-                _ -> false
-              end
-            end)
+          player_is_executing_skill? = Player.player_executing_skill(candidate_player)
 
           if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) or
                enough_time_since_last_skill? or player_has_item_effect? or player_is_executing_skill? do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1732,8 +1732,11 @@ defmodule Arena.GameUpdater do
             now - candidate_player.aditional_info.last_skill_triggered_inside_bush <
               game_config.game.time_visible_in_bush_after_skill
 
+          player_has_item_effect? =
+            candidate_player.aditional_info.item_effect_duration > now
+
           if Enum.empty?(candidate_bush_collisions) or (players_in_same_bush? and players_close_enough?) or
-               enough_time_since_last_skill? do
+               enough_time_since_last_skill? or player_has_item_effect? do
             [candicandidate_player_id | acc]
           else
             acc


### PR DESCRIPTION
## Motivation

We need to always show players with an item effect active or if they are executing an skill

## Summary of changes

Add item effect duration to players entity to identify items duration

## How to test it?

Using another client use an item and go inside a bush, you should be able to see that client as ling as it has the item effect

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
