### PR TITLE
Fix copy version: add missing assocs and assign skill to characters

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
@@ -3,8 +3,8 @@
     Welcome to Champions of Mirra Configurator
   </.header>
 
-  <.link href={~p"/versions/new"}>
-    <.button>New Version</.button>
+  <.link href={~p"/versions/copy"}>
+    <.button>Copy Version</.button>
   </.link>
   <.link href={~p"/versions/show_current_version"}>
     <.button>See Current Version</.button>

--- a/apps/configurator/lib/configurator_web/controllers/version_html/copy.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/version_html/copy.html.heex
@@ -1,0 +1,22 @@
+<.simple_form :let={f} for={%{}} action="/versions/create_copy">
+  <.header>
+    Copy version
+    <:subtitle>Use this form to create a new version record in your database.</:subtitle>
+  </.header>
+
+  <.input
+    field={f[:version_id]}
+    type="select"
+    options={Enum.map(@versions, fn version -> {version.name, version.id} end)}
+    label="Version to copy from"
+    value={Enum.find(@versions, %{}, fn version -> version.current end) |> Map.get(:id)}
+  />
+
+  <.input field={f[:name]} type="text" label="New copy version name" />
+
+  <:actions>
+    <.button>Create new copy version</.button>
+  </:actions>
+</.simple_form>
+
+<.back navigate={~p"/versions"}>Back to versions</.back>

--- a/apps/configurator/lib/configurator_web/controllers/version_html/index.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/version_html/index.html.heex
@@ -1,8 +1,8 @@
 <.header>
   Listing Versions
   <:actions>
-    <.link href={~p"/versions/new"}>
-      <.button>New Version</.button>
+    <.link href={~p"/versions/copy"}>
+      <.button>Copy Version</.button>
     </.link>
   </:actions>
 </.header>

--- a/apps/configurator/lib/configurator_web/controllers/version_html/new.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/version_html/new.html.heex
@@ -3,6 +3,6 @@
   <:subtitle>Use this form to manage version records in your database.</:subtitle>
 </.header>
 
-<.version_form changeset={@changeset} last_version={@last_version} action={~p"/versions"} skills={@skills} />
+<.version_form changeset={@changeset} action={~p"/versions"} skills={@skills} />
 
 <.back navigate={~p"/versions"}>Back to versions</.back>

--- a/apps/configurator/lib/configurator_web/router.ex
+++ b/apps/configurator/lib/configurator_web/router.ex
@@ -57,6 +57,8 @@ defmodule ConfiguratorWeb.Router do
 
     scope "/versions" do
       get "/show_current_version", VersionController, :show_current_version
+      get "/copy", VersionController, :copy
+      post "/create_copy", VersionController, :create_copy
       resources "/", VersionController
       put "/:id/current", VersionController, :mark_as_current
 

--- a/apps/configurator/test/configurator_web/controllers/version_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/version_controller_test.exs
@@ -17,6 +17,13 @@ defmodule ConfiguratorWeb.VersionControllerTest do
     end
   end
 
+  describe "new version" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, ~p"/versions/new")
+      assert html_response(conn, 200) =~ "New Version"
+    end
+  end
+
   describe "create version" do
     test "redirects to show when data is valid", %{conn: conn} do
       conn = post(conn, ~p"/versions", version: @create_attrs)

--- a/apps/configurator/test/configurator_web/controllers/version_controller_test.exs
+++ b/apps/configurator/test/configurator_web/controllers/version_controller_test.exs
@@ -17,13 +17,6 @@ defmodule ConfiguratorWeb.VersionControllerTest do
     end
   end
 
-  describe "new version" do
-    test "renders form", %{conn: conn} do
-      conn = get(conn, ~p"/versions/new")
-      assert html_response(conn, 200) =~ "New Version"
-    end
-  end
-
   describe "create version" do
     test "redirects to show when data is valid", %{conn: conn} do
       conn = post(conn, ~p"/versions", version: @create_attrs)

--- a/apps/game_backend/lib/game_backend/configuration.ex
+++ b/apps/game_backend/lib/game_backend/configuration.ex
@@ -407,6 +407,33 @@ defmodule GameBackend.Configuration do
   """
   def get_version!(id), do: Repo.get!(Version, id)
 
+  def get_preloaded_version!(id) do
+    consumable_items_preload =
+      from(ci in GameBackend.Items.ConsumableItem,
+        preload: [
+          mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]
+        ]
+      )
+
+    q =
+      from(v in Version,
+        where: v.id == ^id,
+        preload: [
+          [consumable_items: ^consumable_items_preload],
+          [skills: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics]]],
+          :map_configurations,
+          :game_configuration,
+          characters: [
+            [basic_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]],
+            [ultimate_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]],
+            [dash_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]]
+          ]
+        ]
+      )
+
+    Repo.one!(q)
+  end
+
   @doc """
   Creates a version.
 
@@ -423,6 +450,41 @@ defmodule GameBackend.Configuration do
     %Version{}
     |> Version.changeset(attrs)
     |> Repo.insert()
+  end
+
+  def copy_version(attrs \\ %{}) do
+    Multi.new()
+    |> Multi.insert(
+      :version,
+      %Version{}
+      |> Version.changeset(attrs)
+    )
+    |> Multi.run(:link_character_skills, fn repo, changes ->
+      characters = changes.version.characters
+      skills = changes.version.skills
+
+      characters
+      |> Enum.each(fn character ->
+        character
+        |> Character.changeset(%{})
+        |> Ecto.Changeset.put_change(
+          :basic_skill_id,
+          Enum.find(skills, fn skill -> skill.name == character.basic_skill.name end).id
+        )
+        |> Ecto.Changeset.put_change(
+          :dash_skill_id,
+          Enum.find(skills, fn skill -> skill.name == character.dash_skill.name end).id
+        )
+        |> Ecto.Changeset.put_change(
+          :ultimate_skill_id,
+          Enum.find(skills, fn skill -> skill.name == character.ultimate_skill.name end).id
+        )
+        |> repo.update!()
+      end)
+
+      {:ok, :ok}
+    end)
+    |> Repo.transaction()
   end
 
   @doc """

--- a/apps/game_backend/lib/game_backend/units/characters/character.ex
+++ b/apps/game_backend/lib/game_backend/units/characters/character.ex
@@ -104,8 +104,9 @@ defmodule GameBackend.Units.Characters.Character do
       :ultimate_skill_id,
       :version_id
     ])
-    |> cast_assoc(:basic_skill)
-    |> cast_assoc(:ultimate_skill)
+    |> cast_assoc(:basic_skill, with: &Skill.assoc_changeset/2)
+    |> cast_assoc(:dash_skill, with: &Skill.assoc_changeset/2)
+    |> cast_assoc(:ultimate_skill, with: &Skill.assoc_changeset/2)
     |> unique_constraint([:game_id, :name, :version_id])
     |> validate_required([:game_id, :name, :active, :faction])
     |> mana_recovery_strategy_validation()


### PR DESCRIPTION
## Motivation

The new version form is hard to understand and unreliable.
Also, there's a bug where the characters' skills are linked to the previous version ones.

## Summary of changes

[Replace new version endpoint to copy any version](https://github.com/lambdaclass/mirra_backend/pull/1044/commits/1b6783ac6fb7ac9fa98bff1138b6c96eee23e1ef)

## How to test it?

Open localhost:4100 and copy any version.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
