### PR TITLE
Check if killer is alive before giving powerup

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1610,13 +1610,13 @@ defmodule Arena.GameUpdater do
   defp grant_power_up_to_killer(game_state, _game_config, nil = _killer, _victim), do: game_state
 
   defp grant_power_up_to_killer(game_state, game_config, killer, victim) do
-    amount_of_power_ups =
-      get_amount_of_power_ups(victim, game_config.game.power_ups_per_kill)
-
-    updated_killer = Player.power_up_boost(killer, amount_of_power_ups, game_config)
-
-    players = Map.get(game_state, :players) |> Map.put(killer.id, updated_killer)
-    Map.put(game_state, :players, players)
+    if Player.alive?(killer) do
+      amount_of_power_ups = get_amount_of_power_ups(victim, game_config.game.power_ups_per_kill)
+      updated_killer = Player.power_up_boost(killer, amount_of_power_ups, game_config)
+      put_in(game_state, [:players, killer.id], updated_killer)
+    else
+      game_state
+    end
   end
 
   defp get_amount_of_power_ups(%{aditional_info: %{power_ups: power_ups}}, power_ups_per_kill) do


### PR DESCRIPTION
## Motivation

Closes #943 

## Summary of changes

Check that the player killer is alive itself before giving a power up. Not performing the check was essentially reviving players cause they get healed by the power up and this revival messed up the match position counter (resulted in negative positions) and thus match results could not be saved

## How to test it?

*You can explain how you tested it or suggest a way to do so.*

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
