### PR TITLE
[GH-917] - Deathmatch mode

### DIFF
--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -17,6 +17,7 @@ defmodule Arena.Application do
       Arena.Matchmaking.GameLauncher,
       Arena.Matchmaking.PairMode,
       Arena.Matchmaking.QuickGameMode,
+      Arena.Matchmaking.DeathmatchMode,
       Arena.GameBountiesFetcher,
       Arena.GameTracker,
       Arena.Authentication.GatewaySigner,

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -452,7 +452,7 @@ defmodule Arena.Game.Player do
   end
 
   def respawn_player(player, position) do
-    aditional_info = player.aditional_info |> Map.put(:health, player.aditional_info.max_health)
+    aditional_info = player.aditional_info |> Map.put(:health, player.aditional_info.base_health)
 
     player
     |> Map.put(:aditional_info, aditional_info)

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -451,6 +451,14 @@ defmodule Arena.Game.Player do
     end)
   end
 
+  def respawn_player(player, position) do
+    aditional_info = player.aditional_info |> Map.put(:health, player.aditional_info.max_health)
+
+    player
+    |> Map.put(:aditional_info, aditional_info)
+    |> Map.put(:position, position)
+  end
+
   ####################
   # Internal helpers #
   ####################

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -116,6 +116,17 @@ defmodule Arena.GameSocketHandler do
     end
   end
 
+  def websocket_info({:respawn_player, player_id}, state) do
+    state =
+      if state.player_id == player_id do
+        state |> Map.put(:enable, true) |> Map.put(:player_alive, true)
+      else
+        state
+      end
+
+    {:ok, state}
+  end
+
   @impl true
   def websocket_info({:block_actions, player_id, value}, state) do
     if state.player_id == player_id do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1911,7 +1911,7 @@ defmodule Arena.GameUpdater do
     end
   end
 
-  defp add_players_to_respawn_queue(game_state, game_config) do
+  defp add_players_to_respawn_queue(game_state, %{game: %{game_mode: :deathmatch}} = game_config) do
     death_players =
       game_state.players
       |> Enum.filter(fn {_player_id, player} ->
@@ -1932,7 +1932,9 @@ defmodule Arena.GameUpdater do
     Map.put(game_state, :respawn_queue, respawn_queue)
   end
 
-  defp respawn_players(game_state, game_config) do
+  defp add_players_to_respawn_queue(game_state, _game_config), do: game_state
+
+  defp respawn_players(game_state, %{game: %{game_mode: :deathmatch}} = game_config) do
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
     players_to_respawn =
@@ -1952,6 +1954,8 @@ defmodule Arena.GameUpdater do
 
     Map.put(game_state, :respawn_queue, respawn_queue)
   end
+
+  defp respawn_players(game_state, _game_config), do: game_state
 
   ##########################
   # End Helpers

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -334,7 +334,6 @@ defmodule Arena.GameUpdater do
       end)
       |> Enum.sort_by(fn {_player_id, _player, kills} -> kills end, :desc)
 
