### PR TITLE
Fix brazil server url

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -3317,7 +3317,7 @@ brazil_arena_server =
   %{
     name: "BRAZIL",
     ip: "",
-    url: "arena-brazil-staging.championsofmirra.com",
+    url: "arena-brazil-testing-aws.championsofmirra.com",
     gateway_url: "https://central-europe-staging.championsofmirra.com",
     status: "active",
     environment: "production"


### PR DESCRIPTION
## Motivation
If you use the servers present on seeds you get an error since the brazil url no longer exists

## Summary of changes

Update brazil url

## How to test it?

In the client change the GATEWAY_URL variabel to "http://localhost:4001" and it should break

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
