### PR TITLE
Add 404 error to user not found

### DIFF
--- a/apps/gateway/lib/gateway/controllers/auth_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/auth_controller.ex
@@ -7,6 +7,8 @@ defmodule Gateway.Controllers.AuthController do
   alias Gateway.Auth.GoogleTokenManager
   alias GameBackend.Users
 
+  action_fallback Gateway.Controllers.FallbackController
+
   def validate_token(conn, %{"provider" => "google", "token_id" => token_id, "client_id" => client_id}) do
     case GoogleTokenManager.verify_and_validate(token_id) do
       {:ok, claims} ->
@@ -42,9 +44,6 @@ defmodule Gateway.Controllers.AuthController do
          {:ok, user} <- Users.get_user_by_id_and_game_id(claims["sub"], curse_id) do
       new_gateway_jwt = TokenManager.generate_user_token(user, client_id)
       send_resp(conn, 200, Jason.encode!(%{gateway_jwt: new_gateway_jwt, user_id: user.id}))
-    else
-      _ ->
-        send_resp(conn, 400, Jason.encode!(%{error: "bad_request"}))
     end
   end
 end

--- a/apps/gateway/lib/gateway/controllers/fallback_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/fallback_controller.ex
@@ -64,6 +64,10 @@ defmodule Gateway.Controllers.FallbackController do
     send_resp(conn, 400, Jason.encode!(%{"error" => "the user doesn't have that quest"}))
   end
 
+  def call(conn, {:error, _failed_operation, :not_found, _changes_so_far}) do
+    send_resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+  end
+
   def call(conn, {:error, failed_operation, _failed_value, _changes_so_far}) when is_binary(failed_operation) do
     send_resp(conn, 400, Jason.encode!(%{"error" => failed_operation}))
   end

--- a/apps/gateway/lib/gateway/controllers/fallback_controller.ex
+++ b/apps/gateway/lib/gateway/controllers/fallback_controller.ex
@@ -75,4 +75,8 @@ defmodule Gateway.Controllers.FallbackController do
   def call(conn, {:error, failed_operation, _failed_value, _changes_so_far}) do
     send_resp(conn, 400, Jason.encode!(%{"error" => Atom.to_string(failed_operation)}))
   end
+
+  def call(conn, _) do
+    send_resp(conn, 400, Jason.encode!(%{"error" => "Bad request"}))
+  end
 end


### PR DESCRIPTION
## Motivation

We needed to identify when a log in request failed due to an unexistant user

## Summary of changes

Added 404 error lo user log in 

## How to test it?

try to log in with an inexistant user id and you should see a 404 error

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