-
     {winner_id, winner, _kills} = Enum.at(players, 0)
 
     state =

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -794,7 +794,7 @@ defmodule Arena.GameUpdater do
       |> Map.put(:external_wall, Entities.new_external_wall(0, config.map.radius))
       |> Map.put(:zone, %{
         radius: config.map.radius,
-        should_start?: config.game.zone_enabled,
+        should_start?: if(config.game.game_mode == :deathmatch, do: false, else: config.game.zone_enabled),
         started: false,
         enabled: false,
         shrinking: false,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -832,7 +832,7 @@ defmodule Arena.GameUpdater do
       |> Map.put(:square_wall, config.map.square_wall)
       |> Map.put(:zone, %{
         radius: config.map.radius,
-        should_start?: if(config.game.game_mode == :deathmatch, do: false, else: config.game.zone_enabled),
+        should_start?: if(config.game.game_mode == :DEATHMATCH, do: false, else: config.game.zone_enabled),
         started: false,
         enabled: false,
         shrinking: false,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1911,7 +1911,7 @@ defmodule Arena.GameUpdater do
     end
   end
 
-  defp add_players_to_respawn_queue(game_state, %{game: %{game_mode: :deathmatch}} = game_config) do
+  defp add_players_to_respawn_queue(game_state, %{game: %{game_mode: :DEATHMATCH}} = game_config) do
     death_players =
       game_state.players
       |> Enum.filter(fn {_player_id, player} ->
@@ -1934,7 +1934,7 @@ defmodule Arena.GameUpdater do
 
   defp add_players_to_respawn_queue(game_state, _game_config), do: game_state
 
-  defp respawn_players(game_state, %{game: %{game_mode: :deathmatch}} = game_config) do
+  defp respawn_players(game_state, %{game: %{game_mode: :DEATHMATCH}} = game_config) do
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
     players_to_respawn =

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -334,7 +334,7 @@ defmodule Arena.GameUpdater do
       end)
       |> Enum.sort_by(fn {_player_id, _player, kills} -> kills end, :desc)
 
-    {winner_id, winner, _kills} = Enum.at(players, 1)
+    {winner_id, winner, _kills} = Enum.at(players, 0)
 
     state =
       state
@@ -1912,17 +1912,11 @@ defmodule Arena.GameUpdater do
   end
 
   defp add_players_to_respawn_queue(game_state, %{game: %{game_mode: :DEATHMATCH}} = game_config) do
-    death_players =
-      game_state.players
-      |> Enum.filter(fn {_player_id, player} ->
-        not Player.alive?(player)
-      end)
-
     now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
     respawn_queue =
-      Enum.reduce(death_players, game_state.respawn_queue, fn {player_id, _player}, respawn_queue ->
-        if Map.has_key?(respawn_queue, player_id) do
+      Enum.reduce(game_state.players, game_state.respawn_queue, fn {player_id, player}, respawn_queue ->
+        if Map.has_key?(respawn_queue, player_id) || Player.alive?(player) do
           respawn_queue
         else
           Map.put(respawn_queue, player_id, now + game_config.game.respawn_time)

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -6,5 +6,6 @@ defmodule Arena.Matchmaking do
   def get_queue("battle-royale"), do: Arena.Matchmaking.GameLauncher
   def get_queue("pair"), do: Arena.Matchmaking.PairMode
   def get_queue("quick-game"), do: Arena.Matchmaking.QuickGameMode
+  def get_queue("deathmatch"), do: Arena.Matchmaking.DeathmatchMode
   def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher
 end

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -13,20 +13,6 @@ defmodule Arena.Matchmaking.DeathmatchMode do
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 4_000
 
-  @bot_names [
-    "TheBlackSwordman",
-    "SlashJava",
-    "SteelBallRun",
-    "Jeff",
-    "Messi",
-    "Stone Ocean",
-    "Jeepers Creepers",
-    "Bob",
-    "El javo",
-    "Alberso",
-    "Thomas"
-  ]
-
   # API
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -116,7 +102,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
-      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+      {client_id, Enum.random(characters).name, Enum.at(Arena.Utils.bot_names(), i), nil}
     end)
   end
 

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -6,7 +6,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
   use GenServer
 
   # 3 Mins
-  @match_duration 30_000
+  @match_duration 180_000
   @respawn_time 5000
 
   # Time to wait to start game with any amount of clients

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -6,6 +6,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
   use GenServer
 
   # 3 Mins
+  # TODO: add this to the configurator https://github.com/lambdaclass/mirra_backend/issues/985
   @match_duration 180_000
   @respawn_time 5000
 

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -6,7 +6,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
   use GenServer
 
   # 3 Mins
-  @match_duration 180_000
+  @match_duration 30_000
   @respawn_time 5000
 
   # Time to wait to start game with any amount of clients

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -135,7 +135,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
         bot_clients: bot_clients,
         game_params:
           game_params
-          |> Map.put(:game_mode, :deathmatch)
+          |> Map.put(:game_mode, :DEATHMATCH)
           |> Map.put(:match_duration, @match_duration)
           |> Map.put(:respawn_time, @respawn_time)
       })

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -5,6 +5,10 @@ defmodule Arena.Matchmaking.DeathmatchMode do
 
   use GenServer
 
+  # 3 Mins
+  @match_duration 180_000
+  @respawn_time 5000
+
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 4_000
 
@@ -129,7 +133,11 @@ defmodule Arena.Matchmaking.DeathmatchMode do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params |> Map.put(:game_mode, :deathmatch)
+        game_params:
+          game_params
+          |> Map.put(:game_mode, :deathmatch)
+          |> Map.put(:match_duration, @match_duration)
+          |> Map.put(:respawn_time, @respawn_time)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -129,7 +129,7 @@ defmodule Arena.Matchmaking.GameLauncher do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params
+        game_params: game_params |> Map.put(:game_mode, :battle_royale)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -8,25 +8,6 @@ defmodule Arena.Matchmaking.GameLauncher do
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 4_000
 
-  @bot_names [
-    "TheBlackSwordman",
-    "SlashJava",
-    "SteelBallRun",
-    "Jeff",
-    "Messi",
-    "Stone Ocean",
-    "Jeepers Creepers",
-    "Bob",
-    "El javo",
-    "Alberso",
-    "Thomas",
-    "Timmy",
-    "Pablito",
-    "Nicolino",
-    "Cangrejo",
-    "Mansito"
-  ]
-
   # API
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -116,7 +97,7 @@ defmodule Arena.Matchmaking.GameLauncher do
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
-      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+      {client_id, Enum.random(characters).name, Enum.at(Arena.Utils.bot_names(), i), nil}
     end)
   end
 

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -129,7 +129,7 @@ defmodule Arena.Matchmaking.GameLauncher do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params |> Map.put(:game_mode, :battle_royale)
+        game_params: game_params |> Map.put(:game_mode, :BATTLE)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/pair_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/pair_mode.ex
@@ -7,25 +7,6 @@ defmodule Arena.Matchmaking.PairMode do
 
   # Time to wait to start game with any amount of clients
   @start_timeout_ms 10_000
-  # The available names for bots to enter a match, we should change this in the future
-  @bot_names [
-    "TheBlackSwordman",
-    "SlashJava",
-    "SteelBallRun",
-    "Jeff",
-    "Messi",
-    "Stone Ocean",
-    "Jeepers Creepers",
-    "Bob",
-    "El javo",
-    "Alberso",
-    "Thomas",
-    "Timmy",
-    "Pablito",
-    "Nicolino",
-    "Cangrejo",
-    "Mansito"
-  ]
 
   # API
   def start_link(_) do
@@ -110,7 +91,7 @@ defmodule Arena.Matchmaking.PairMode do
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
-      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+      {client_id, Enum.random(characters).name, Enum.at(Arena.Utils.bot_names(), i), nil}
     end)
   end
 

--- a/apps/arena/lib/arena/matchmaking/pair_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/pair_mode.ex
@@ -129,7 +129,7 @@ defmodule Arena.Matchmaking.PairMode do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params
+        game_params: game_params |> Map.put(:game_mode, :pair_mode)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/pair_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/pair_mode.ex
@@ -129,7 +129,7 @@ defmodule Arena.Matchmaking.PairMode do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params |> Map.put(:game_mode, :pair_mode)
+        game_params: game_params |> Map.put(:game_mode, :PAIR)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -96,7 +96,7 @@ defmodule Arena.Matchmaking.QuickGameMode do
       GenServer.start(Arena.GameUpdater, %{
         clients: clients,
         bot_clients: bot_clients,
-        game_params: game_params |> Map.put(:game_mode, :quick_game)
+        game_params: game_params |> Map.put(:game_mode, :QUICK_GAME)
       })
 
     game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -5,26 +5,6 @@ defmodule Arena.Matchmaking.QuickGameMode do
 
   use GenServer
 
-  # The available names for bots to enter a match, we should change this in the future
-  @bot_names [
-    "TheBlackSwordman",
-    "SlashJava",
-    "SteelBallRun",
-    "Jeff",
-    "Messi",
-    "Stone Ocean",
-    "Jeepers Creepers",
-    "Bob",
-    "El javo",
-    "Alberso",
-    "Thomas",
-    "Timmy",
-    "Pablito",
-    "Nicolino",
-    "Cangrejo",
-    "Mansito"
-  ]
-
   # API
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -80,7 +60,7 @@ defmodule Arena.Matchmaking.QuickGameMode do
     Enum.map(1..missing_clients//1, fn i ->
       client_id = UUID.generate()
 
-      {client_id, Enum.random(characters).name, Enum.at(@bot_names, i), nil}
+      {client_id, Enum.random(characters).name, Enum.at(Arena.Utils.bot_names(), i), nil}
     end)
   end
 

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -1,7 +1,18 @@
+defmodule Arena.Serialization.GameMode do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:BATTLE, 0)
+  field(:DEATHMATCH, 1)
+  field(:PAIR, 2)
+  field(:QUICK_GAME, 3)
+end
+
 defmodule Arena.Serialization.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -12,7 +23,7 @@ end
 defmodule Arena.Serialization.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PROJECTILE_STATUS_UNDEFINED, 0)
   field(:ACTIVE, 1)
@@ -23,7 +34,7 @@ end
 defmodule Arena.Serialization.CrateStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:CRATE_STATUS_UNDEFINED, 0)
   field(:FINE, 1)
@@ -33,7 +44,7 @@ end
 defmodule Arena.Serialization.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -43,7 +54,7 @@ end
 defmodule Arena.Serialization.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -56,7 +67,7 @@ end
 defmodule Arena.Serialization.TrapStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PENDING, 0)
   field(:PREPARED, 1)
@@ -67,7 +78,7 @@ end
 defmodule Arena.Serialization.PoolStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:WAITING, 0)
   field(:READY, 1)
@@ -76,7 +87,7 @@ end
 defmodule Arena.Serialization.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -85,7 +96,7 @@ end
 defmodule Arena.Serialization.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -94,7 +105,7 @@ end
 defmodule Arena.Serialization.ListPositionPB do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:positions, 1, repeated: true, type: Arena.Serialization.Position)
 end
@@ -102,7 +113,7 @@ end
 defmodule Arena.Serialization.LobbyEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -115,25 +126,25 @@ end
 defmodule Arena.Serialization.LeaveLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.LeftLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.JoinedLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -152,7 +163,7 @@ end
 defmodule Arena.Serialization.BountySelected do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty, 1, type: Arena.Serialization.BountyInfo)
 end
@@ -160,7 +171,7 @@ end
 defmodule Arena.Serialization.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -169,7 +180,7 @@ end
 defmodule Arena.Serialization.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:winner, 1, type: Arena.Serialization.Entity)
 
@@ -183,7 +194,7 @@ end
 defmodule Arena.Serialization.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: Arena.Serialization.Configuration)
@@ -193,7 +204,7 @@ end
 defmodule Arena.Serialization.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game, 1, type: Arena.Serialization.ConfigGame)
   field(:map, 2, type: Arena.Serialization.ConfigMap)
@@ -204,17 +215,18 @@ end
 defmodule Arena.Serialization.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
   field(:bounty_pick_time_ms, 2, type: :float, json_name: "bountyPickTimeMs")
   field(:start_game_time_ms, 3, type: :float, json_name: "startGameTimeMs")
+  field(:game_mode, 4, type: Arena.Serialization.GameMode, json_name: "gameMode", enum: true)
 end
 
 defmodule Arena.Serialization.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:name, 2, type: :string)
@@ -223,7 +235,7 @@ end
 defmodule Arena.Serialization.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: Arena.Serialization.ConfigSkill)
@@ -232,7 +244,7 @@ end
 defmodule Arena.Serialization.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -253,7 +265,7 @@ end
 defmodule Arena.Serialization.ClientConfig do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:server_update, 1, type: Arena.Serialization.ConfigServerUpdate, json_name: "serverUpdate")
 end
@@ -261,7 +273,7 @@ end
 defmodule Arena.Serialization.ConfigServerUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:timestamp_difference_samples_to_check_warning, 1,
     type: :uint64,
