### PR TITLE
Fix bots url protocol + bot process dying when attacking

### DIFF
--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -24,9 +24,12 @@ defmodule Arena.Utils do
 
   def get_bot_connection_url(game_id, bot_client) do
     server_url = System.get_env("PHX_HOST") || "localhost"
-    bot_manager_host = System.get_env("BOT_MANAGER_HOST", "localhost")
-    bot_manager_port = System.get_env("BOT_MANAGER_PORT", "4003")
+    bot_manager_host = System.get_env("BOT_MANAGER_HOST", "localhost:4003")
+    protocol = get_correct_protocol(bot_manager_host)
 
-    "http://#{bot_manager_host}:#{bot_manager_port}/join/#{server_url}/#{game_id}/#{bot_client}"
+    "#{protocol}#{bot_manager_host}/join/#{server_url}/#{game_id}/#{bot_client}"
   end
+
+  defp get_correct_protocol("localhost" <> _host), do: "http://"
+  defp get_correct_protocol(_host), do: "https://"
 end

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -71,21 +71,16 @@ defmodule BotManager.GameSocketHandler do
 
   def handle_info(:perform_action, state) do
     Process.send_after(self(), :perform_action, @action_delay_ms)
-
     send_current_action(state)
-
-    state =
-      case state.current_action do
-        {:attack, _} ->
-          Map.put(state, :attack_blocked, true)
-          Process.send_after(self(), :unblock_attack, Enum.random(2000..4000))
-
-        _ ->
-          state
-      end
-
-    {:ok, state}
+    {:ok, update_block_attack_state(state)}
   end
+
+  defp update_block_attack_state(%{current_action: {:attack, _}} = state) do
+    Process.send_after(self(), :unblock_attack, Enum.random(2000..4000))
+    Map.put(state, :attack_blocked, true)
+  end
+
+  defp update_block_attack_state(state), do: state
 
   def handle_cast({:send, {_type, _msg} = frame}, state) do
     {:reply, frame, state}


### PR DESCRIPTION
## Motivation

Closes #954 
We have to reach bots through SSL

## Summary of changes

- [Fix bots url protocol](https://github.com/lambdaclass/mirra_backend/pull/956/commits/ba051f739581b544ef06e91aaa7939d59a2c2557)
- [Fix attack block behavior killing bots processes](https://github.com/lambdaclass/mirra_backend/pull/956/commits/2a57eb4db81d9af369f49d2d8278bf2598c6efd2)

## How to test it?

Playtest.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
