### PR TITLE
Filter out destroyed crates in collision calculation

### DIFF
--- a/apps/arena/lib/arena/game/crate.ex
+++ b/apps/arena/lib/arena/game/crate.ex
@@ -10,7 +10,7 @@ defmodule Arena.Game.Crate do
     crate.aditional_info.health > 0
   end
 
-  def interactable_crates(crates) do
+  def alive_crates(crates) do
     Map.filter(crates, fn {_crate_id, crate} -> alive?(crate) end)
   end
 end

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -221,7 +221,7 @@ defmodule Arena.Game.Player do
           |> Skill.maybe_auto_aim(skill, player, targetable_players(game_state.players))
           |> case do
             {false, _} ->
-              Skill.maybe_auto_aim(skill_params.target, skill, player, Crate.interactable_crates(game_state.crates))
+              Skill.maybe_auto_aim(skill_params.target, skill, player, Crate.alive_crates(game_state.crates))
 
             auto_aim ->
               auto_aim

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -468,11 +468,11 @@ defmodule Arena.Game.Skill do
 
     # Crates
 
-    interactable_crates =
-      Crate.interactable_crates(game_state.crates)
+    alive_crates =
+      Crate.alive_crates(game_state.crates)
 
     crates =
-      Physics.check_collisions(skill_entity, interactable_crates)
+      Physics.check_collisions(skill_entity, alive_crates)
       |> Enum.reduce(game_state.crates, fn crate_id, crates_acc ->
         real_damage = Player.calculate_real_damage(player, damage)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1138,7 +1138,7 @@ defmodule Arena.GameUpdater do
     entities_to_collide_with =
       Player.alive_players(players)
       |> Map.merge(Obstacle.get_collisionable_obstacles_for_projectiles(obstacles))
-      |> Map.merge(crates)
+      |> Map.merge(crates |> Map.filter(fn {_id, crate} -> crate.aditional_info.status != :DESTROYED end))
       |> Map.merge(pools)
       |> Map.merge(%{external_wall.id => external_wall})
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1138,7 +1138,7 @@ defmodule Arena.GameUpdater do
     entities_to_collide_with =
       Player.alive_players(players)
       |> Map.merge(Obstacle.get_collisionable_obstacles_for_projectiles(obstacles))
-      |> Map.merge(crates |> Map.filter(fn {_id, crate} -> crate.aditional_info.status != :DESTROYED end))
+      |> Map.merge(Crate.alive_crates(crates))
       |> Map.merge(pools)
       |> Map.merge(%{external_wall.id => external_wall})
 


### PR DESCRIPTION
## Motivation

Projectiles were colliding with destroyed crates.

## Summary of changes

[Filter out destroyed crates in collision calculation](https://github.com/lambdaclass/mirra_backend/pull/904/commits/fb1e96b17869a884819947c85f054f20f0ae0df3)

## How to test it?

Play a game as any projectile-shooter character. Destroy a crate and keep firing at it, the projectile should keep going its way.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