@@ -282,7 +294,7 @@ end
 defmodule Arena.Serialization.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -299,7 +311,7 @@ end
 defmodule Arena.Serialization.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -308,7 +320,7 @@ end
 defmodule Arena.Serialization.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -317,7 +329,7 @@ end
 defmodule Arena.Serialization.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -326,7 +338,7 @@ end
 defmodule Arena.Serialization.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -335,7 +347,7 @@ end
 defmodule Arena.Serialization.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -344,7 +356,7 @@ end
 defmodule Arena.Serialization.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -353,7 +365,7 @@ end
 defmodule Arena.Serialization.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -362,7 +374,7 @@ end
 defmodule Arena.Serialization.GameState.ObstaclesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -371,7 +383,7 @@ end
 defmodule Arena.Serialization.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -380,7 +392,7 @@ end
 defmodule Arena.Serialization.GameState.CratesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -389,7 +401,7 @@ end
 defmodule Arena.Serialization.GameState.BushesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -398,7 +410,7 @@ end
 defmodule Arena.Serialization.GameState.TrapsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: Arena.Serialization.Entity)
@@ -407,7 +419,7 @@ end
 defmodule Arena.Serialization.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
   field(:players, 2, repeated: true, type: Arena.Serialization.GameState.PlayersEntry, map: true)
@@ -470,7 +482,7 @@ end
 defmodule Arena.Serialization.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:aditional_info, 0)
 
@@ -499,7 +511,7 @@ end
 defmodule Arena.Serialization.Player.CooldownsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: :uint64)
@@ -508,7 +520,7 @@ end
 defmodule Arena.Serialization.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
   field(:kill_count, 2, proto3_optional: true, type: :uint64, json_name: "killCount")
@@ -544,7 +556,7 @@ end
 defmodule Arena.Serialization.Effect do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -554,7 +566,7 @@ end
 defmodule Arena.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
 end
@@ -562,7 +574,7 @@ end
 defmodule Arena.Serialization.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:damage, 1, proto3_optional: true, type: :uint64)
   field(:owner_id, 2, proto3_optional: true, type: :uint64, json_name: "ownerId")
@@ -573,7 +585,7 @@ end
 defmodule Arena.Serialization.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:color, 1, proto3_optional: true, type: :string)
   field(:collisionable, 2, proto3_optional: true, type: :bool)
@@ -584,7 +596,7 @@ end
 defmodule Arena.Serialization.PowerUp do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: Arena.Serialization.PowerUpstatus, enum: true)
@@ -593,7 +605,7 @@ end
 defmodule Arena.Serialization.Crate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
 
@@ -609,7 +621,7 @@ end
 defmodule Arena.Serialization.Pool do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: Arena.Serialization.PoolStatus, enum: true)
@@ -620,13 +632,13 @@ end
 defmodule Arena.Serialization.Bush do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.Trap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:name, 2, type: :string)
@@ -636,7 +648,7 @@ end
 defmodule Arena.Serialization.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:action, 1, type: Arena.Serialization.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -647,7 +659,7 @@ end
 defmodule Arena.Serialization.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:direction, 1, type: Arena.Serialization.Direction)
 end
@@ -655,7 +667,7 @@ end
 defmodule Arena.Serialization.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: Arena.Serialization.AttackParameters)
@@ -664,7 +676,7 @@ end
 defmodule Arena.Serialization.AttackParameters do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target, 1, type: Arena.Serialization.Direction)
 end
@@ -672,7 +684,7 @@ end
 defmodule Arena.Serialization.UseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -680,7 +692,7 @@ end
 defmodule Arena.Serialization.SelectBounty do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty_quest_id, 1, type: :string, json_name: "bountyQuestId")
 end
@@ -688,19 +700,19 @@ end
 defmodule Arena.Serialization.ToggleZone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.ToggleBots do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule Arena.Serialization.ChangeTickrate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tickrate, 1, type: :int64)
 end
@@ -708,7 +720,7 @@ end
 defmodule Arena.Serialization.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:action_type, 0)
 
@@ -737,7 +749,7 @@ end
 defmodule Arena.Serialization.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -748,7 +760,7 @@ end
 defmodule Arena.Serialization.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")
@@ -757,7 +769,7 @@ end
 defmodule Arena.Serialization.BountyInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:description, 2, type: :string)
@@ -768,7 +780,7 @@ end
 defmodule Arena.Serialization.CurrencyReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: :string)
   field(:amount, 2, type: :int64)

