### PR TITLE
[GH-994] - Deathmatch Improvements

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -66,7 +66,8 @@ defmodule Arena.Entities do
         selected_bounty: nil,
         bounty_completed: false,
         current_basic_animation: 0,
-        item_effects_expires_at: now
+        item_effects_expires_at: now,
+        position: nil
       },
       collides_with: []
     }
@@ -395,7 +396,8 @@ defmodule Arena.Entities do
        forced_movement: get_in(entity, [:aditional_info, :forced_movement]),
        bounty_completed: get_in(entity, [:aditional_info, :bounty_completed]),
        mana: get_in(entity, [:aditional_info, :mana]),
-       current_basic_animation: get_in(entity, [:aditional_info, :current_basic_animation])
+       current_basic_animation: get_in(entity, [:aditional_info, :current_basic_animation]),
+       match_position: get_in(entity, [:aditional_info, :match_position])
      }}
   end
 

--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -357,4 +357,22 @@ defmodule Arena.Game.Effect do
 
     GameUpdater.update_entity_in_game_state(game_state, updated_entity)
   end
+
+  def invincible_effect do
+    %{
+      name: "respawn_grace_period",
+      duration_ms: 2000,
+      remove_on_action: false,
+      one_time_application: true,
+      allow_multiple_effects: true,
+      disabled_outside_pool: true,
+      effect_mechanics: [
+        %{
+          name: "damage_immunity",
+          effect_delay_ms: 0,
+          execute_multiple_times: false
+        }
+      ]
+    }
+  end
 end

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -458,7 +458,12 @@ defmodule Arena.Game.Player do
   end
 
   def respawn_player(player, position) do
-    aditional_info = player.aditional_info |> Map.put(:health, player.aditional_info.base_health)
+    aditional_info =
+      player.aditional_info
+      |> Map.put(:max_health, player.aditional_info.base_health)
+      |> Map.put(:health, player.aditional_info.base_health)
+      |> Map.put(:effects, [])
+      |> Map.put(:power_ups, 0)
 
     player
     |> Map.put(:aditional_info, aditional_info)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -555,7 +555,12 @@ defmodule Arena.GameUpdater do
       |> update_in([:killfeed], fn killfeed -> [entry | killfeed] end)
       |> maybe_add_kill_to_player(killer_id)
       |> grant_power_up_to_killer(game_config, killer_id, victim_id)
-      |> put_player_position(victim_id)
+
+    game_state = if game_config.game.game_mode != :DEATHMATCH do
+      put_player_position(game_state, victim_id)
+    else
+      game_state
+    end
 
     broadcast_player_dead(state.game_state.game_id, victim_id)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -556,11 +556,12 @@ defmodule Arena.GameUpdater do
       |> maybe_add_kill_to_player(killer_id)
       |> grant_power_up_to_killer(game_config, killer_id, victim_id)
 
-    game_state = if game_config.game.game_mode != :DEATHMATCH do
-      put_player_position(game_state, victim_id)
-    else
-      game_state
-    end
+    game_state =
+      if game_config.game.game_mode != :DEATHMATCH do
+        put_player_position(game_state, victim_id)
+      else
+        game_state
+      end
 
     broadcast_player_dead(state.game_state.game_id, victim_id)
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -789,6 +789,7 @@ defmodule Arena.GameUpdater do
     }
 
     encoded_state = GameEvent.encode(%GameEvent{event: {:finished, game_state}})
+    decoded_state = GameEvent.decode(encoded_state)
     PubSub.broadcast(Arena.PubSub, state.game_id, {:game_finished, encoded_state})
   end
 
@@ -1849,14 +1850,18 @@ defmodule Arena.GameUpdater do
     {client_id, _player_id} =
       Enum.find(game_state.client_to_player_map, fn {_, map_player_id} -> map_player_id == player_id end)
 
-    update_in(game_state, [:positions], fn positions -> Map.put(positions, client_id, "#{next_position}") end)
+    game_state
+    |> update_in([:players, player_id, :aditional_info, :match_position], fn _ -> next_position end)
+    |> update_in([:positions], fn positions -> Map.put(positions, client_id, "#{next_position}") end)
   end
 
   defp put_player_position(game_state, player_id, next_position) do
     {client_id, _player_id} =
       Enum.find(game_state.client_to_player_map, fn {_, map_player_id} -> map_player_id == player_id end)
 
-    update_in(game_state, [:positions], fn positions -> Map.put(positions, client_id, "#{next_position}") end)
+    game_state
+    |> update_in([:players, player_id, :aditional_info, :match_position], fn _ -> next_position end)
+    |> update_in([:positions], fn positions -> Map.put(positions, client_id, "#{next_position}") end)
   end
 
   defp maybe_add_kill_to_player(%{players: players} = game_state, player_id) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -789,7 +789,6 @@ defmodule Arena.GameUpdater do
     }
 
     encoded_state = GameEvent.encode(%GameEvent{event: {:finished, game_state}})
