### PR TITLE
feat: set merliot as default map

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1284,7 +1284,7 @@ slow_field_effect = %{
 araban_map_config = %{
   name: "Araban",
   radius: 5520.0,
-  active: true,
+  active: false,
   initial_positions: [
     %{
       x: 5400,
@@ -3403,7 +3403,7 @@ araban_map_config = %{
 merliot_map_config = %{
   name: "Merliot",
   radius: 10000.0,
-  active: false,
+  active: true,
   initial_positions: [
     %{
       x: 5360.0,


### PR DESCRIPTION
## Motivation
Merge once https://github.com/lambdaclass/champions_of_mirra/pull/2183 gets merged
we'll start using merliot as our default map and stop using araban, at least for now

Closes #issue_number

## Summary of changes

## How to test it?

*You can explain how you tested it or suggest a way to do so.*

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
