### PR TITLE
Fix fake_item mechanic field name in seeds

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/index.html.heex
@@ -8,7 +8,8 @@
 </.header>
 
 <.table id="map_configurations" rows={@map_configurations}>
-  <:col :let={map_configuration} label="name"><%= map_configuration.name %></:col>
+  <:col :let={map_configuration} label="Name"><%= map_configuration.name %></:col>
+  <:col :let={map_configuration} label="Active"><%= map_configuration.active %></:col>
   <:col :let={map_configuration} label="Radius"><%= map_configuration.radius %></:col>
   <:col :let={map_configuration} label="Initial positions">
     <%= if (Enum.empty?(map_configuration.initial_positions)) do %>

--- a/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/map_configuration_html/show.html.heex
@@ -29,6 +29,10 @@
     <dd><%= @map_configuration.name %></dd>
   </div>
   <div class="flex gap-5 py-4 border-b-2 items-center">
+    <dt>Active</dt>
+    <dd><%= @map_configuration.active %></dd>
+  </div>
+  <div class="flex gap-5 py-4 border-b-2 items-center">
     <dt>Map Radius</dt>
     <dd><%= @map_configuration.radius %></dd>
   </div>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1535,7 +1535,7 @@ fake_item_params = %{
   active: false,
   name: "fake_item",
   radius: 200.0,
-  effect_mechanics: [spawn_bomb_mechanic],
+  mechanics: [spawn_bomb_mechanic],
   version_id: version.id
 }
 


### PR DESCRIPTION
## Motivation

DB has associations and data that violates our changesets.
Also some data isn't being inserted in seeds, due to wrong association field names.
Closes #1041

## Summary of changes

- [Fix fake_item mechanic field name in seeds](https://github.com/lambdaclass/mirra_backend/pull/1042/commits/c6026a487b9c1f8603a7ce004a28ead1716e671b)
- [Add MapConfiguration.active field to show and index templates](https://github.com/lambdaclass/mirra_backend/pull/1042/commits/6cb0989c7b4c464284263f0ab89ebe3b2729e431)

## How to test it?

Run seeds, open localhost:4100.
You should see same data as testing Configurator and be able to create new versions.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