-    decoded_state = GameEvent.decode(encoded_state)
     PubSub.broadcast(Arena.PubSub, state.game_id, {:game_finished, encoded_state})
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1952,9 +1952,16 @@ defmodule Arena.GameUpdater do
       Enum.reduce(players_to_respawn, {game_state, game_state.respawn_queue}, fn {player_id, _time},
                                                                                  {game_state, respawn_queue} ->
         new_position = Enum.random(game_config.map.initial_positions)
-        player = Map.get(game_state.players, player_id) |> Player.respawn_player(new_position)
+
+        player =
+          Map.get(game_state.players, player_id)
+          |> Player.respawn_player(new_position)
+
+        game_state =
+          Effect.put_effect_to_entity(game_state, player, player_id, Effect.invincible_effect())
+
         broadcast_player_respawn(game_state.game_id, player_id)
-        {put_in(game_state, [:players, player_id], player), Map.delete(respawn_queue, player_id)}
+        {game_state, Map.delete(respawn_queue, player_id)}
       end)
 
     Map.put(game_state, :respawn_queue, respawn_queue)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -342,7 +342,7 @@ defmodule Arena.GameUpdater do
       |> put_in([:game_state, :status], :ENDED)
       |> update_in([:game_state], fn game_state ->
         players
-        |> Enum.reduce(game_state, fn {{player_id, _player, kills}, position}, game_state_acc ->
+        |> Enum.reduce(game_state, fn {{player_id, _player, _kills}, position}, game_state_acc ->
           put_player_position(game_state_acc, player_id, position)
         end)
       end)

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -7,7 +7,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
 
   # 3 Mins
   # TODO: add this to the configurator https://github.com/lambdaclass/mirra_backend/issues/985
-  @match_duration 180_000
+  @match_duration 20_000
   @respawn_time 5000
 
   # Time to wait to start game with any amount of clients

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -7,7 +7,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
 
   # 3 Mins
   # TODO: add this to the configurator https://github.com/lambdaclass/mirra_backend/issues/985
-  @match_duration 20_000
+  @match_duration 180_000
   @respawn_time 5000
 
   # Time to wait to start game with any amount of clients

--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -7,7 +7,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
 
   # 3 Mins
   # TODO: add this to the configurator https://github.com/lambdaclass/mirra_backend/issues/985
-  @match_duration 20_000
+  @match_duration 180_000
   @respawn_time 5000
 
   # API

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -551,6 +551,8 @@ defmodule Arena.Serialization.Player do
     type: :uint32,
     json_name: "currentBasicAnimation"
   )
+
+  field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
 end
 
 defmodule Arena.Serialization.Effect do

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.11.1",
+      version: "0.12.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -604,6 +604,8 @@ defmodule ArenaLoadTest.Serialization.Player do
     type: :uint32,
     json_name: "currentBasicAnimation"
   )
+
+  field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
 end
 
 defmodule ArenaLoadTest.Serialization.Effect do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -551,6 +551,8 @@ defmodule BotManager.Protobuf.Player do
     type: :uint32,
     json_name: "currentBasicAnimation"
   )
