### PR TITLE
Unblock player action inputs when dash/leap are finished

### DIFF
--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -235,7 +235,13 @@ defmodule Arena.Game.Player do
           end
 
         execution_duration = calculate_duration(skill, player.position, skill_direction, auto_aim?)
-        Process.send_after(self(), {:block_actions, player.id, false}, execution_duration)
+
+        # For dash and leaps, we rely the unblock action message to their stop action callbacks
+        is_dash_or_leap? = Enum.any?(skill.mechanics, fn mechanic -> mechanic.type in ["leap", "dash"] end)
+
+        unless is_dash_or_leap? do
+          Process.send_after(self(), {:block_actions, player.id, false}, execution_duration)
+        end
 
         if skill.block_movement do
           send(self(), {:block_movement, player.id, true})

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -371,6 +371,9 @@ defmodule Arena.GameUpdater do
       Map.get(state.game_state.players, player_id)
       |> Player.reset_forced_movement(previous_speed)
 
+    # Dash finished, we unblock the actions.
+    broadcast_player_block_actions(state.game_state.game_id, player_id, false)
+
     state = put_in(state, [:game_state, :players, player_id], player)
     {:noreply, state}
   end
@@ -383,6 +386,9 @@ defmodule Arena.GameUpdater do
     game_state =
       put_in(state.game_state, [:players, player_id], player)
       |> Skill.do_mechanic(player, on_arrival_mechanic, %{skill_direction: player.direction})
+
+    # Leap finished, we unblock the actions.
+    broadcast_player_block_actions(state.game_state.game_id, player_id, false)
 
     {:noreply, %{state | game_state: game_state}}
   end


### PR DESCRIPTION
## Motivation

Closes front issue https://github.com/lambdaclass/champions_of_mirra/issues/2270

## Summary of changes

[Unblock player action inputs when dash/leap are finished](https://github.com/lambdaclass/mirra_backend/commit/a375cf2fe42ab626bd479603a8914d8e7dccdf36)

## How to test it?

In main, muflus bots increase their speed considerably. Other bots also attack before the leap/dash is finished.
Now they shouldn't. To trigger muflus cheat by yourself, you can spam "o" and "p" keys in game client.
See if the bots behave weird even with this fix.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
