### PR TITLE
[HOTFIX] - Wrongly assigned the match position in Battle Mode

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -1867,7 +1867,7 @@ defmodule Arena.GameUpdater do
   end
 
   defp put_player_position(%{positions: positions} = game_state, player_id) do
-    next_position = Application.get_env(:arena, :players_needed_in_match) - Enum.count(positions)
+    next_position = Enum.count(game_state.players) - Enum.count(positions)
 
     {client_id, _player_id} =
       Enum.find(game_state.client_to_player_map, fn {_, map_player_id} -> map_player_id == player_id end)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -379,6 +379,8 @@ defmodule Arena.GameUpdater do
           state.game_config.game.end_game_interval_ms
         )
 
+        {:noreply, state}
+
       {:ended, winner_team} ->
         winner_team_ids = Enum.map(winner_team, fn {id, _player} -> id end)
         winner_team_number = Enum.random(winner_team) |> elem(1) |> get_in([:aditional_info, :team])
@@ -395,9 +397,8 @@ defmodule Arena.GameUpdater do
         ## sending messages, this way we give some time before making them crash
         ## (sending to inexistant process will cause them to crash)
         Process.send_after(self(), :game_ended, state.game_config.game.shutdown_game_wait_ms)
+        {:noreply, state}
     end
-
-    {:noreply, state}
   end
 
   # Shutdown


### PR DESCRIPTION
## Motivation

In battle mode, when playing with fewer than 12 players, some players were incorrectly assigned a match position of 12, even though there weren’t 12 participants. Additionally, the winner of the match is displayed with a rank of 0 on the win screen instead of 1.

## Summary of changes

- [fix: use the current amount of players](https://github.com/lambdaclass/mirra_backend/commit/5d48f5132884d9e7f89a9bd7cf24db8ad39c16a0)
- [fix: return the state](https://github.com/lambdaclass/mirra_backend/commit/19e3278826dff5e9224e9e52f973d3cc4c0430ed)

## How to test it?

Play some matches in battle mode, win 1, lose some others and check that your rank is correct.
In `apps/arena/lib/arena/matchmaking/game_launcher.ex:104`, we have this piece of code:

```elixir
    Enum.map(1..missing_clients//1, fn i ->
      client_id = UUID.generate()

      %{client_id: client_id, character_name: Enum.random(characters).name, name: Enum.at(bot_names, i - 1), type: :bot}
    end)
```
If you change `1..missing_clients//1` for a number below 12, you'll able to reproduce the results faster

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