+
+  field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
 end
 
 defmodule BotManager.Protobuf.Effect do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -1033,8 +1033,8 @@ proto.Direction.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Direction.toObject = function(includeInstance, msg) {
   var f, obj = {
-    x: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
-    y: jspb.Message.getFloatingPointFieldWithDefault(msg, 2, 0.0)
+x: (f = jspb.Message.getOptionalFloatingPointField(msg, 1)) == null ? undefined : f,
+y: (f = jspb.Message.getOptionalFloatingPointField(msg, 2)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -1229,8 +1229,8 @@ proto.Position.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Position.toObject = function(includeInstance, msg) {
   var f, obj = {
-    x: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
-    y: jspb.Message.getFloatingPointFieldWithDefault(msg, 2, 0.0)
+x: (f = jspb.Message.getOptionalFloatingPointField(msg, 1)) == null ? undefined : f,
+y: (f = jspb.Message.getOptionalFloatingPointField(msg, 2)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -1432,7 +1432,7 @@ proto.ListPositionPB.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ListPositionPB.toObject = function(includeInstance, msg) {
   var f, obj = {
-    positionsList: jspb.Message.toObjectList(msg.getPositionsList(),
+positionsList: jspb.Message.toObjectList(msg.getPositionsList(),
     proto.Position.toObject, includeInstance)
   };
 
@@ -1613,10 +1613,10 @@ proto.LobbyEvent.prototype.toObject = function(opt_includeInstance) {
  */
 proto.LobbyEvent.toObject = function(includeInstance, msg) {
   var f, obj = {
-    leave: (f = msg.getLeave()) && proto.LeaveLobby.toObject(includeInstance, f),
-    left: (f = msg.getLeft()) && proto.LeftLobby.toObject(includeInstance, f),
-    joined: (f = msg.getJoined()) && proto.JoinedLobby.toObject(includeInstance, f),
-    game: (f = msg.getGame()) && proto.GameState.toObject(includeInstance, f)
+leave: (f = msg.getLeave()) && proto.LeaveLobby.toObject(includeInstance, f),
+left: (f = msg.getLeft()) && proto.LeftLobby.toObject(includeInstance, f),
+joined: (f = msg.getJoined()) && proto.JoinedLobby.toObject(includeInstance, f),
+game: (f = msg.getGame()) && proto.GameState.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -2249,11 +2249,11 @@ proto.GameEvent.prototype.toObject = function(opt_includeInstance) {
  */
 proto.GameEvent.toObject = function(includeInstance, msg) {
   var f, obj = {
-    joined: (f = msg.getJoined()) && proto.GameJoined.toObject(includeInstance, f),
-    update: (f = msg.getUpdate()) && proto.GameState.toObject(includeInstance, f),
-    finished: (f = msg.getFinished()) && proto.GameFinished.toObject(includeInstance, f),
-    toggleBots: (f = msg.getToggleBots()) && proto.ToggleBots.toObject(includeInstance, f),
-    bountySelected: (f = msg.getBountySelected()) && proto.BountySelected.toObject(includeInstance, f)
+joined: (f = msg.getJoined()) && proto.GameJoined.toObject(includeInstance, f),
+update: (f = msg.getUpdate()) && proto.GameState.toObject(includeInstance, f),
+finished: (f = msg.getFinished()) && proto.GameFinished.toObject(includeInstance, f),
+toggleBots: (f = msg.getToggleBots()) && proto.ToggleBots.toObject(includeInstance, f),
+bountySelected: (f = msg.getBountySelected()) && proto.BountySelected.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -2604,7 +2604,7 @@ proto.BountySelected.prototype.toObject = function(opt_includeInstance) {
  */
 proto.BountySelected.toObject = function(includeInstance, msg) {
   var f, obj = {
-    bounty: (f = msg.getBounty()) && proto.BountyInfo.toObject(includeInstance, f)
+bounty: (f = msg.getBounty()) && proto.BountyInfo.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -2755,8 +2755,8 @@ proto.GameFinished.prototype.toObject = function(opt_includeInstance) {
  */
 proto.GameFinished.toObject = function(includeInstance, msg) {
   var f, obj = {
-    winner: (f = msg.getWinner()) && proto.Entity.toObject(includeInstance, f),
-    playersMap: (f = msg.getPlayersMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : []
+winner: (f = msg.getWinner()) && proto.Entity.toObject(includeInstance, f),
+playersMap: (f = msg.getPlayersMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : []
   };
 
   if (includeInstance) {
@@ -2947,9 +2947,9 @@ proto.GameJoined.prototype.toObject = function(opt_includeInstance) {
  */
 proto.GameJoined.toObject = function(includeInstance, msg) {
   var f, obj = {
-    playerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    config: (f = msg.getConfig()) && proto.Configuration.toObject(includeInstance, f),
-    bountiesList: jspb.Message.toObjectList(msg.getBountiesList(),
+playerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+config: (f = msg.getConfig()) && proto.Configuration.toObject(includeInstance, f),
+bountiesList: jspb.Message.toObjectList(msg.getBountiesList(),
     proto.BountyInfo.toObject, includeInstance)
   };
 
@@ -3188,11 +3188,11 @@ proto.Configuration.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Configuration.toObject = function(includeInstance, msg) {
   var f, obj = {
-    game: (f = msg.getGame()) && proto.ConfigGame.toObject(includeInstance, f),
-    map: (f = msg.getMap()) && proto.ConfigMap.toObject(includeInstance, f),
-    charactersList: jspb.Message.toObjectList(msg.getCharactersList(),
+game: (f = msg.getGame()) && proto.ConfigGame.toObject(includeInstance, f),
+map: (f = msg.getMap()) && proto.ConfigMap.toObject(includeInstance, f),
+charactersList: jspb.Message.toObjectList(msg.getCharactersList(),
     proto.ConfigCharacter.toObject, includeInstance),
-    clientConfig: (f = msg.getClientConfig()) && proto.ClientConfig.toObject(includeInstance, f)
+clientConfig: (f = msg.getClientConfig()) && proto.ClientConfig.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -3494,10 +3494,10 @@ proto.ConfigGame.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigGame.toObject = function(includeInstance, msg) {
   var f, obj = {
-    tickRateMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
-    bountyPickTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 2, 0.0),
-    startGameTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0),
-    gameMode: jspb.Message.getFieldWithDefault(msg, 4, 0)
+tickRateMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
+bountyPickTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 2, 0.0),
+startGameTimeMs: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0),
+gameMode: jspb.Message.getFieldWithDefault(msg, 4, 0)
   };
 
   if (includeInstance) {
@@ -3714,8 +3714,8 @@ proto.ConfigMap.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigMap.toObject = function(includeInstance, msg) {
   var f, obj = {
-    radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
-    name: jspb.Message.getFieldWithDefault(msg, 2, "")
+radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
+name: jspb.Message.getFieldWithDefault(msg, 2, "")
   };
 
   if (includeInstance) {
@@ -3874,14 +3874,14 @@ proto.ConfigCharacter.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigCharacter.toObject = function(includeInstance, msg) {
   var f, obj = {
-    name: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    active: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
-    baseSpeed: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0),
-    baseSize: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
-    baseHealth: jspb.Message.getFieldWithDefault(msg, 5, 0),
-    maxInventorySize: jspb.Message.getFieldWithDefault(msg, 6, 0),
-    skillsMap: (f = msg.getSkillsMap()) ? f.toObject(includeInstance, proto.ConfigSkill.toObject) : [],
-    baseMana: jspb.Message.getFieldWithDefault(msg, 8, 0)
+name: jspb.Message.getFieldWithDefault(msg, 1, ""),
+active: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
+baseSpeed: jspb.Message.getFloatingPointFieldWithDefault(msg, 3, 0.0),
+baseSize: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
+baseHealth: jspb.Message.getFieldWithDefault(msg, 5, 0),
+maxInventorySize: jspb.Message.getFieldWithDefault(msg, 6, 0),
+skillsMap: (f = msg.getSkillsMap()) ? f.toObject(includeInstance, proto.ConfigSkill.toObject) : [],
+baseMana: jspb.Message.getFieldWithDefault(msg, 8, 0)
   };
 
   if (includeInstance) {
@@ -4218,7 +4218,7 @@ proto.ClientConfig.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ClientConfig.toObject = function(includeInstance, msg) {
   var f, obj = {
-    serverUpdate: (f = msg.getServerUpdate()) && proto.ConfigServerUpdate.toObject(includeInstance, f)
+serverUpdate: (f = msg.getServerUpdate()) && proto.ConfigServerUpdate.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -4369,12 +4369,12 @@ proto.ConfigServerUpdate.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigServerUpdate.toObject = function(includeInstance, msg) {
   var f, obj = {
-    timestampDifferenceSamplesToCheckWarning: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    timestampDifferencesSamplesMaxLength: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    showWarningThreshold: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    stopWarningThreshold: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    msWithoutUpdateShowWarning: jspb.Message.getFieldWithDefault(msg, 5, 0),
-    msWithoutUpdateDisconnect: jspb.Message.getFieldWithDefault(msg, 6, 0)
+timestampDifferenceSamplesToCheckWarning: jspb.Message.getFieldWithDefault(msg, 1, 0),
+timestampDifferencesSamplesMaxLength: jspb.Message.getFieldWithDefault(msg, 2, 0),
+showWarningThreshold: jspb.Message.getFieldWithDefault(msg, 3, 0),
+stopWarningThreshold: jspb.Message.getFieldWithDefault(msg, 4, 0),
+msWithoutUpdateShowWarning: jspb.Message.getFieldWithDefault(msg, 5, 0),
+msWithoutUpdateDisconnect: jspb.Message.getFieldWithDefault(msg, 6, 0)
   };
 
   if (includeInstance) {
@@ -4649,16 +4649,16 @@ proto.ConfigSkill.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ConfigSkill.toObject = function(includeInstance, msg) {
   var f, obj = {
-    name: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    cooldownMs: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    executionDurationMs: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    targettingRadius: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
-    targettingAngle: jspb.Message.getFloatingPointFieldWithDefault(msg, 5, 0.0),
-    targettingRange: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
-    staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0),
-    targettingOffset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0),
-    manaCost: jspb.Message.getFieldWithDefault(msg, 9, 0),
-    isCombo: jspb.Message.getBooleanFieldWithDefault(msg, 10, false)
+name: jspb.Message.getFieldWithDefault(msg, 1, ""),
+cooldownMs: jspb.Message.getFieldWithDefault(msg, 2, 0),
+executionDurationMs: jspb.Message.getFieldWithDefault(msg, 3, 0),
+targettingRadius: jspb.Message.getFloatingPointFieldWithDefault(msg, 4, 0.0),
+targettingAngle: jspb.Message.getFloatingPointFieldWithDefault(msg, 5, 0.0),
+targettingRange: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
+staminaCost: jspb.Message.getFieldWithDefault(msg, 7, 0),
+targettingOffset: jspb.Message.getFloatingPointFieldWithDefault(msg, 8, 0.0),
+manaCost: jspb.Message.getFieldWithDefault(msg, 9, 0),
+isCombo: jspb.Message.getBooleanFieldWithDefault(msg, 10, false)
   };
 
   if (includeInstance) {
@@ -5056,26 +5056,26 @@ proto.GameState.prototype.toObject = function(opt_includeInstance) {
  */
 proto.GameState.toObject = function(includeInstance, msg) {
   var f, obj = {
-    gameId: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    playersMap: (f = msg.getPlayersMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    projectilesMap: (f = msg.getProjectilesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    playerTimestampsMap: (f = msg.getPlayerTimestampsMap()) ? f.toObject(includeInstance, undefined) : [],
-    serverTimestamp: jspb.Message.getFieldWithDefault(msg, 5, 0),
-    zone: (f = msg.getZone()) && proto.Zone.toObject(includeInstance, f),
-    killfeedList: jspb.Message.toObjectList(msg.getKillfeedList(),
+gameId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+playersMap: (f = msg.getPlayersMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+projectilesMap: (f = msg.getProjectilesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+playerTimestampsMap: (f = msg.getPlayerTimestampsMap()) ? f.toObject(includeInstance, undefined) : [],
+serverTimestamp: jspb.Message.getFieldWithDefault(msg, 5, 0),
+zone: (f = msg.getZone()) && proto.Zone.toObject(includeInstance, f),
+killfeedList: jspb.Message.toObjectList(msg.getKillfeedList(),
     proto.KillEntry.toObject, includeInstance),
-    damageTakenMap: (f = msg.getDamageTakenMap()) ? f.toObject(includeInstance, undefined) : [],
-    damageDoneMap: (f = msg.getDamageDoneMap()) ? f.toObject(includeInstance, undefined) : [],
-    powerUpsMap: (f = msg.getPowerUpsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    status: jspb.Message.getFieldWithDefault(msg, 11, 0),
-    startGameTimestamp: jspb.Message.getFieldWithDefault(msg, 12, 0),
-    itemsMap: (f = msg.getItemsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    obstaclesMap: (f = msg.getObstaclesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    poolsMap: (f = msg.getPoolsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    cratesMap: (f = msg.getCratesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    bushesMap: (f = msg.getBushesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    trapsMap: (f = msg.getTrapsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
-    externalWall: (f = msg.getExternalWall()) && proto.Entity.toObject(includeInstance, f)
+damageTakenMap: (f = msg.getDamageTakenMap()) ? f.toObject(includeInstance, undefined) : [],
+damageDoneMap: (f = msg.getDamageDoneMap()) ? f.toObject(includeInstance, undefined) : [],
+powerUpsMap: (f = msg.getPowerUpsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+status: jspb.Message.getFieldWithDefault(msg, 11, 0),
+startGameTimestamp: jspb.Message.getFieldWithDefault(msg, 12, 0),
+itemsMap: (f = msg.getItemsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+obstaclesMap: (f = msg.getObstaclesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+poolsMap: (f = msg.getPoolsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+cratesMap: (f = msg.getCratesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+bushesMap: (f = msg.getBushesMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+trapsMap: (f = msg.getTrapsMap()) ? f.toObject(includeInstance, proto.Entity.toObject) : [],
+externalWall: (f = msg.getExternalWall()) && proto.Entity.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -5879,26 +5879,26 @@ proto.Entity.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Entity.toObject = function(includeInstance, msg) {
   var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    category: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    shape: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    name: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    position: (f = msg.getPosition()) && proto.Position.toObject(includeInstance, f),
-    radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 6, 0.0),
-    vertices: (f = msg.getVertices()) && proto.ListPositionPB.toObject(includeInstance, f),
-    collidesWithList: (f = jspb.Message.getRepeatedField(msg, 8)) == null ? undefined : f,
-    speed: jspb.Message.getFloatingPointFieldWithDefault(msg, 9, 0.0),
-    direction: (f = msg.getDirection()) && proto.Direction.toObject(includeInstance, f),
-    isMoving: jspb.Message.getBooleanFieldWithDefault(msg, 11, false),
-    player: (f = msg.getPlayer()) && proto.Player.toObject(includeInstance, f),
-    projectile: (f = msg.getProjectile()) && proto.Projectile.toObject(includeInstance, f),
-    obstacle: (f = msg.getObstacle()) && proto.Obstacle.toObject(includeInstance, f),
-    powerUp: (f = msg.getPowerUp()) && proto.PowerUp.toObject(includeInstance, f),
-    item: (f = msg.getItem()) && proto.Item.toObject(includeInstance, f),
-    pool: (f = msg.getPool()) && proto.Pool.toObject(includeInstance, f),
-    crate: (f = msg.getCrate()) && proto.Crate.toObject(includeInstance, f),
-    bush: (f = msg.getBush()) && proto.Bush.toObject(includeInstance, f),
-    trap: (f = msg.getTrap()) && proto.Trap.toObject(includeInstance, f)
+id: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
+category: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+shape: (f = jspb.Message.getField(msg, 3)) == null ? undefined : f,
+name: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f,
+position: (f = msg.getPosition()) && proto.Position.toObject(includeInstance, f),
+radius: (f = jspb.Message.getOptionalFloatingPointField(msg, 6)) == null ? undefined : f,
+vertices: (f = msg.getVertices()) && proto.ListPositionPB.toObject(includeInstance, f),
+collidesWithList: (f = jspb.Message.getRepeatedField(msg, 8)) == null ? undefined : f,
+speed: (f = jspb.Message.getOptionalFloatingPointField(msg, 9)) == null ? undefined : f,
+direction: (f = msg.getDirection()) && proto.Direction.toObject(includeInstance, f),
+isMoving: (f = jspb.Message.getBooleanField(msg, 11)) == null ? undefined : f,
+player: (f = msg.getPlayer()) && proto.Player.toObject(includeInstance, f),
+projectile: (f = msg.getProjectile()) && proto.Projectile.toObject(includeInstance, f),
+obstacle: (f = msg.getObstacle()) && proto.Obstacle.toObject(includeInstance, f),
+powerUp: (f = msg.getPowerUp()) && proto.PowerUp.toObject(includeInstance, f),
+item: (f = msg.getItem()) && proto.Item.toObject(includeInstance, f),
+pool: (f = msg.getPool()) && proto.Pool.toObject(includeInstance, f),
+crate: (f = msg.getCrate()) && proto.Crate.toObject(includeInstance, f),
+bush: (f = msg.getBush()) && proto.Bush.toObject(includeInstance, f),
+trap: (f = msg.getTrap()) && proto.Trap.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -6985,26 +6985,27 @@ proto.Player.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Player.toObject = function(includeInstance, msg) {
   var f, obj = {
-    health: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    killCount: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    currentActionsList: jspb.Message.toObjectList(msg.getCurrentActionsList(),
+health: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
+killCount: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+currentActionsList: jspb.Message.toObjectList(msg.getCurrentActionsList(),
     proto.PlayerAction.toObject, includeInstance),
-    availableStamina: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    maxStamina: jspb.Message.getFieldWithDefault(msg, 5, 0),
-    staminaInterval: jspb.Message.getFieldWithDefault(msg, 6, 0),
-    rechargingStamina: jspb.Message.getBooleanFieldWithDefault(msg, 7, false),
-    characterName: jspb.Message.getFieldWithDefault(msg, 8, ""),
-    powerUps: jspb.Message.getFieldWithDefault(msg, 9, 0),
-    effectsList: jspb.Message.toObjectList(msg.getEffectsList(),
+availableStamina: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f,
+maxStamina: (f = jspb.Message.getField(msg, 5)) == null ? undefined : f,
+staminaInterval: (f = jspb.Message.getField(msg, 6)) == null ? undefined : f,
+rechargingStamina: (f = jspb.Message.getBooleanField(msg, 7)) == null ? undefined : f,
+characterName: (f = jspb.Message.getField(msg, 8)) == null ? undefined : f,
+powerUps: (f = jspb.Message.getField(msg, 9)) == null ? undefined : f,
+effectsList: jspb.Message.toObjectList(msg.getEffectsList(),
     proto.Effect.toObject, includeInstance),
-    inventory: (f = msg.getInventory()) && proto.Item.toObject(includeInstance, f),
-    cooldownsMap: (f = msg.getCooldownsMap()) ? f.toObject(includeInstance, undefined) : [],
-    visiblePlayersList: (f = jspb.Message.getRepeatedField(msg, 13)) == null ? undefined : f,
-    onBush: jspb.Message.getBooleanFieldWithDefault(msg, 14, false),
-    forcedMovement: jspb.Message.getBooleanFieldWithDefault(msg, 15, false),
-    bountyCompleted: jspb.Message.getBooleanFieldWithDefault(msg, 16, false),
-    mana: jspb.Message.getFieldWithDefault(msg, 17, 0),
-    currentBasicAnimation: jspb.Message.getFieldWithDefault(msg, 18, 0)
+inventory: (f = msg.getInventory()) && proto.Item.toObject(includeInstance, f),
+cooldownsMap: (f = msg.getCooldownsMap()) ? f.toObject(includeInstance, undefined) : [],
+visiblePlayersList: (f = jspb.Message.getRepeatedField(msg, 13)) == null ? undefined : f,
+onBush: (f = jspb.Message.getBooleanField(msg, 14)) == null ? undefined : f,
+forcedMovement: (f = jspb.Message.getBooleanField(msg, 15)) == null ? undefined : f,
+bountyCompleted: (f = jspb.Message.getBooleanField(msg, 16)) == null ? undefined : f,
+mana: (f = jspb.Message.getField(msg, 17)) == null ? undefined : f,
+currentBasicAnimation: (f = jspb.Message.getField(msg, 18)) == null ? undefined : f,
+matchPosition: (f = jspb.Message.getField(msg, 19)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -7119,6 +7120,10 @@ proto.Player.deserializeBinaryFromReader = function(msg, reader) {
     case 18:
       var value = /** @type {number} */ (reader.readUint32());
       msg.setCurrentBasicAnimation(value);
+      break;
+    case 19:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setMatchPosition(value);
       break;
     default:
       reader.skipField();
@@ -7272,6 +7277,13 @@ proto.Player.serializeBinaryToWriter = function(message, writer) {
   if (f != null) {
     writer.writeUint32(
       18,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 19));
+  if (f != null) {
+    writer.writeUint32(
+      19,
       f
     );
   }
@@ -7919,6 +7931,42 @@ proto.Player.prototype.hasCurrentBasicAnimation = function() {
 };
 
 
+/**
+ * optional uint32 match_position = 19;
+ * @return {number}
+ */
+proto.Player.prototype.getMatchPosition = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 19, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.setMatchPosition = function(value) {
+  return jspb.Message.setField(this, 19, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.clearMatchPosition = function() {
+  return jspb.Message.setField(this, 19, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.Player.prototype.hasMatchPosition = function() {
+  return jspb.Message.getField(this, 19) != null;
+};
+
+
 
 
 
@@ -7951,9 +7999,9 @@ proto.Effect.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Effect.toObject = function(includeInstance, msg) {
   var f, obj = {
-    name: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    durationMs: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    id: jspb.Message.getFieldWithDefault(msg, 3, 0)
+name: jspb.Message.getFieldWithDefault(msg, 1, ""),
+durationMs: jspb.Message.getFieldWithDefault(msg, 2, 0),
+id: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -8141,7 +8189,7 @@ proto.Item.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Item.toObject = function(includeInstance, msg) {
   var f, obj = {
-    name: jspb.Message.getFieldWithDefault(msg, 2, "")
+name: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -8289,10 +8337,10 @@ proto.Projectile.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Projectile.toObject = function(includeInstance, msg) {
   var f, obj = {
-    damage: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    ownerId: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    status: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    skillKey: jspb.Message.getFieldWithDefault(msg, 4, "")
+damage: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
+ownerId: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+status: jspb.Message.getFieldWithDefault(msg, 3, 0),
+skillKey: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -8563,10 +8611,10 @@ proto.Obstacle.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Obstacle.toObject = function(includeInstance, msg) {
   var f, obj = {
-    color: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    collisionable: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
-    status: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    type: jspb.Message.getFieldWithDefault(msg, 4, "")
+color: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
+collisionable: (f = jspb.Message.getBooleanField(msg, 2)) == null ? undefined : f,
+status: (f = jspb.Message.getField(msg, 3)) == null ? undefined : f,
+type: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -8855,8 +8903,8 @@ proto.PowerUp.prototype.toObject = function(opt_includeInstance) {
  */
 proto.PowerUp.toObject = function(includeInstance, msg) {
   var f, obj = {
-    ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    status: jspb.Message.getFieldWithDefault(msg, 2, 0)
+ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+status: jspb.Message.getFieldWithDefault(msg, 2, 0)
   };
 
   if (includeInstance) {
@@ -9015,9 +9063,9 @@ proto.Crate.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Crate.toObject = function(includeInstance, msg) {
   var f, obj = {
-    health: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    amountOfPowerUps: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    status: jspb.Message.getFieldWithDefault(msg, 3, 0)
+health: (f = jspb.Message.getField(msg, 1)) == null ? undefined : f,
+amountOfPowerUps: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+status: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -9248,11 +9296,11 @@ proto.Pool.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Pool.toObject = function(includeInstance, msg) {
   var f, obj = {
-    ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    status: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    effectsList: jspb.Message.toObjectList(msg.getEffectsList(),
+ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+status: jspb.Message.getFieldWithDefault(msg, 2, 0),
+effectsList: jspb.Message.toObjectList(msg.getEffectsList(),
     proto.Effect.toObject, includeInstance),
-    skillKey: jspb.Message.getFieldWithDefault(msg, 4, "")
+skillKey: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -9592,9 +9640,9 @@ proto.Trap.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Trap.toObject = function(includeInstance, msg) {
   var f, obj = {
-    ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    name: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    status: jspb.Message.getFieldWithDefault(msg, 3, 0)
+ownerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+name: jspb.Message.getFieldWithDefault(msg, 2, ""),
+status: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -9782,10 +9830,10 @@ proto.PlayerAction.prototype.toObject = function(opt_includeInstance) {
  */
 proto.PlayerAction.toObject = function(includeInstance, msg) {
   var f, obj = {
-    action: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    duration: jspb.Message.getFieldWithDefault(msg, 2, 0),
-    destination: (f = msg.getDestination()) && proto.Position.toObject(includeInstance, f),
-    direction: (f = msg.getDirection()) && proto.Position.toObject(includeInstance, f)
+action: jspb.Message.getFieldWithDefault(msg, 1, 0),
+duration: jspb.Message.getFieldWithDefault(msg, 2, 0),
+destination: (f = msg.getDestination()) && proto.Position.toObject(includeInstance, f),
+direction: (f = msg.getDirection()) && proto.Position.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -10044,7 +10092,7 @@ proto.Move.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Move.toObject = function(includeInstance, msg) {
   var f, obj = {
-    direction: (f = msg.getDirection()) && proto.Direction.toObject(includeInstance, f)
+direction: (f = msg.getDirection()) && proto.Direction.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -10195,8 +10243,8 @@ proto.Attack.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Attack.toObject = function(includeInstance, msg) {
   var f, obj = {
-    skill: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    parameters: (f = msg.getParameters()) && proto.AttackParameters.toObject(includeInstance, f)
+skill: jspb.Message.getFieldWithDefault(msg, 1, ""),
+parameters: (f = msg.getParameters()) && proto.AttackParameters.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -10376,7 +10424,7 @@ proto.AttackParameters.prototype.toObject = function(opt_includeInstance) {
  */
 proto.AttackParameters.toObject = function(includeInstance, msg) {
   var f, obj = {
-    target: (f = msg.getTarget()) && proto.Direction.toObject(includeInstance, f)
+target: (f = msg.getTarget()) && proto.Direction.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -10527,7 +10575,7 @@ proto.UseItem.prototype.toObject = function(opt_includeInstance) {
  */
 proto.UseItem.toObject = function(includeInstance, msg) {
   var f, obj = {
-    item: jspb.Message.getFieldWithDefault(msg, 1, 0)
+item: jspb.Message.getFieldWithDefault(msg, 1, 0)
   };
 
   if (includeInstance) {
@@ -10657,7 +10705,7 @@ proto.SelectBounty.prototype.toObject = function(opt_includeInstance) {
  */
 proto.SelectBounty.toObject = function(includeInstance, msg) {
   var f, obj = {
-    bountyQuestId: jspb.Message.getFieldWithDefault(msg, 1, "")
+bountyQuestId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
 
   if (includeInstance) {
@@ -10989,7 +11037,7 @@ proto.ChangeTickrate.prototype.toObject = function(opt_includeInstance) {
  */
 proto.ChangeTickrate.toObject = function(includeInstance, msg) {
   var f, obj = {
-    tickrate: jspb.Message.getFieldWithDefault(msg, 1, 0)
+tickrate: jspb.Message.getFieldWithDefault(msg, 1, 0)
   };
 
   if (includeInstance) {
@@ -11150,14 +11198,14 @@ proto.GameAction.prototype.toObject = function(opt_includeInstance) {
  */
 proto.GameAction.toObject = function(includeInstance, msg) {
   var f, obj = {
-    move: (f = msg.getMove()) && proto.Move.toObject(includeInstance, f),
-    attack: (f = msg.getAttack()) && proto.Attack.toObject(includeInstance, f),
-    useItem: (f = msg.getUseItem()) && proto.UseItem.toObject(includeInstance, f),
-    selectBounty: (f = msg.getSelectBounty()) && proto.SelectBounty.toObject(includeInstance, f),
-    toggleZone: (f = msg.getToggleZone()) && proto.ToggleZone.toObject(includeInstance, f),
-    toggleBots: (f = msg.getToggleBots()) && proto.ToggleBots.toObject(includeInstance, f),
-    changeTickrate: (f = msg.getChangeTickrate()) && proto.ChangeTickrate.toObject(includeInstance, f),
-    timestamp: jspb.Message.getFieldWithDefault(msg, 3, 0)
+move: (f = msg.getMove()) && proto.Move.toObject(includeInstance, f),
+attack: (f = msg.getAttack()) && proto.Attack.toObject(includeInstance, f),
+useItem: (f = msg.getUseItem()) && proto.UseItem.toObject(includeInstance, f),
+selectBounty: (f = msg.getSelectBounty()) && proto.SelectBounty.toObject(includeInstance, f),
+toggleZone: (f = msg.getToggleZone()) && proto.ToggleZone.toObject(includeInstance, f),
+toggleBots: (f = msg.getToggleBots()) && proto.ToggleBots.toObject(includeInstance, f),
+changeTickrate: (f = msg.getChangeTickrate()) && proto.ChangeTickrate.toObject(includeInstance, f),
+timestamp: jspb.Message.getFieldWithDefault(msg, 3, 0)
   };
 
   if (includeInstance) {
@@ -11637,10 +11685,10 @@ proto.Zone.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Zone.toObject = function(includeInstance, msg) {
   var f, obj = {
-    radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
-    enabled: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
-    nextZoneChangeTimestamp: jspb.Message.getFieldWithDefault(msg, 3, 0),
-    shrinking: jspb.Message.getBooleanFieldWithDefault(msg, 4, false)
+radius: jspb.Message.getFloatingPointFieldWithDefault(msg, 1, 0.0),
+enabled: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
+nextZoneChangeTimestamp: jspb.Message.getFieldWithDefault(msg, 3, 0),
+shrinking: jspb.Message.getBooleanFieldWithDefault(msg, 4, false)
   };
 
   if (includeInstance) {
@@ -11857,8 +11905,8 @@ proto.KillEntry.prototype.toObject = function(opt_includeInstance) {
  */
 proto.KillEntry.toObject = function(includeInstance, msg) {
   var f, obj = {
-    killerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    victimId: jspb.Message.getFieldWithDefault(msg, 2, 0)
+killerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
+victimId: jspb.Message.getFieldWithDefault(msg, 2, 0)
   };
 
   if (includeInstance) {
@@ -12017,10 +12065,10 @@ proto.BountyInfo.prototype.toObject = function(opt_includeInstance) {
  */
 proto.BountyInfo.toObject = function(includeInstance, msg) {
   var f, obj = {
-    id: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    description: jspb.Message.getFieldWithDefault(msg, 2, ""),
-    questType: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    reward: (f = msg.getReward()) && proto.CurrencyReward.toObject(includeInstance, f)
+id: jspb.Message.getFieldWithDefault(msg, 1, ""),
+description: jspb.Message.getFieldWithDefault(msg, 2, ""),
+questType: jspb.Message.getFieldWithDefault(msg, 3, ""),
+reward: (f = msg.getReward()) && proto.CurrencyReward.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -12258,8 +12306,8 @@ proto.CurrencyReward.prototype.toObject = function(opt_includeInstance) {
  */
 proto.CurrencyReward.toObject = function(includeInstance, msg) {
   var f, obj = {
-    currency: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    amount: jspb.Message.getFieldWithDefault(msg, 2, 0)
+currency: jspb.Message.getFieldWithDefault(msg, 1, ""),
+amount: jspb.Message.getFieldWithDefault(msg, 2, 0)
   };
 
   if (includeInstance) {

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -551,6 +551,8 @@ defmodule GameClient.Protobuf.Player do
     type: :uint32,
     json_name: "currentBasicAnimation"
   )
+
+  field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
 end
 
 defmodule GameClient.Protobuf.Effect do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -216,6 +216,7 @@ message Player {
   optional bool bounty_completed = 16;
   optional uint64 mana = 17;
   optional uint32 current_basic_animation = 18;
+  optional uint32 match_position = 19;
 }
 
 message Effect {


### PR DESCRIPTION
## Motivation

Fix some a few concerns of the deathmatch mode
Addresses part of #994 

## Summary of changes

- Fixed respawn issues [feat: respawn issues](https://github.com/lambdaclass/mirra_backend/commit/17a4511f6e1feae380caaa64d8f814e82c6d8cb1)
   - set the power ups to 0 when respawning
   - restore the max health to the base health when respawning (otherwise the player would stay with the power ups buff)
   - clear all the effects when respawning
   - add an invincibility  effect when respawning
- [fix: players positions were being applied after every kill](https://github.com/lambdaclass/mirra_backend/commit/e47a181278eaa7c422eacbc24aca3cdb86b8453e)

## How to test it?

- See the changes above and play a deathmatch move 

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
