### PR TITLE
Make central configurable for arena

### DIFF
--- a/.github/workflows/central-europe-staging-deploy.yml
+++ b/.github/workflows/central-europe-staging-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           MIX_ENV: ${{ vars.MIX_ENV }}
           RELEASE: central_backend
           PHX_SERVER: ${{ vars.PHX_SERVER }}
-          PHX_HOST: ${{ vars.HOST }}
+          PHX_HOST: ${{ vars.PHX_HOST_STAGING }}
           PORT: ${{ vars.ARENA_PORT }}
           GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
           CONFIGURATOR_HOST: ${{ vars.CONFIGURATOR_HOST }}

--- a/apps/arena/lib/arena_web/controllers/health_controller.ex
+++ b/apps/arena/lib/arena_web/controllers/health_controller.ex
@@ -12,4 +12,12 @@ defmodule ArenaWeb.HealthController do
     |> put_status(:ok)
     |> text(Application.spec(:arena, :vsn))
   end
+
+  def update_central(conn, %{"gateway_url" => gateway_url}) do
+    System.put_env("GATEWAY_URL", gateway_url)
+
+    conn
+    |> put_status(:ok)
+    |> text(gateway_url)
+  end
 end

--- a/apps/arena/lib/arena_web/router.ex
+++ b/apps/arena/lib/arena_web/router.ex
@@ -10,6 +10,7 @@ defmodule ArenaWeb.Router do
 
     get "/health", HealthController, :check
     get "/version", HealthController, :version
+    post "/update_central", HealthController, :update_central
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_controller.ex
@@ -17,6 +17,8 @@ defmodule ConfiguratorWeb.ArenaServerController do
   def create(conn, %{"arena_server" => arena_server_params}) do
     case Configuration.create_arena_server(arena_server_params) do
       {:ok, arena_server} ->
+        update_arena_gateway_url(arena_server.gateway_url, arena_server_params["gateway_url"], arena_server.url)
+
         conn
         |> put_flash(:info, "Arena server created successfully.")
         |> redirect(to: ~p"/arena_servers/#{arena_server}")
@@ -39,6 +41,7 @@ defmodule ConfiguratorWeb.ArenaServerController do
 
   def update(conn, %{"id" => id, "arena_server" => arena_server_params}) do
     arena_server = Configuration.get_arena_server!(id)
+    update_arena_gateway_url(arena_server.gateway_url, arena_server_params["gateway_url"], arena_server.url)
 
     case Configuration.update_arena_server(arena_server, arena_server_params) do
       {:ok, arena_server} ->
@@ -65,5 +68,23 @@ defmodule ConfiguratorWeb.ArenaServerController do
         |> put_flash(:info, "Arena server deleted successfully.")
         |> redirect(to: ~p"/arena_servers")
     end
+  end
+
+  defp update_arena_gateway_url(former_url, former_url, _arena_url), do: nil
+
+  defp update_arena_gateway_url(_former_url, new_url, arena_url) do
+    payload = Jason.encode!(%{gateway_url: new_url})
+
+    arena_url =
+      if String.contains?(arena_url, "localhost") do
+        "http://" <> arena_url
+      else
+        "https://" <> arena_url
+      end
+
+    spawn(fn ->
+      Finch.build(:post, arena_url <> "/api/update_central", [{"content-type", "application/json"}], payload)
+      |> Finch.request(Gateway.Finch)
+    end)
   end
 end

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_controller.ex
@@ -73,18 +73,18 @@ defmodule ConfiguratorWeb.ArenaServerController do
   defp update_arena_gateway_url(former_url, former_url, _arena_url), do: nil
 
   defp update_arena_gateway_url(_former_url, new_url, arena_url) do
-    payload = Jason.encode!(%{gateway_url: new_url})
+    if System.get_env("PHX_HOST") == "central-europe-staging.championsofmirra.com" do
+      payload = Jason.encode!(%{gateway_url: new_url})
 
-    arena_url =
-      if String.contains?(arena_url, "localhost") do
-        "http://" <> arena_url
-      else
-        "https://" <> arena_url
-      end
-
-    spawn(fn ->
-      Finch.build(:post, arena_url <> "/api/update_central", [{"content-type", "application/json"}], payload)
-      |> Finch.request(Gateway.Finch)
-    end)
+      spawn(fn ->
+        Finch.build(
+          :post,
+          "https://" <> arena_url <> "/api/update_central",
+          [{"content-type", "application/json"}],
+          payload
+        )
+        |> Finch.request(Gateway.Finch)
+      end)
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Closes #920 
We can edit gateway_url in configurator but Arena's server never notices about this change.

## Summary of changes

- [Add post endpoint in arena to update gateway url](https://github.com/lambdaclass/mirra_backend/commit/07b1b7af711eed66fb32dc459d54a1e072079d28)
- [Make post request to update arena's gateway_url at arena_server creation and update](https://github.com/lambdaclass/mirra_backend/commit/894586f1b833598d76ebb8f5d6bd1720aefcf61c)

## How to test it?

Create a new server or update a current one in configurator.
Then, set/update its gateway_url. Now that arena should point to that central.
You can check by connecting to ssh to that server or just play a game and see what config it takes.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