--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -4,6 +4,26 @@ defmodule Arena.Utils do
   It contains utility functions like math functions.
   """
 
+  # The available names for bots to enter a match, we should change this in the future
+  @bot_names [
+    "TheBlackSwordman",
+    "SlashJava",
+    "SteelBallRun",
+    "Jeff",
+    "Messi",
+    "Stone Ocean",
+    "Jeepers Creepers",
+    "Bob",
+    "El javo",
+    "Alberso",
+    "Thomas",
+    "Timmy",
+    "Pablito",
+    "Nicolino",
+    "Cangrejo",
+    "Mansito"
+  ]
+
   def normalize(%{x: 0, y: 0}) do
     %{x: 0, y: 0}
   end
@@ -28,6 +48,10 @@ defmodule Arena.Utils do
     protocol = get_correct_protocol(bot_manager_host)
 
     "#{protocol}#{bot_manager_host}/join/#{server_url}/#{game_id}/#{bot_client}"
+  end
+
+  def bot_names() do
+    @bot_names
   end
 
   defp get_correct_protocol("localhost" <> _host), do: "http://"

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.9.1",
+      version: "0.10.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.8.1",
+      version: "0.9.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.10.1",
+      version: "0.11.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -1,7 +1,18 @@
+defmodule ArenaLoadTest.Serialization.GameMode do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:BATTLE, 0)
+  field(:DEATHMATCH, 1)
+  field(:PAIR, 2)
+  field(:QUICK_GAME, 3)
+end
+
 defmodule ArenaLoadTest.Serialization.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -12,7 +23,7 @@ end
 defmodule ArenaLoadTest.Serialization.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PROJECTILE_STATUS_UNDEFINED, 0)
   field(:ACTIVE, 1)
@@ -23,7 +34,7 @@ end
 defmodule ArenaLoadTest.Serialization.CrateStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:CRATE_STATUS_UNDEFINED, 0)
   field(:FINE, 1)
@@ -33,7 +44,7 @@ end
 defmodule ArenaLoadTest.Serialization.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -43,7 +54,7 @@ end
 defmodule ArenaLoadTest.Serialization.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -56,7 +67,7 @@ end
 defmodule ArenaLoadTest.Serialization.TrapStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PENDING, 0)
   field(:PREPARED, 1)
@@ -67,7 +78,7 @@ end
 defmodule ArenaLoadTest.Serialization.PoolStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:WAITING, 0)
   field(:READY, 1)
@@ -76,7 +87,7 @@ end
 defmodule ArenaLoadTest.Serialization.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -85,7 +96,7 @@ end
 defmodule ArenaLoadTest.Serialization.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -94,7 +105,7 @@ end
 defmodule ArenaLoadTest.Serialization.ListPositionPB do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:positions, 1, repeated: true, type: ArenaLoadTest.Serialization.Position)
 end
@@ -102,7 +113,7 @@ end
 defmodule ArenaLoadTest.Serialization.LobbyEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -115,25 +126,25 @@ end
 defmodule ArenaLoadTest.Serialization.LeaveLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.LeftLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.JoinedLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -157,7 +168,7 @@ end
 defmodule ArenaLoadTest.Serialization.BountySelected do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty, 1, type: ArenaLoadTest.Serialization.BountyInfo)
 end
@@ -165,7 +176,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -174,7 +185,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:winner, 1, type: ArenaLoadTest.Serialization.Entity)
 
@@ -188,7 +199,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: ArenaLoadTest.Serialization.Configuration)
@@ -198,7 +209,7 @@ end
 defmodule ArenaLoadTest.Serialization.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game, 1, type: ArenaLoadTest.Serialization.ConfigGame)
   field(:map, 2, type: ArenaLoadTest.Serialization.ConfigMap)
@@ -213,17 +224,23 @@ end
 defmodule ArenaLoadTest.Serialization.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
   field(:bounty_pick_time_ms, 2, type: :float, json_name: "bountyPickTimeMs")
   field(:start_game_time_ms, 3, type: :float, json_name: "startGameTimeMs")
+
+  field(:game_mode, 4,
+    type: ArenaLoadTest.Serialization.GameMode,
+    json_name: "gameMode",
+    enum: true
+  )
 end
 
 defmodule ArenaLoadTest.Serialization.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:name, 2, type: :string)
@@ -232,7 +249,7 @@ end
 defmodule ArenaLoadTest.Serialization.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: ArenaLoadTest.Serialization.ConfigSkill)
@@ -241,7 +258,7 @@ end
 defmodule ArenaLoadTest.Serialization.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -262,7 +279,7 @@ end
 defmodule ArenaLoadTest.Serialization.ClientConfig do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:server_update, 1,
     type: ArenaLoadTest.Serialization.ConfigServerUpdate,
@@ -273,7 +290,7 @@ end
 defmodule ArenaLoadTest.Serialization.ConfigServerUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:timestamp_difference_samples_to_check_warning, 1,
     type: :uint64,
@@ -294,7 +311,7 @@ end
 defmodule ArenaLoadTest.Serialization.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -311,7 +328,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -320,7 +337,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -329,7 +346,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -338,7 +355,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -347,7 +364,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -356,7 +373,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -365,7 +382,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -374,7 +391,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.ObstaclesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -383,7 +400,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -392,7 +409,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.CratesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -401,7 +418,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.BushesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -410,7 +427,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState.TrapsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: ArenaLoadTest.Serialization.Entity)
@@ -419,7 +436,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
 
@@ -512,7 +529,7 @@ end
 defmodule ArenaLoadTest.Serialization.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:aditional_info, 0)
 
@@ -541,7 +558,7 @@ end
 defmodule ArenaLoadTest.Serialization.Player.CooldownsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: :uint64)
@@ -550,7 +567,7 @@ end
 defmodule ArenaLoadTest.Serialization.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
   field(:kill_count, 2, proto3_optional: true, type: :uint64, json_name: "killCount")
@@ -592,7 +609,7 @@ end
 defmodule ArenaLoadTest.Serialization.Effect do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -602,7 +619,7 @@ end
 defmodule ArenaLoadTest.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
 end
@@ -610,7 +627,7 @@ end
 defmodule ArenaLoadTest.Serialization.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:damage, 1, proto3_optional: true, type: :uint64)
   field(:owner_id, 2, proto3_optional: true, type: :uint64, json_name: "ownerId")
@@ -621,7 +638,7 @@ end
 defmodule ArenaLoadTest.Serialization.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:color, 1, proto3_optional: true, type: :string)
   field(:collisionable, 2, proto3_optional: true, type: :bool)
@@ -632,7 +649,7 @@ end
 defmodule ArenaLoadTest.Serialization.PowerUp do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: ArenaLoadTest.Serialization.PowerUpstatus, enum: true)
@@ -641,7 +658,7 @@ end
 defmodule ArenaLoadTest.Serialization.Crate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
 
@@ -657,7 +674,7 @@ end
 defmodule ArenaLoadTest.Serialization.Pool do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: ArenaLoadTest.Serialization.PoolStatus, enum: true)
@@ -668,13 +685,13 @@ end
 defmodule ArenaLoadTest.Serialization.Bush do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.Trap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:name, 2, type: :string)
@@ -684,7 +701,7 @@ end
 defmodule ArenaLoadTest.Serialization.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:action, 1, type: ArenaLoadTest.Serialization.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -695,7 +712,7 @@ end
 defmodule ArenaLoadTest.Serialization.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:direction, 1, type: ArenaLoadTest.Serialization.Direction)
 end
@@ -703,7 +720,7 @@ end
 defmodule ArenaLoadTest.Serialization.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: ArenaLoadTest.Serialization.AttackParameters)
@@ -712,7 +729,7 @@ end
 defmodule ArenaLoadTest.Serialization.AttackParameters do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target, 1, type: ArenaLoadTest.Serialization.Direction)
 end
@@ -720,7 +737,7 @@ end
 defmodule ArenaLoadTest.Serialization.UseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -728,7 +745,7 @@ end
 defmodule ArenaLoadTest.Serialization.SelectBounty do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty_quest_id, 1, type: :string, json_name: "bountyQuestId")
 end
@@ -736,19 +753,19 @@ end
 defmodule ArenaLoadTest.Serialization.ToggleZone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.ToggleBots do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule ArenaLoadTest.Serialization.ChangeTickrate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tickrate, 1, type: :int64)
 end
@@ -756,7 +773,7 @@ end
 defmodule ArenaLoadTest.Serialization.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:action_type, 0)
 
@@ -794,7 +811,7 @@ end
 defmodule ArenaLoadTest.Serialization.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -805,7 +822,7 @@ end
 defmodule ArenaLoadTest.Serialization.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")
@@ -814,7 +831,7 @@ end
 defmodule ArenaLoadTest.Serialization.BountyInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:description, 2, type: :string)
@@ -825,7 +842,7 @@ end
 defmodule ArenaLoadTest.Serialization.CurrencyReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: :string)
   field(:amount, 2, type: :int64)

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -1,7 +1,18 @@
+defmodule BotManager.Protobuf.GameMode do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:BATTLE, 0)
+  field(:DEATHMATCH, 1)
+  field(:PAIR, 2)
+  field(:QUICK_GAME, 3)
+end
+
 defmodule BotManager.Protobuf.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -12,7 +23,7 @@ end
 defmodule BotManager.Protobuf.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PROJECTILE_STATUS_UNDEFINED, 0)
   field(:ACTIVE, 1)
@@ -23,7 +34,7 @@ end
 defmodule BotManager.Protobuf.CrateStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:CRATE_STATUS_UNDEFINED, 0)
   field(:FINE, 1)
@@ -33,7 +44,7 @@ end
 defmodule BotManager.Protobuf.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -43,7 +54,7 @@ end
 defmodule BotManager.Protobuf.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -56,7 +67,7 @@ end
 defmodule BotManager.Protobuf.TrapStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PENDING, 0)
   field(:PREPARED, 1)
@@ -67,7 +78,7 @@ end
 defmodule BotManager.Protobuf.PoolStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:WAITING, 0)
   field(:READY, 1)
@@ -76,7 +87,7 @@ end
 defmodule BotManager.Protobuf.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -85,7 +96,7 @@ end
 defmodule BotManager.Protobuf.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -94,7 +105,7 @@ end
 defmodule BotManager.Protobuf.ListPositionPB do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:positions, 1, repeated: true, type: BotManager.Protobuf.Position)
 end
@@ -102,7 +113,7 @@ end
 defmodule BotManager.Protobuf.LobbyEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -115,25 +126,25 @@ end
 defmodule BotManager.Protobuf.LeaveLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.LeftLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.JoinedLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -152,7 +163,7 @@ end
 defmodule BotManager.Protobuf.BountySelected do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty, 1, type: BotManager.Protobuf.BountyInfo)
 end
@@ -160,7 +171,7 @@ end
 defmodule BotManager.Protobuf.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -169,7 +180,7 @@ end
 defmodule BotManager.Protobuf.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:winner, 1, type: BotManager.Protobuf.Entity)
 
@@ -183,7 +194,7 @@ end
 defmodule BotManager.Protobuf.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: BotManager.Protobuf.Configuration)
@@ -193,7 +204,7 @@ end
 defmodule BotManager.Protobuf.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game, 1, type: BotManager.Protobuf.ConfigGame)
   field(:map, 2, type: BotManager.Protobuf.ConfigMap)
@@ -204,17 +215,18 @@ end
 defmodule BotManager.Protobuf.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
   field(:bounty_pick_time_ms, 2, type: :float, json_name: "bountyPickTimeMs")
   field(:start_game_time_ms, 3, type: :float, json_name: "startGameTimeMs")
+  field(:game_mode, 4, type: BotManager.Protobuf.GameMode, json_name: "gameMode", enum: true)
 end
 
 defmodule BotManager.Protobuf.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:name, 2, type: :string)
@@ -223,7 +235,7 @@ end
 defmodule BotManager.Protobuf.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: BotManager.Protobuf.ConfigSkill)
@@ -232,7 +244,7 @@ end
 defmodule BotManager.Protobuf.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -253,7 +265,7 @@ end
 defmodule BotManager.Protobuf.ClientConfig do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:server_update, 1, type: BotManager.Protobuf.ConfigServerUpdate, json_name: "serverUpdate")
 end
@@ -261,7 +273,7 @@ end
 defmodule BotManager.Protobuf.ConfigServerUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:timestamp_difference_samples_to_check_warning, 1,
     type: :uint64,
@@ -282,7 +294,7 @@ end
 defmodule BotManager.Protobuf.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -299,7 +311,7 @@ end
 defmodule BotManager.Protobuf.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -308,7 +320,7 @@ end
 defmodule BotManager.Protobuf.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -317,7 +329,7 @@ end
 defmodule BotManager.Protobuf.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -326,7 +338,7 @@ end
 defmodule BotManager.Protobuf.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -335,7 +347,7 @@ end
 defmodule BotManager.Protobuf.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -344,7 +356,7 @@ end
 defmodule BotManager.Protobuf.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -353,7 +365,7 @@ end
 defmodule BotManager.Protobuf.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -362,7 +374,7 @@ end
 defmodule BotManager.Protobuf.GameState.ObstaclesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -371,7 +383,7 @@ end
 defmodule BotManager.Protobuf.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -380,7 +392,7 @@ end
 defmodule BotManager.Protobuf.GameState.CratesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -389,7 +401,7 @@ end
 defmodule BotManager.Protobuf.GameState.BushesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -398,7 +410,7 @@ end
 defmodule BotManager.Protobuf.GameState.TrapsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: BotManager.Protobuf.Entity)
@@ -407,7 +419,7 @@ end
 defmodule BotManager.Protobuf.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
   field(:players, 2, repeated: true, type: BotManager.Protobuf.GameState.PlayersEntry, map: true)
@@ -470,7 +482,7 @@ end
 defmodule BotManager.Protobuf.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:aditional_info, 0)
 
@@ -499,7 +511,7 @@ end
 defmodule BotManager.Protobuf.Player.CooldownsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: :uint64)
@@ -508,7 +520,7 @@ end
 defmodule BotManager.Protobuf.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
   field(:kill_count, 2, proto3_optional: true, type: :uint64, json_name: "killCount")
@@ -544,7 +556,7 @@ end
 defmodule BotManager.Protobuf.Effect do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -554,7 +566,7 @@ end
 defmodule BotManager.Protobuf.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
 end
@@ -562,7 +574,7 @@ end
 defmodule BotManager.Protobuf.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:damage, 1, proto3_optional: true, type: :uint64)
   field(:owner_id, 2, proto3_optional: true, type: :uint64, json_name: "ownerId")
@@ -573,7 +585,7 @@ end
 defmodule BotManager.Protobuf.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:color, 1, proto3_optional: true, type: :string)
   field(:collisionable, 2, proto3_optional: true, type: :bool)
@@ -584,7 +596,7 @@ end
 defmodule BotManager.Protobuf.PowerUp do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: BotManager.Protobuf.PowerUpstatus, enum: true)
@@ -593,7 +605,7 @@ end
 defmodule BotManager.Protobuf.Crate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
 
@@ -609,7 +621,7 @@ end
 defmodule BotManager.Protobuf.Pool do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: BotManager.Protobuf.PoolStatus, enum: true)
@@ -620,13 +632,13 @@ end
 defmodule BotManager.Protobuf.Bush do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.Trap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:name, 2, type: :string)
@@ -636,7 +648,7 @@ end
 defmodule BotManager.Protobuf.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:action, 1, type: BotManager.Protobuf.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -647,7 +659,7 @@ end
 defmodule BotManager.Protobuf.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:direction, 1, type: BotManager.Protobuf.Direction)
 end
@@ -655,7 +667,7 @@ end
 defmodule BotManager.Protobuf.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: BotManager.Protobuf.AttackParameters)
@@ -664,7 +676,7 @@ end
 defmodule BotManager.Protobuf.AttackParameters do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target, 1, type: BotManager.Protobuf.Direction)
 end
@@ -672,7 +684,7 @@ end
 defmodule BotManager.Protobuf.UseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -680,7 +692,7 @@ end
 defmodule BotManager.Protobuf.SelectBounty do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty_quest_id, 1, type: :string, json_name: "bountyQuestId")
 end
@@ -688,19 +700,19 @@ end
 defmodule BotManager.Protobuf.ToggleZone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.ToggleBots do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule BotManager.Protobuf.ChangeTickrate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tickrate, 1, type: :int64)
 end
@@ -708,7 +720,7 @@ end
 defmodule BotManager.Protobuf.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:action_type, 0)
 
@@ -737,7 +749,7 @@ end
 defmodule BotManager.Protobuf.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -748,7 +760,7 @@ end
 defmodule BotManager.Protobuf.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")
@@ -757,7 +769,7 @@ end
 defmodule BotManager.Protobuf.BountyInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:description, 2, type: :string)
@@ -768,7 +780,7 @@ end
 defmodule BotManager.Protobuf.CurrencyReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: :string)
   field(:amount, 2, type: :int64)

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -47,6 +47,7 @@ goog.exportSymbol('proto.GameEvent', null, global);
 goog.exportSymbol('proto.GameEvent.EventCase', null, global);
 goog.exportSymbol('proto.GameFinished', null, global);
 goog.exportSymbol('proto.GameJoined', null, global);
+goog.exportSymbol('proto.GameMode', null, global);
 goog.exportSymbol('proto.GameState', null, global);
 goog.exportSymbol('proto.GameStatus', null, global);
 goog.exportSymbol('proto.Item', null, global);
@@ -3495,7 +3496,8 @@ proto.ConfigGame.toObject = function(includeInstance, msg) {
   var f, obj = {
     tickRateMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
     bountyPickTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 2, 0.0),
-    startGameTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0)
+    startGameTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0),
+    gameMode: jspb.Message.getFieldWithDefault(msg, 4, 0)
   };
 
   if (includeInstance) {
@@ -3544,6 +3546,10 @@ proto.ConfigGame.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {number} */ (reader.readFloat());
       msg.setStartGameTimeMs(value);
       break;
+    case 4:
+      var value = /** @type {!proto.GameMode} */ (reader.readEnum());
+      msg.setGameMode(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3591,6 +3597,13 @@ proto.ConfigGame.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0.0) {
     writer.writeFloat(
       3,
+      f
+    );
+  }
+  f = message.getGameMode();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      4,
       f
     );
   }
@@ -3648,6 +3661,24 @@ proto.ConfigGame.prototype.getStartGameTimeMs = function() {
  */
 proto.ConfigGame.prototype.setStartGameTimeMs = function(value) {
   return jspb.Message.setProto3FloatField(this, 3, value);
+};
+
+
+/**
+ * optional GameMode game_mode = 4;
+ * @return {!proto.GameMode}
+ */
+proto.ConfigGame.prototype.getGameMode = function() {
+  return /** @type {!proto.GameMode} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+};
+
+
+/**
+ * @param {!proto.GameMode} value
+ * @return {!proto.ConfigGame} returns this
+ */
+proto.ConfigGame.prototype.setGameMode = function(value) {
+  return jspb.Message.setProto3EnumField(this, 4, value);
 };
 
 
@@ -12354,6 +12385,16 @@ proto.CurrencyReward.prototype.setAmount = function(value) {
   return jspb.Message.setProto3IntField(this, 2, value);
 };
 
+
+/**
+ * @enum {number}
+ */
+proto.GameMode = {
+  BATTLE: 0,
+  DEATHMATCH: 1,
+  PAIR: 2,
+  QUICK_GAME: 3
+};
 
 /**
  * @enum {number}

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -1,7 +1,18 @@
+defmodule GameClient.Protobuf.GameMode do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:BATTLE, 0)
+  field(:DEATHMATCH, 1)
+  field(:PAIR, 2)
+  field(:QUICK_GAME, 3)
+end
+
 defmodule GameClient.Protobuf.GameStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PREPARING, 0)
   field(:RUNNING, 1)
@@ -12,7 +23,7 @@ end
 defmodule GameClient.Protobuf.ProjectileStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PROJECTILE_STATUS_UNDEFINED, 0)
   field(:ACTIVE, 1)
@@ -23,7 +34,7 @@ end
 defmodule GameClient.Protobuf.CrateStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:CRATE_STATUS_UNDEFINED, 0)
   field(:FINE, 1)
@@ -33,7 +44,7 @@ end
 defmodule GameClient.Protobuf.PowerUpstatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:AVAILABLE, 0)
   field(:TAKEN, 1)
@@ -43,7 +54,7 @@ end
 defmodule GameClient.Protobuf.PlayerActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:MOVING, 0)
   field(:STARTING_SKILL_1, 1)
@@ -56,7 +67,7 @@ end
 defmodule GameClient.Protobuf.TrapStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:PENDING, 0)
   field(:PREPARED, 1)
@@ -67,7 +78,7 @@ end
 defmodule GameClient.Protobuf.PoolStatus do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:WAITING, 0)
   field(:READY, 1)
@@ -76,7 +87,7 @@ end
 defmodule GameClient.Protobuf.Direction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -85,7 +96,7 @@ end
 defmodule GameClient.Protobuf.Position do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:x, 1, proto3_optional: true, type: :float)
   field(:y, 2, proto3_optional: true, type: :float)
@@ -94,7 +105,7 @@ end
 defmodule GameClient.Protobuf.ListPositionPB do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:positions, 1, repeated: true, type: GameClient.Protobuf.Position)
 end
@@ -102,7 +113,7 @@ end
 defmodule GameClient.Protobuf.LobbyEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -115,25 +126,25 @@ end
 defmodule GameClient.Protobuf.LeaveLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.LeftLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.JoinedLobby do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.GameEvent do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:event, 0)
 
@@ -152,7 +163,7 @@ end
 defmodule GameClient.Protobuf.BountySelected do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty, 1, type: GameClient.Protobuf.BountyInfo)
 end
@@ -160,7 +171,7 @@ end
 defmodule GameClient.Protobuf.GameFinished.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -169,7 +180,7 @@ end
 defmodule GameClient.Protobuf.GameFinished do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:winner, 1, type: GameClient.Protobuf.Entity)
 
@@ -183,7 +194,7 @@ end
 defmodule GameClient.Protobuf.GameJoined do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:player_id, 1, type: :uint64, json_name: "playerId")
   field(:config, 2, type: GameClient.Protobuf.Configuration)
@@ -193,7 +204,7 @@ end
 defmodule GameClient.Protobuf.Configuration do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game, 1, type: GameClient.Protobuf.ConfigGame)
   field(:map, 2, type: GameClient.Protobuf.ConfigMap)
@@ -204,17 +215,18 @@ end
 defmodule GameClient.Protobuf.ConfigGame do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tick_rate_ms, 1, type: :float, json_name: "tickRateMs")
   field(:bounty_pick_time_ms, 2, type: :float, json_name: "bountyPickTimeMs")
   field(:start_game_time_ms, 3, type: :float, json_name: "startGameTimeMs")
+  field(:game_mode, 4, type: GameClient.Protobuf.GameMode, json_name: "gameMode", enum: true)
 end
 
 defmodule GameClient.Protobuf.ConfigMap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:name, 2, type: :string)
@@ -223,7 +235,7 @@ end
 defmodule GameClient.Protobuf.ConfigCharacter.SkillsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: GameClient.Protobuf.ConfigSkill)
@@ -232,7 +244,7 @@ end
 defmodule GameClient.Protobuf.ConfigCharacter do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:active, 2, type: :bool)
@@ -253,7 +265,7 @@ end
 defmodule GameClient.Protobuf.ClientConfig do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:server_update, 1, type: GameClient.Protobuf.ConfigServerUpdate, json_name: "serverUpdate")
 end
@@ -261,7 +273,7 @@ end
 defmodule GameClient.Protobuf.ConfigServerUpdate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:timestamp_difference_samples_to_check_warning, 1,
     type: :uint64,
@@ -282,7 +294,7 @@ end
 defmodule GameClient.Protobuf.ConfigSkill do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:cooldown_ms, 2, type: :uint64, json_name: "cooldownMs")
@@ -299,7 +311,7 @@ end
 defmodule GameClient.Protobuf.GameState.PlayersEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -308,7 +320,7 @@ end
 defmodule GameClient.Protobuf.GameState.ProjectilesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -317,7 +329,7 @@ end
 defmodule GameClient.Protobuf.GameState.PlayerTimestampsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :int64)
@@ -326,7 +338,7 @@ end
 defmodule GameClient.Protobuf.GameState.DamageTakenEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -335,7 +347,7 @@ end
 defmodule GameClient.Protobuf.GameState.DamageDoneEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: :uint64)
@@ -344,7 +356,7 @@ end
 defmodule GameClient.Protobuf.GameState.PowerUpsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -353,7 +365,7 @@ end
 defmodule GameClient.Protobuf.GameState.ItemsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -362,7 +374,7 @@ end
 defmodule GameClient.Protobuf.GameState.ObstaclesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -371,7 +383,7 @@ end
 defmodule GameClient.Protobuf.GameState.PoolsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -380,7 +392,7 @@ end
 defmodule GameClient.Protobuf.GameState.CratesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -389,7 +401,7 @@ end
 defmodule GameClient.Protobuf.GameState.BushesEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -398,7 +410,7 @@ end
 defmodule GameClient.Protobuf.GameState.TrapsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :uint64)
   field(:value, 2, type: GameClient.Protobuf.Entity)
@@ -407,7 +419,7 @@ end
 defmodule GameClient.Protobuf.GameState do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:game_id, 1, type: :string, json_name: "gameId")
   field(:players, 2, repeated: true, type: GameClient.Protobuf.GameState.PlayersEntry, map: true)
@@ -470,7 +482,7 @@ end
 defmodule GameClient.Protobuf.Entity do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:aditional_info, 0)
 
@@ -499,7 +511,7 @@ end
 defmodule GameClient.Protobuf.Player.CooldownsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:key, 1, type: :string)
   field(:value, 2, type: :uint64)
@@ -508,7 +520,7 @@ end
 defmodule GameClient.Protobuf.Player do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
   field(:kill_count, 2, proto3_optional: true, type: :uint64, json_name: "killCount")
@@ -544,7 +556,7 @@ end
 defmodule GameClient.Protobuf.Effect do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:duration_ms, 2, type: :uint32, json_name: "durationMs")
@@ -554,7 +566,7 @@ end
 defmodule GameClient.Protobuf.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
 end
@@ -562,7 +574,7 @@ end
 defmodule GameClient.Protobuf.Projectile do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:damage, 1, proto3_optional: true, type: :uint64)
   field(:owner_id, 2, proto3_optional: true, type: :uint64, json_name: "ownerId")
@@ -573,7 +585,7 @@ end
 defmodule GameClient.Protobuf.Obstacle do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:color, 1, proto3_optional: true, type: :string)
   field(:collisionable, 2, proto3_optional: true, type: :bool)
@@ -584,7 +596,7 @@ end
 defmodule GameClient.Protobuf.PowerUp do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: GameClient.Protobuf.PowerUpstatus, enum: true)
@@ -593,7 +605,7 @@ end
 defmodule GameClient.Protobuf.Crate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:health, 1, proto3_optional: true, type: :uint64)
 
@@ -609,7 +621,7 @@ end
 defmodule GameClient.Protobuf.Pool do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:status, 2, type: GameClient.Protobuf.PoolStatus, enum: true)
@@ -620,13 +632,13 @@ end
 defmodule GameClient.Protobuf.Bush do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.Trap do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:owner_id, 1, type: :uint64, json_name: "ownerId")
   field(:name, 2, type: :string)
@@ -636,7 +648,7 @@ end
 defmodule GameClient.Protobuf.PlayerAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:action, 1, type: GameClient.Protobuf.PlayerActionType, enum: true)
   field(:duration, 2, type: :uint64)
@@ -647,7 +659,7 @@ end
 defmodule GameClient.Protobuf.Move do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:direction, 1, type: GameClient.Protobuf.Direction)
 end
@@ -655,7 +667,7 @@ end
 defmodule GameClient.Protobuf.Attack do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill, 1, type: :string)
   field(:parameters, 2, type: GameClient.Protobuf.AttackParameters)
@@ -664,7 +676,7 @@ end
 defmodule GameClient.Protobuf.AttackParameters do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target, 1, type: GameClient.Protobuf.Direction)
 end
@@ -672,7 +684,7 @@ end
 defmodule GameClient.Protobuf.UseItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:item, 1, type: :uint64)
 end
@@ -680,7 +692,7 @@ end
 defmodule GameClient.Protobuf.SelectBounty do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:bounty_quest_id, 1, type: :string, json_name: "bountyQuestId")
 end
@@ -688,19 +700,19 @@ end
 defmodule GameClient.Protobuf.ToggleZone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.ToggleBots do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 end
 
 defmodule GameClient.Protobuf.ChangeTickrate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:tickrate, 1, type: :int64)
 end
@@ -708,7 +720,7 @@ end
 defmodule GameClient.Protobuf.GameAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:action_type, 0)
 
@@ -737,7 +749,7 @@ end
 defmodule GameClient.Protobuf.Zone do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:radius, 1, type: :float)
   field(:enabled, 2, type: :bool)
@@ -748,7 +760,7 @@ end
 defmodule GameClient.Protobuf.KillEntry do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:killer_id, 1, type: :uint64, json_name: "killerId")
   field(:victim_id, 2, type: :uint64, json_name: "victimId")
@@ -757,7 +769,7 @@ end
 defmodule GameClient.Protobuf.BountyInfo do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:description, 2, type: :string)
@@ -768,7 +780,7 @@ end
 defmodule GameClient.Protobuf.CurrencyReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: :string)
   field(:amount, 2, type: :int64)

--- a/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
+++ b/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
@@ -5,6 +5,7 @@
     <.button type="submit" name="game_mode" value="battle-royale">Play Battle Royal</.button>
     <.button type="submit" name="game_mode" value="pair">Play Pair</.button>
     <.button type="submit" name="game_mode" value="quick-game">Quick Game</.button>
+    <.button type="submit" name="game_mode" value="deathmatch">Deathmatch</.button>
   </.form>
 
   <p>Logged in as user_id: <%= @current_user_id %></p>

--- a/apps/gateway/lib/gateway/serialization/gateway.pb.ex
+++ b/apps/gateway/lib/gateway/serialization/gateway.pb.ex
@@ -1,7 +1,7 @@
 defmodule Gateway.Serialization.SkillActionType do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:ANIMATION_START, 0)
   field(:EFFECT_TRIGGER, 1)
@@ -12,7 +12,7 @@ end
 defmodule Gateway.Serialization.Stat do
   @moduledoc false
 
-  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:HEALTH, 0)
   field(:ENERGY, 1)
@@ -25,7 +25,7 @@ end
 defmodule Gateway.Serialization.WebSocketRequest do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:request_type, 0)
 
@@ -127,7 +127,7 @@ end
 defmodule Gateway.Serialization.GetUser do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -135,7 +135,7 @@ end
 defmodule Gateway.Serialization.GetUserByUsername do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:username, 1, type: :string)
 end
@@ -143,7 +143,7 @@ end
 defmodule Gateway.Serialization.CreateUser do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:username, 1, type: :string)
 end
@@ -151,7 +151,7 @@ end
 defmodule Gateway.Serialization.GetCampaigns do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -159,7 +159,7 @@ end
 defmodule Gateway.Serialization.GetCampaign do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -168,7 +168,7 @@ end
 defmodule Gateway.Serialization.GetLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:level_id, 2, type: :string, json_name: "levelId")
@@ -177,7 +177,7 @@ end
 defmodule Gateway.Serialization.FightLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:level_id, 2, type: :string, json_name: "levelId")
@@ -186,7 +186,7 @@ end
 defmodule Gateway.Serialization.SelectUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -196,7 +196,7 @@ end
 defmodule Gateway.Serialization.UnselectUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -205,7 +205,7 @@ end
 defmodule Gateway.Serialization.LevelUpUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -214,7 +214,7 @@ end
 defmodule Gateway.Serialization.TierUpUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -223,7 +223,7 @@ end
 defmodule Gateway.Serialization.FuseUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:unit_id, 2, type: :string, json_name: "unitId")
@@ -233,7 +233,7 @@ end
 defmodule Gateway.Serialization.EquipItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -243,7 +243,7 @@ end
 defmodule Gateway.Serialization.UnequipItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -252,7 +252,7 @@ end
 defmodule Gateway.Serialization.GetItem do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_id, 2, type: :string, json_name: "itemId")
@@ -261,7 +261,7 @@ end
 defmodule Gateway.Serialization.FuseItems do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:item_ids, 2, repeated: true, type: :string, json_name: "itemIds")
@@ -270,7 +270,7 @@ end
 defmodule Gateway.Serialization.GetKalineAfkRewards do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -278,7 +278,7 @@ end
 defmodule Gateway.Serialization.ClaimKalineAfkRewards do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -286,7 +286,7 @@ end
 defmodule Gateway.Serialization.GetBoxes do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -294,7 +294,7 @@ end
 defmodule Gateway.Serialization.GetBox do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:box_id, 1, type: :string, json_name: "boxId")
 end
@@ -302,7 +302,7 @@ end
 defmodule Gateway.Serialization.Summon do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:box_id, 2, type: :string, json_name: "boxId")
@@ -311,7 +311,7 @@ end
 defmodule Gateway.Serialization.GetUserSuperCampaignProgresses do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -319,7 +319,7 @@ end
 defmodule Gateway.Serialization.LevelUpKalineTree do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -327,7 +327,7 @@ end
 defmodule Gateway.Serialization.ClaimDungeonAfkRewards do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -335,7 +335,7 @@ end
 defmodule Gateway.Serialization.LevelUpDungeonSettlement do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
 end
@@ -343,7 +343,7 @@ end
 defmodule Gateway.Serialization.PurchaseDungeonUpgrade do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:upgrade_id, 2, type: :string, json_name: "upgradeId")
@@ -352,7 +352,7 @@ end
 defmodule Gateway.Serialization.WebSocketResponse do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:response_type, 0)
 
@@ -403,7 +403,7 @@ end
 defmodule Gateway.Serialization.User do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:username, 2, type: :string)
@@ -429,7 +429,7 @@ end
 defmodule Gateway.Serialization.KalineTreeLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint64)
@@ -447,7 +447,7 @@ end
 defmodule Gateway.Serialization.DungeonSettlementLevel do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint64)
@@ -472,7 +472,7 @@ end
 defmodule Gateway.Serialization.SuperCampaignProgresses do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:super_campaign_progresses, 1,
     repeated: true,
@@ -484,7 +484,7 @@ end
 defmodule Gateway.Serialization.SuperCampaignProgress do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user_id, 1, type: :string, json_name: "userId")
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -495,7 +495,7 @@ end
 defmodule Gateway.Serialization.AfkRewardRate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:kaline_tree_level_id, 1, type: :string, json_name: "kalineTreeLevelId")
   field(:currency, 2, type: Gateway.Serialization.Currency)
@@ -505,7 +505,7 @@ end
 defmodule Gateway.Serialization.UserCurrency do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 2, type: :uint32)
@@ -514,7 +514,7 @@ end
 defmodule Gateway.Serialization.Currency do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
 end
@@ -522,7 +522,7 @@ end
 defmodule Gateway.Serialization.Unit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint32)
@@ -539,7 +539,7 @@ end
 defmodule Gateway.Serialization.Units do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:units, 1, repeated: true, type: Gateway.Serialization.Unit)
 end
@@ -547,7 +547,7 @@ end
 defmodule Gateway.Serialization.UnitAndCurrencies do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:unit, 1, type: Gateway.Serialization.Unit)
 
@@ -561,7 +561,7 @@ end
 defmodule Gateway.Serialization.Character do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:active, 1, type: :bool)
   field(:name, 2, type: :string)
@@ -572,7 +572,7 @@ end
 defmodule Gateway.Serialization.Item do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:level, 2, type: :uint32)
@@ -584,7 +584,7 @@ end
 defmodule Gateway.Serialization.ItemTemplate do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:name, 2, type: :string)
@@ -605,7 +605,7 @@ end
 defmodule Gateway.Serialization.ItemModifier do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:attribute, 1, type: :string)
   field(:value, 2, type: :float)
@@ -615,7 +615,7 @@ end
 defmodule Gateway.Serialization.Campaigns do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:campaigns, 1, repeated: true, type: Gateway.Serialization.Campaign)
 end
@@ -623,7 +623,7 @@ end
 defmodule Gateway.Serialization.Campaign do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:super_campaign_name, 2, type: :string, json_name: "superCampaignName")
@@ -634,7 +634,7 @@ end
 defmodule Gateway.Serialization.Level do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:campaign_id, 2, type: :string, json_name: "campaignId")
@@ -661,7 +661,7 @@ end
 defmodule Gateway.Serialization.CurrencyReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 3, type: :uint64)
@@ -670,7 +670,7 @@ end
 defmodule Gateway.Serialization.AfkRewards do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:afk_rewards, 1,
     repeated: true,
@@ -682,7 +682,7 @@ end
 defmodule Gateway.Serialization.AfkReward do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 2, type: :uint64)
@@ -691,7 +691,7 @@ end
 defmodule Gateway.Serialization.Error do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:reason, 1, type: :string)
 end
@@ -699,7 +699,7 @@ end
 defmodule Gateway.Serialization.Boxes do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:boxes, 1, repeated: true, type: Gateway.Serialization.Box)
 end
@@ -707,7 +707,7 @@ end
 defmodule Gateway.Serialization.Box do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:name, 2, type: :string)
@@ -726,7 +726,7 @@ end
 defmodule Gateway.Serialization.RankWeights do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:rank, 1, type: :int32)
   field(:weight, 2, type: :int32)
@@ -735,7 +735,7 @@ end
 defmodule Gateway.Serialization.CurrencyCost do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:currency, 1, type: Gateway.Serialization.Currency)
   field(:amount, 2, type: :int32)
@@ -744,7 +744,7 @@ end
 defmodule Gateway.Serialization.UserAndUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:user, 1, type: Gateway.Serialization.User)
   field(:unit, 2, type: Gateway.Serialization.Unit)
@@ -753,7 +753,7 @@ end
 defmodule Gateway.Serialization.Unlock do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:upgrade, 2, type: Gateway.Serialization.Upgrade)
@@ -762,7 +762,7 @@ end
 defmodule Gateway.Serialization.Upgrade do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 1, type: :string)
   field(:description, 2, type: :string)
@@ -774,7 +774,7 @@ end
 defmodule Gateway.Serialization.Buff do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:attribute, 1, type: :string)
   field(:value, 2, type: :float)
@@ -784,7 +784,7 @@ end
 defmodule Gateway.Serialization.BattleResult do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:initial_state, 1, type: Gateway.Serialization.State, json_name: "initialState")
   field(:steps, 2, repeated: true, type: Gateway.Serialization.Step)
@@ -794,7 +794,7 @@ end
 defmodule Gateway.Serialization.State do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:units, 1, repeated: true, type: Gateway.Serialization.BattleUnit)
 end
@@ -802,7 +802,7 @@ end
 defmodule Gateway.Serialization.BattleUnit do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:id, 1, type: :string)
   field(:health, 2, type: :int32)
@@ -814,7 +814,7 @@ end
 defmodule Gateway.Serialization.Step do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:step_number, 1, type: :int32, json_name: "stepNumber")
   field(:actions, 2, repeated: true, type: Gateway.Serialization.Action)
@@ -823,7 +823,7 @@ end
 defmodule Gateway.Serialization.Action do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   oneof(:action_type, 0)
 
@@ -876,7 +876,7 @@ end
 defmodule Gateway.Serialization.StatAffected do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:stat, 1, type: Gateway.Serialization.Stat, enum: true)
   field(:amount, 2, type: :float)
@@ -885,7 +885,7 @@ end
 defmodule Gateway.Serialization.SkillAction do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:caster_id, 1, type: :string, json_name: "casterId")
   field(:target_ids, 2, repeated: true, type: :string, json_name: "targetIds")
@@ -901,7 +901,7 @@ end
 defmodule Gateway.Serialization.ExecutionReceived do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target_id, 1, type: :string, json_name: "targetId")
   field(:stat_affected, 2, type: Gateway.Serialization.StatAffected, json_name: "statAffected")
@@ -910,7 +910,7 @@ end
 defmodule Gateway.Serialization.ModifierReceived do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill_id, 1, type: :string, json_name: "skillId")
   field(:target_id, 2, type: :string, json_name: "targetId")
@@ -921,7 +921,7 @@ end
 defmodule Gateway.Serialization.TagReceived do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill_id, 1, type: :string, json_name: "skillId")
   field(:target_id, 2, type: :string, json_name: "targetId")
@@ -931,7 +931,7 @@ end
 defmodule Gateway.Serialization.ModifierExpired do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill_id, 1, type: :string, json_name: "skillId")
   field(:target_id, 2, type: :string, json_name: "targetId")
@@ -942,7 +942,7 @@ end
 defmodule Gateway.Serialization.TagExpired do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:skill_id, 1, type: :string, json_name: "skillId")
   field(:target_id, 2, type: :string, json_name: "targetId")
@@ -952,7 +952,7 @@ end
 defmodule Gateway.Serialization.Death do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:unit_id, 1, type: :string, json_name: "unitId")
 end
@@ -960,7 +960,7 @@ end
 defmodule Gateway.Serialization.EnergyRegen do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target_id, 1, type: :string, json_name: "targetId")
   field(:skill_id, 2, type: :string, json_name: "skillId")
@@ -970,7 +970,7 @@ end
 defmodule Gateway.Serialization.StatOverride do
   @moduledoc false
 
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:target_id, 1, type: :string, json_name: "targetId")
   field(:stat_affected, 2, type: Gateway.Serialization.StatAffected, json_name: "statAffected")

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -69,10 +69,18 @@ message Configuration {
   ClientConfig client_config = 4;
 }
 
+enum GameMode{
+  BATTLE = 0;
+  DEATHMATCH = 1;
+  PAIR = 2;
+  QUICK_GAME = 3;
+}
+
 message ConfigGame {
   float tick_rate_ms = 1;
   float bounty_pick_time_ms = 2;
   float start_game_time_ms = 3;
+  GameMode game_mode = 4;
 }
 
 message ConfigMap {


### PR DESCRIPTION
> [!Warning]
> Merge alongside https://github.com/lambdaclass/champions_of_mirra/pull/2230
## Motivation

Add a new game mode based on the deathmatch concept. All against all mode where the player with most kills wins the match.

Closes #917

## Summary of changes

- Added a new matchmaking for deathmatch mode
- Added a respawn feature only enabled for deathmatch mode
- Added a new win condition only enabled for deathmatch mode
- Send the gamemode to the client

## How to test it?

- Open the browser client and play a game in the deathmatch mode. If you want, you can print the winner in `apps/arena/lib/arena/game_updater.ex:337` and check that it is correct

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
