### PR TITLE
[GH-680] Make bots do not follow invisible players

### DIFF
--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -46,7 +46,6 @@ defmodule BotManager.BotStateMachine do
     |> Map.filter(fn {player_id, player} ->
       Utils.player_alive?(player) && is_player_within_visible_players(bot_player, player_id)
     end)
-    |> IO.inspect(label: :wea)
     |> Enum.map(fn {_player_id, player} ->
       player_info =
         get_distance_and_direction_to_positions(bot_player.position, player.position)

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -44,7 +44,7 @@ defmodule BotManager.BotStateMachine do
   defp map_directions_to_players(game_state, bot_player) do
     Map.delete(game_state.players, bot_player.id)
     |> Map.filter(fn {player_id, player} ->
-      Utils.player_alive?(player) && is_player_within_visible_players(bot_player, player_id)
+      Utils.player_alive?(player) && player_within_visible_players?(bot_player, player_id)
     end)
     |> Enum.map(fn {_player_id, player} ->
       player_info =
@@ -65,7 +65,7 @@ defmodule BotManager.BotStateMachine do
     }
   end
 
-  defp is_player_within_visible_players(bot_player, player_id) do
+  defp player_within_visible_players?(bot_player, player_id) do
     {:player, aditiona_info} = bot_player.aditional_info
     Enum.member?(aditiona_info.visible_players, player_id)
   end

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -43,7 +43,10 @@ defmodule BotManager.BotStateMachine do
 
   defp map_directions_to_players(game_state, bot_player) do
     Map.delete(game_state.players, bot_player.id)
-    |> Map.filter(fn {_player_id, player} -> Utils.player_alive?(player) end)
+    |> Map.filter(fn {player_id, player} ->
+      Utils.player_alive?(player) && is_player_within_visible_players(bot_player, player_id)
+    end)
+    |> IO.inspect(label: :wea)
     |> Enum.map(fn {_player_id, player} ->
       player_info =
         get_distance_and_direction_to_positions(bot_player.position, player.position)
@@ -61,5 +64,10 @@ defmodule BotManager.BotStateMachine do
       direction: direction,
       distance: distance
     }
+  end
+
+  defp is_player_within_visible_players(bot_player, player_id) do
+    {:player, aditiona_info} = bot_player.aditional_info
+    Enum.member?(aditiona_info.visible_players, player_id)
   end
 end

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -142,4 +142,8 @@ defmodule BotManager.GameSocketHandler do
       "wss://#{arena_host}/play/#{game_id}/#{bot_client}"
     end
   end
+
+  def terminate(close_reason, state) do
+    Logger.error("Terminating bot with reason: #{inspect(close_reason)}")
+  end
 end

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -143,7 +143,7 @@ defmodule BotManager.GameSocketHandler do
     end
   end
 
-  def terminate(close_reason, state) do
+  def terminate(close_reason, _state) do
     Logger.error("Terminating bot with reason: #{inspect(close_reason)}")
   end
 end


### PR DESCRIPTION
## Motivation

Bots are able to track players that are not in their field of vision and creating and unfair gameplay for testers

Closes #680

## Summary of changes

- [code: add logger for bots game socket handler](https://github.com/lambdaclass/mirra_backend/commit/b7834b7b474df254e5f2853f9a78c47183d4e871)  Needed because if the bot application crashes, it did not popped out any errors
- [feat: make bot take into account only visible players](https://github.com/lambdaclass/mirra_backend/commit/ae9d6d41aa91e527f6c56133eb0ee49abb937bf4)

## How to test it?

Play a match and hide within bushes

## Checklist
- [x] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
