### PR TITLE
Fix crate bug in map configuration editing

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_controller.ex
@@ -162,6 +162,7 @@ defmodule ConfiguratorWeb.MapConfigurationController do
     |> Map.update("obstacles", "", &parse_json/1)
     |> Map.update("bushes", "", &parse_json/1)
     |> Map.update("pools", "", &parse_json/1)
+    |> Map.update("crates", "", &parse_json/1)
   end
 
   defp parse_json(""), do: []

--- a/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/map_configuration_controller_test.exs
@@ -12,6 +12,7 @@ defmodule ConfiguratorWeb.MapConfigurationControllerTest do
     obstacles: "",
     bushes: "",
     pools: "",
+    crates: "",
     active: true
   }
   @update_attrs %{
@@ -21,9 +22,19 @@ defmodule ConfiguratorWeb.MapConfigurationControllerTest do
     obstacles: "",
     bushes: "",
     pools: "",
+    crates: "",
     active: false
   }
-  @invalid_attrs %{name: nil, radius: nil, initial_positions: nil, obstacles: nil, bushes: nil, pools: nil, active: nil}
+  @invalid_attrs %{
+    name: nil,
+    radius: nil,
+    initial_positions: nil,
+    obstacles: nil,
+    bushes: nil,
+    pools: nil,
+    crates: nil,
+    active: nil
+  }
 
   describe "index" do
     test "lists all map_configurations", %{conn: conn} do


### PR DESCRIPTION
## Motivation

You were not able to edit any map configuration since the crates would always fail

## Summary of changes

Add crates json parse to map configuration controller

## How to test it?

Edit a map configuration

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
