### PR TITLE
[GH-982] Square Wall Parameters in the Configurator

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_controller.ex
@@ -163,6 +163,7 @@ defmodule ConfiguratorWeb.MapConfigurationController do
     |> Map.update("bushes", "", &parse_json/1)
     |> Map.update("pools", "", &parse_json/1)
     |> Map.update("crates", "", &parse_json/1)
+    |> Map.update("square_wall", "", &parse_json/1)
   end
 
   defp parse_json(""), do: []

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html.ex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html.ex
@@ -15,8 +15,7 @@ defmodule ConfiguratorWeb.MapConfigurationHTML do
     embeds
     |> Enum.map(&embed_to_string/1)
     |> Enum.reject(&(&1 == nil))
-    |> Jason.encode!()
-    |> Jason.Formatter.pretty_print()
+    |> json_encode
   end
 
   def embed_to_string(nil), do: nil
@@ -33,5 +32,11 @@ defmodule ConfiguratorWeb.MapConfigurationHTML do
 
   def embed_to_string(struct) when is_map(struct) do
     struct
+  end
+
+  def json_encode(value) do
+    value
+    |> Jason.encode!()
+    |> Jason.Formatter.pretty_print()
   end
 end

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
@@ -60,6 +60,16 @@
       </.modal>
     <% end %>
   </:col>
+  <:col :let={map_configuration} label="Square Wall">
+    <%= if is_nil(map_configuration.square_wall) do %>
+      <p>N/A</p>
+    <% else %>
+      <.button type="button" phx-click={show_modal("square-wall-#{map_configuration.id}")}>Show</.button>
+      <.modal id={"square-wall-#{map_configuration.id}"}>
+        <p class="whitespace-pre"><%= json_encode(map_configuration.square_wall) %></p>
+      </.modal>
+    <% end %>
+  </:col>
   <:action :let={map_configuration}>
     <.link navigate={~p"/map_configurations/#{map_configuration}"}>View</.link>
   </:action>

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/map_configuration_form.html.heex
@@ -16,6 +16,7 @@
     label="Initial positions"
     value={embed_to_string(f[:initial_positions].value)}
   />
+  <.input field={f[:square_wall]} type="textarea" label="Square Wall" value={json_encode(f[:square_wall].value)} />
   <.input field={f[:obstacles]} type="textarea" label="Obstacles" value={embed_to_string(f[:obstacles].value)} />
   <.input field={f[:bushes]} type="textarea" label="Bushes" value={embed_to_string(f[:bushes].value)} />
   <.input field={f[:pools]} type="textarea" label="Pools" value={embed_to_string(f[:pools].value)} />

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
@@ -97,6 +97,19 @@
       <% end %>
     </dd>
   </div>
+  <div class="flex gap-5 py-4 border-b-2 items-center">
+    <dt>Square Wall</dt>
+    <dd>
+      <%= if is_nil(@map_configuration.square_wall) do %>
+        <p>N/A</p>
+      <% else %>
+        <.button type="button" phx-click={show_modal("square-wall-#{@map_configuration.id}")}>Show</.button>
+        <.modal id={"square-wall-#{@map_configuration.id}"}>
+          <p class="whitespace-pre"><%= json_encode(@map_configuration.square_wall) %></p>
+        </.modal>
+      <% end %>
+    </dd>
+  </div>
 </div>
 
 <.back navigate={~p"/map_configurations"}>Back to Map Configurations</.back>


### PR DESCRIPTION
## Motivation

in #977 we added new parameters to the map configuration, but they were not added into the configurator.

Closes #982 

## Summary of changes

- [feat: add square wall to map configurations form](https://github.com/lambdaclass/mirra_backend/commit/e0953360de1b9fab3e8b7fae4a6026fe41f08b4b)
- [feat: add square wall to show](https://github.com/lambdaclass/mirra_backend/commit/077b6ae4383decf9b7141fa40ad70329ea76e98c)
- [feat: add square wall to index](https://github.com/lambdaclass/mirra_backend/commit/ba351588c3b24f91ea5782d9c3405a146ad5b59d)

## How to test it?

You can find the parameters in `/map_configurations` or `/map_configurations/map_id`  

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
