### PR TITLE
[GH-1010] - Fix deathmatch endgame results

### DIFF
--- a/apps/arena/lib/arena/game_tracker.ex
+++ b/apps/arena/lib/arena/game_tracker.ex
@@ -30,6 +30,7 @@ defmodule Arena.GameTracker do
           | {:heal, player_id(), non_neg_integer()}
           | {:kill_by_zone, player_id()}
           | {:select_bounty, player_id(), bounty_quest_id()}
+          | {:deathmatch_position, player_id(), pos_integer()}
 
   @spec push_event(pid(), event()) :: :ok
   def push_event(match_pid, event) do
@@ -134,6 +135,11 @@ defmodule Arena.GameTracker do
     |> put_in([:players, victim_id, :killed_by_bot], false)
     |> put_in([:players, victim_id, :position], data.position_on_death)
     |> put_in([:position_on_death], data.position_on_death - 1)
+  end
+
+  defp update_data(data, {:deathmatch_position, player_id, position}) do
+    data
+    |> put_in([:players, player_id, :position], position)
   end
 
   defp update_data(data, {:damage_taken, player_id, amount}) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -354,6 +354,7 @@ defmodule Arena.GameUpdater do
         teams_with_kills
         |> Enum.reduce(game_state, fn {team, position}, game_state_acc ->
           Enum.reduce(team.players, game_state_acc, fn player, game_state_acc ->
+            GameTracker.push_event(self(), {:deathmatch_position, player.id, position})
             put_player_position(game_state_acc, player.id, position)
           end)
         end)

--- a/apps/game_backend/priv/arena_prestige_ranks.json
+++ b/apps/game_backend/priv/arena_prestige_ranks.json
@@ -439,6 +439,136 @@
           "reward": -12
         }
       ]
+    },
+    {
+      "position": 11,
+      "distributions": [
+        {
+          "min": 0,
+          "max": 49,
+          "reward": 0
+        },
+        {
+          "min": 50,
+          "max": 99,
+          "reward": -1
+        },
+        {
+          "min": 100,
+          "max": 199,
+          "reward": -2
+        },
+        {
+          "min": 200,
+          "max": 299,
+          "reward": -3
+        },
+        {
+          "min": 300,
+          "max": 399,
+          "reward": -4
+        },
+        {
+          "min": 400,
+          "max": 499,
+          "reward": -5
+        },
+        {
+          "min": 500,
+          "max": 599,
+          "reward": -6
+        },
+        {
+          "min": 600,
+          "max": 699,
+          "reward": -7
+        },
+        {
+          "min": 700,
+          "max": 799,
+          "reward": -8
+        },
+        {
+          "min": 800,
+          "max": 899,
+          "reward": -9
+        },
+        {
+          "min": 900,
+          "max": 999,
+          "reward": -10
+        },
+        {
+          "min": 1000,
+          "max": 2147483647,
+          "reward": -12
+        }
+      ]
+    },
+    {
+      "position": 12,
+      "distributions": [
+        {
+          "min": 0,
+          "max": 49,
+          "reward": 0
+        },
+        {
+          "min": 50,
+          "max": 99,
+          "reward": -1
+        },
+        {
+          "min": 100,
+          "max": 199,
+          "reward": -2
+        },
+        {
+          "min": 200,
+          "max": 299,
+          "reward": -3
+        },
+        {
+          "min": 300,
+          "max": 399,
+          "reward": -4
+        },
+        {
+          "min": 400,
+          "max": 499,
+          "reward": -5
+        },
+        {
+          "min": 500,
+          "max": 599,
+          "reward": -6
+        },
+        {
+          "min": 600,
+          "max": 699,
+          "reward": -7
+        },
+        {
+          "min": 700,
+          "max": 799,
+          "reward": -8
+        },
+        {
+          "min": 800,
+          "max": 899,
+          "reward": -9
+        },
+        {
+          "min": 900,
+          "max": 999,
+          "reward": -10
+        },
+        {
+          "min": 1000,
+          "max": 2147483647,
+          "reward": -12
+        }
+      ]
     }
   ],
   "ranks": [


### PR DESCRIPTION
## Motivation

Closes #1010 
We were unable to store the results of some players due to two main reasons:

1. The file `apps/game_backend/priv/arena_prestige_ranks.json`, where we store prestiges based on player positions, only supported up to 10 players 😬.  
2. The game tracker was not properly tracking the players' positions in the match.  

I created an issue with the things we can improve #1011 

## Summary of changes

- [fix: add missing prestiges](https://github.com/lambdaclass/mirra_backend/pull/1008/commits/c9b6f414e25dd0275bd5e55f041854af9e1cb130)
- [fix: deathmatch position in game tracker](https://github.com/lambdaclass/mirra_backend/pull/1008/commits/3b0ee5ad07d8eae7078efb56d45b0667b5898d44)

## How to test it?

*You can explain how you tested it or suggest a way to do so.*

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
