### PR TITLE
Add bot manager workflow

### DIFF
--- a/.github/workflows/arena-argentina-testing-deploy.yaml
+++ b/.github/workflows/arena-argentina-testing-deploy.yaml
@@ -49,7 +49,7 @@ jobs:
           PORT: ${{ vars.ARENA_PORT }}
           GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
-          BOT_MANAGER_HOST: ${{ vars.LOADTEST_CLIENT_HOST }}
+          BOT_MANAGER_HOST: ${{ vars.BOT_MANAGER_HOST }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME }}

--- a/.github/workflows/arena-argentina-testing-hostcolor-deploy.yaml
+++ b/.github/workflows/arena-argentina-testing-hostcolor-deploy.yaml
@@ -46,7 +46,7 @@ jobs:
           PORT: ${{ vars.ARENA_PORT }}
           GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
-          BOT_MANAGER_HOST: ${{ vars.LOADTEST_CLIENT_HOST }}
+          BOT_MANAGER_HOST: ${{ vars.BOT_MANAGER_HOST }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME_HOSTCOLOR }}

--- a/.github/workflows/arena-brazil-testing-aws-deploy.yml
+++ b/.github/workflows/arena-brazil-testing-aws-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           PORT: ${{ vars.ARENA_PORT }}
           GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
-          BOT_MANAGER_HOST: ${{ vars.LOADTEST_CLIENT_HOST }}
+          BOT_MANAGER_HOST: ${{ vars.BOT_MANAGER_HOST }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME_AWS }}

--- a/.github/workflows/arena-chile-testing-deploy.yaml
+++ b/.github/workflows/arena-chile-testing-deploy.yaml
@@ -47,7 +47,7 @@ jobs:
           PORT: ${{ vars.ARENA_PORT }}
           GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
-          BOT_MANAGER_HOST: ${{ vars.LOADTEST_CLIENT_HOST }}
+          BOT_MANAGER_HOST: ${{ vars.BOT_MANAGER_HOST }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME }}

--- a/.github/workflows/bot-manager-deploy.yml
+++ b/.github/workflows/bot-manager-deploy.yml
@@ -1,9 +1,6 @@
 name: "[BOT-MANAGER] Deploy to Bot Manager Server"
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - add-bot-manager-workflow
 
 jobs:
   build-deploy:

--- a/.github/workflows/bot-manager-deploy.yml
+++ b/.github/workflows/bot-manager-deploy.yml
@@ -1,0 +1,76 @@
+name: "[BOT-MANAGER] Deploy to Bot Manager Server"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - add-bot-manager-workflow
+
+jobs:
+  build-deploy:
+    name: Build and deploy to Chile Loadtest Client
+    runs-on: ubuntu-latest
+    environment:
+      name: bot-manager
+      url: https://bot-manager.championsofmirra.com/
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Create ssh private key file from env var
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST: ${{ vars.TS_HOST }}
+        run: |
+          set -ex
+          mkdir -p ~/.ssh/
+          sed -E 's/(-+(BEGIN|END) OPENSSH PRIVATE KEY-+) *| +/\1\n/g' <<< "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+          retries=5; until ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts || [ $retries -eq 0 ]; do ((retries--)); sleep 5; done
+
+      - name: Copy deploy script
+        env:
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          SSH_HOST: ${{ vars.TS_HOST }}
+        run: |
+          set -ex
+          rsync -avz --mkpath devops/deploy.sh ${SSH_USERNAME}@${SSH_HOST}:/home/${SSH_USERNAME}/deploy-script/
+
+      - name: Execute deploy script
+        env:
+          XDG_RUNTIME_DIR: ${{ vars.XDG_RUNTIME_DIR }}
+          SSH_HOST: ${{ vars.TS_HOST }}
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          MIX_ENV: ${{ vars.MIX_ENV }}
+          RELEASE: bot_manager
+          PHX_SERVER: ${{ vars.PHX_SERVER }}
+          PHX_HOST: ${{ vars.HOST }}
+          PORT: ${{ vars.BOT_MANAGER_PORT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME }}
+          NEWRELIC_KEY: ${{ secrets.NEWRELIC_KEY }}
+          DBUS_SESSION_BUS_ADDRESS: ${{ vars.DBUS_SESSION_BUS_ADDRESS }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -ex
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+                XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} \
+                BRANCH_NAME=${BRANCH_NAME} \
+                MIX_ENV=${MIX_ENV} \
+                RELEASE=${RELEASE} \
+                PHX_SERVER=${PHX_SERVER} \
+                PHX_HOST=${PHX_HOST} \
+                PORT=${PORT} \
+                DATABASE_URL=${DATABASE_URL} \
+                SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+                NEWRELIC_APP_NAME=${NEWRELIC_APP_NAME} \
+                NEWRELIC_KEY=${NEWRELIC_KEY} \
+                DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS} \
+                /home/${SSH_USERNAME}/deploy-script/deploy.sh


### PR DESCRIPTION
## Motivation

We have a new server for bot_manager app.

## Summary of changes

- [Add new bot manager workflow](https://github.com/lambdaclass/mirra_backend/commit/317a3e87612660de1cedf1e5afd91afbd4298ea3)
- [Use BOT_MANAGER_HOST instead of LOADTEST_CLIENT_HOST](https://github.com/lambdaclass/mirra_backend/commit/2dfead2dc8697a5cf59309df709bb9813b151e6e)

## How to test it?

Trust don't verify.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
