### PR TITLE
Add new silence item

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -246,6 +246,8 @@ defmodule Arena.Entities do
       aditional_info: %{
         name: config.name,
         mechanic_radius: get_range_from_mechanic(config.mechanics),
+        status: :ITEM_STATUS_UNDEFINED,
+        owner_id: nil,
         effect: config.effect,
         mechanics: config.mechanics,
         pull_immunity: true
@@ -490,7 +492,9 @@ defmodule Arena.Entities do
     {:item,
      %Arena.Serialization.Item{
        name: get_in(entity, [:aditional_info, :name]),
-       mechanic_radius: get_in(entity, [:aditional_info, :mechanic_radius])
+       mechanic_radius: get_in(entity, [:aditional_info, :mechanic_radius]),
+       status: get_in(entity, [:aditional_info, :status]),
+       owner_id: get_in(entity, [:aditional_info, :owner_id])
      }}
   end
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -245,12 +245,16 @@ defmodule Arena.Entities do
       is_moving: false,
       aditional_info: %{
         name: config.name,
+        mechanic_radius: get_range_from_mechanic(config.mechanics),
         effect: config.effect,
         mechanics: config.mechanics,
         pull_immunity: true
       }
     }
   end
+
+  defp get_range_from_mechanic([]), do: nil
+  defp get_range_from_mechanic([mechanic | _]), do: mechanic.range
 
   def new_obstacle(id, %{position: position, radius: radius, shape: shape, vertices: vertices} = params) do
     %{
@@ -485,7 +489,8 @@ defmodule Arena.Entities do
   def maybe_add_custom_info(entity) when entity.category == :item do
     {:item,
      %Arena.Serialization.Item{
-       name: get_in(entity, [:aditional_info, :name])
+       name: get_in(entity, [:aditional_info, :name]),
+       mechanic_radius: get_in(entity, [:aditional_info, :mechanic_radius])
      }}
   end
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -91,7 +91,8 @@ defmodule Arena.Entities do
         bounty_completed: false,
         current_basic_animation: 0,
         item_effects_expires_at: now,
-        position: nil
+        position: nil,
+        blocked_actions: false
       },
       collides_with: []
     }
@@ -438,7 +439,8 @@ defmodule Arena.Entities do
        mana: get_in(entity, [:aditional_info, :mana]),
        current_basic_animation: get_in(entity, [:aditional_info, :current_basic_animation]),
        match_position: get_in(entity, [:aditional_info, :match_position]),
-       team: get_in(entity, [:aditional_info, :team])
+       team: get_in(entity, [:aditional_info, :team]),
+       blocked_actions: get_in(entity, [:aditional_info, :blocked_actions])
      }}
   end
 
@@ -577,6 +579,12 @@ defmodule Arena.Entities do
 
   def refresh_cooldowns(%{category: :player} = entity) do
     put_in(entity, [:aditional_info, :cooldowns], %{})
+  end
+
+  def block_actions_for_duration(%{category: :player} = entity, duration) do
+    Process.send(self(), {:block_actions, entity.id, true}, [])
+    Process.send_after(self(), {:block_actions, entity.id, false}, duration)
+    put_in(entity, [:aditional_info, :blocked_actions], true)
   end
 
   def obstacle_collisionable?(%{type: "dynamic"} = params) do

--- a/apps/arena/lib/arena/game/effect.ex
+++ b/apps/arena/lib/arena/game/effect.ex
@@ -276,6 +276,10 @@ defmodule Arena.Game.Effect do
     Entities.refresh_cooldowns(entity)
   end
 
+  defp do_effect_mechanics(_game_state, entity, effect, %{name: "silence"} = _silence_mechanic) do
+    Entities.block_actions_for_duration(entity, effect.duration_ms)
+  end
+
   ## Sink for mechanics that don't do anything
   defp do_effect_mechanics(_game_state, entity, _effect, _mechanic) do
     entity

--- a/apps/arena/lib/arena/game/item.ex
+++ b/apps/arena/lib/arena/game/item.ex
@@ -5,6 +5,7 @@ defmodule Arena.Game.Item do
 
   alias Arena.Entities
   alias Arena.Game.Player
+  alias Arena.Game.Skill
 
   @doc """
   Apply all item mechanics to an entity
@@ -35,6 +36,10 @@ defmodule Arena.Game.Item do
   def do_mechanic(game_state, entity, %{type: "heal"} = item_params) do
     player = Player.add_health(entity, item_params.amount)
     put_in(game_state, [:players, player.id], player)
+  end
+
+  def do_mechanic(game_state, entity, %{type: "circle_hit"} = item_params) do
+    Skill.do_mechanic(game_state, entity, item_params, %{})
   end
 
   def do_mechanic(game_state, _entity, _mechanic) do

--- a/apps/arena/lib/arena/game/player.ex
+++ b/apps/arena/lib/arena/game/player.ex
@@ -379,6 +379,8 @@ defmodule Arena.Game.Player do
 
         Item.do_mechanics(game_state, player, item.mechanics)
         |> put_in([:players, player.id, :aditional_info, :inventory], nil)
+        |> put_in([:items, item.id, :aditional_info, :status], :ITEM_USED)
+        |> put_in([:items, item.id, :aditional_info, :owner_id], player.id)
     end
   end
 

--- a/apps/arena/lib/arena/game/skill.ex
+++ b/apps/arena/lib/arena/game/skill.ex
@@ -48,6 +48,27 @@ defmodule Arena.Game.Skill do
   defp execute_mechanic(
          game_state,
          entity,
+         %{type: "circle_hit"} = circle_hit,
+         _skill_params
+       ) do
+    circle_center_position = get_position_with_offset(entity.position, nil, circle_hit.offset)
+    circular_damage_area = Entities.make_circular_area(entity.id, circle_center_position, circle_hit.range)
+
+    entity_player_owner = get_entity_player_owner(game_state, entity)
+
+    apply_damage_and_effects_to_entities(
+      game_state,
+      entity_player_owner,
+      circular_damage_area,
+      circle_hit.damage,
+      circle_hit.effect
+    )
+    |> maybe_move_player(entity, circle_hit[:move_by])
+  end
+
+  defp execute_mechanic(
+         game_state,
+         entity,
          %{type: "cone_hit"} = cone_hit,
          %{skill_direction: skill_direction} = _skill_params
        ) do
@@ -401,6 +422,13 @@ defmodule Arena.Game.Skill do
       end)
 
     Enum.concat([add_side, middle, sub_side])
+  end
+
+  defp get_position_with_offset(position, nil, offset) do
+    real_position_x = position.x + offset
+    real_position_y = position.y + offset
+
+    %{x: real_position_x, y: real_position_y}
   end
 
   defp get_position_with_offset(position, direction, offset) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -2043,7 +2043,7 @@ defmodule Arena.GameUpdater do
                   {players_acc, Map.put(items_acc, item.id, item)}
 
                 not Player.inventory_full?(player) ->
-                  player = Player.store_item(player, item.aditional_info)
+                  player = Player.store_item(player, item.aditional_info |> Map.put(:id, item.id))
 
                   {Map.put(players_acc, player.id, player),
                    Map.put(items_acc, item.id, put_in(item, [:aditional_info, :status], :ITEM_PICKED_UP))}

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -675,6 +675,7 @@ defmodule Arena.GameUpdater do
   end
 
   def handle_info({:block_actions, player_id, value}, state) do
+    state = put_in(state, [:game_state, :players, player_id, :aditional_info, :blocked_actions], value)
     broadcast_player_block_actions(state.game_state.game_id, player_id, value)
     {:noreply, state}
   end

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -248,7 +248,6 @@ defmodule Arena.GameUpdater do
       |> Effect.apply_effect_mechanic_to_entities()
       # Players
       |> move_players()
-      |> update_pickup_time_for_items()
       |> reduce_players_cooldowns(delta_time)
       |> recover_mana()
       |> resolve_projectiles_effects_on_collisions()
@@ -260,8 +259,6 @@ defmodule Arena.GameUpdater do
       |> move_projectiles()
       |> resolve_projectiles_collisions()
       |> explode_projectiles()
-      # Items
-      |> update_items_status()
       # Pools
       |> add_pools_collisions()
       |> handle_pools()
@@ -278,6 +275,8 @@ defmodule Arena.GameUpdater do
       |> add_players_to_respawn_queue(state.game_config)
       |> respawn_players(state.game_config)
       # Items
+      |> update_pickup_time_for_items()
+      |> update_items_status()
       |> remove_pickup_time_for_items()
 
     {:ok, state_diff} = diff(state.last_broadcasted_game_state, game_state)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -2063,18 +2063,30 @@ defmodule Arena.GameUpdater do
   defp remove_pickup_time_for_items(game_state) do
     items =
       Enum.reduce(game_state.items, %{}, fn {item_id, item}, acc ->
-        players_colliding = Physics.check_collisions(item, game_state.players)
-
         item =
-          put_in(
-            item,
-            [:aditional_info, :pick_up_time_elapsed],
-            Map.take(item.aditional_info.pick_up_time_elapsed, players_colliding)
-          )
-          |> put_in(
-            [:aditional_info, :pick_up_time_initial_timestamp],
-            Map.take(item.aditional_info.pick_up_time_initial_timestamp, players_colliding)
-          )
+          if item.aditional_info.status != :ITEM_STATUS_UNDEFINED do
+            put_in(
+              item,
+              [:aditional_info, :pick_up_time_elapsed],
+              %{}
+            )
+            |> put_in(
+              [:aditional_info, :pick_up_time_initial_timestamp],
+              nil
+            )
+          else
+            players_colliding = Physics.check_collisions(item, game_state.players)
+
+            put_in(
+              item,
+              [:aditional_info, :pick_up_time_elapsed],
+              Map.take(item.aditional_info.pick_up_time_elapsed, players_colliding)
+            )
+            |> put_in(
+              [:aditional_info, :pick_up_time_initial_timestamp],
+              Map.take(item.aditional_info.pick_up_time_initial_timestamp, players_colliding)
+            )
+          end
 
         Map.put(acc, item_id, item)
       end)

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -20,6 +20,18 @@ defmodule Arena.Serialization.GameStatus do
   field(:SELECTING_BOUNTY, 3)
 end
 
+defmodule Arena.Serialization.ItemStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:ITEM_STATUS_UNDEFINED, 0)
+  field(:ITEM_PICKED_UP, 1)
+  field(:ITEM_USED, 2)
+  field(:ITEM_ACTIVE, 3)
+  field(:ITEM_EXPIRED, 4)
+end
+
 defmodule Arena.Serialization.ProjectileStatus do
   @moduledoc false
 
@@ -588,6 +600,8 @@ defmodule Arena.Serialization.Item do
 
   field(:name, 2, proto3_optional: true, type: :string)
   field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
+  field(:status, 4, type: Arena.Serialization.ItemStatus, enum: true)
+  field(:owner_id, 5, proto3_optional: true, type: :uint64, json_name: "ownerId")
 end
 
 defmodule Arena.Serialization.Projectile do

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -587,6 +587,7 @@ defmodule Arena.Serialization.Item do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
+  field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
 end
 
 defmodule Arena.Serialization.Projectile do

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -568,6 +568,7 @@ defmodule Arena.Serialization.Player do
   field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
   field(:team, 20, proto3_optional: true, type: :uint32)
   field(:max_health, 21, proto3_optional: true, type: :uint64, json_name: "maxHealth")
+  field(:blocked_actions, 22, proto3_optional: true, type: :bool, json_name: "blockedActions")
 end
 
 defmodule Arena.Serialization.Effect do

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.15.1",
+      version: "0.16.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.14.1",
+      version: "0.15.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -640,6 +640,7 @@ defmodule ArenaLoadTest.Serialization.Item do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
+  field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
 end
 
 defmodule ArenaLoadTest.Serialization.Projectile do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -20,6 +20,18 @@ defmodule ArenaLoadTest.Serialization.GameStatus do
   field(:SELECTING_BOUNTY, 3)
 end
 
+defmodule ArenaLoadTest.Serialization.ItemStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:ITEM_STATUS_UNDEFINED, 0)
+  field(:ITEM_PICKED_UP, 1)
+  field(:ITEM_USED, 2)
+  field(:ITEM_ACTIVE, 3)
+  field(:ITEM_EXPIRED, 4)
+end
+
 defmodule ArenaLoadTest.Serialization.ProjectileStatus do
   @moduledoc false
 
@@ -641,6 +653,8 @@ defmodule ArenaLoadTest.Serialization.Item do
 
   field(:name, 2, proto3_optional: true, type: :string)
   field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
+  field(:status, 4, type: ArenaLoadTest.Serialization.ItemStatus, enum: true)
+  field(:owner_id, 5, proto3_optional: true, type: :uint64, json_name: "ownerId")
 end
 
 defmodule ArenaLoadTest.Serialization.Projectile do

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -621,6 +621,7 @@ defmodule ArenaLoadTest.Serialization.Player do
   field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
   field(:team, 20, proto3_optional: true, type: :uint32)
   field(:max_health, 21, proto3_optional: true, type: :uint64, json_name: "maxHealth")
+  field(:blocked_actions, 22, proto3_optional: true, type: :bool, json_name: "blockedActions")
 end
 
 defmodule ArenaLoadTest.Serialization.Effect do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -20,6 +20,18 @@ defmodule BotManager.Protobuf.GameStatus do
   field(:SELECTING_BOUNTY, 3)
 end
 
+defmodule BotManager.Protobuf.ItemStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:ITEM_STATUS_UNDEFINED, 0)
+  field(:ITEM_PICKED_UP, 1)
+  field(:ITEM_USED, 2)
+  field(:ITEM_ACTIVE, 3)
+  field(:ITEM_EXPIRED, 4)
+end
+
 defmodule BotManager.Protobuf.ProjectileStatus do
   @moduledoc false
 
@@ -588,6 +600,8 @@ defmodule BotManager.Protobuf.Item do
 
   field(:name, 2, proto3_optional: true, type: :string)
   field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
+  field(:status, 4, type: BotManager.Protobuf.ItemStatus, enum: true)
+  field(:owner_id, 5, proto3_optional: true, type: :uint64, json_name: "ownerId")
 end
 
 defmodule BotManager.Protobuf.Projectile do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -568,6 +568,7 @@ defmodule BotManager.Protobuf.Player do
   field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
   field(:team, 20, proto3_optional: true, type: :uint32)
   field(:max_health, 21, proto3_optional: true, type: :uint64, json_name: "maxHealth")
+  field(:blocked_actions, 22, proto3_optional: true, type: :bool, json_name: "blockedActions")
 end
 
 defmodule BotManager.Protobuf.Effect do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -587,6 +587,7 @@ defmodule BotManager.Protobuf.Item do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
+  field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
 end
 
 defmodule BotManager.Protobuf.Projectile do

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/effect.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/effect.ex
@@ -81,7 +81,8 @@ defmodule GameBackend.CurseOfMirra.Effect do
           :buff_pool,
           :refresh_stamina,
           :refresh_cooldowns,
-          :invisible
+          :invisible,
+          :silence
         ]
       )
 

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -51,6 +51,7 @@ goog.exportSymbol('proto.GameMode', null, global);
 goog.exportSymbol('proto.GameState', null, global);
 goog.exportSymbol('proto.GameStatus', null, global);
 goog.exportSymbol('proto.Item', null, global);
+goog.exportSymbol('proto.ItemStatus', null, global);
 goog.exportSymbol('proto.JoinedLobby', null, global);
 goog.exportSymbol('proto.KillEntry', null, global);
 goog.exportSymbol('proto.LeaveLobby', null, global);
@@ -8317,7 +8318,9 @@ proto.Item.prototype.toObject = function(opt_includeInstance) {
 proto.Item.toObject = function(includeInstance, msg) {
   var f, obj = {
 name: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
-mechanicRadius: (f = jspb.Message.getOptionalFloatingPointField(msg, 3)) == null ? undefined : f
+mechanicRadius: (f = jspb.Message.getOptionalFloatingPointField(msg, 3)) == null ? undefined : f,
+status: jspb.Message.getFieldWithDefault(msg, 4, 0),
+ownerId: (f = jspb.Message.getField(msg, 5)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -8362,6 +8365,14 @@ proto.Item.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {number} */ (reader.readFloat());
       msg.setMechanicRadius(value);
       break;
+    case 4:
+      var value = /** @type {!proto.ItemStatus} */ (reader.readEnum());
+      msg.setStatus(value);
+      break;
+    case 5:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOwnerId(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -8402,6 +8413,20 @@ proto.Item.serializeBinaryToWriter = function(message, writer) {
   if (f != null) {
     writer.writeFloat(
       3,
+      f
+    );
+  }
+  f = message.getStatus();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      4,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 5));
+  if (f != null) {
+    writer.writeUint64(
+      5,
       f
     );
   }
@@ -8477,6 +8502,60 @@ proto.Item.prototype.clearMechanicRadius = function() {
  */
 proto.Item.prototype.hasMechanicRadius = function() {
   return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional ItemStatus status = 4;
+ * @return {!proto.ItemStatus}
+ */
+proto.Item.prototype.getStatus = function() {
+  return /** @type {!proto.ItemStatus} */ (jspb.Message.getFieldWithDefault(this, 4, 0));
+};
+
+
+/**
+ * @param {!proto.ItemStatus} value
+ * @return {!proto.Item} returns this
+ */
+proto.Item.prototype.setStatus = function(value) {
+  return jspb.Message.setProto3EnumField(this, 4, value);
+};
+
+
+/**
+ * optional uint64 owner_id = 5;
+ * @return {number}
+ */
+proto.Item.prototype.getOwnerId = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.Item} returns this
+ */
+proto.Item.prototype.setOwnerId = function(value) {
+  return jspb.Message.setField(this, 5, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.Item} returns this
+ */
+proto.Item.prototype.clearOwnerId = function() {
+  return jspb.Message.setField(this, 5, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.Item.prototype.hasOwnerId = function() {
+  return jspb.Message.getField(this, 5) != null;
 };
 
 
@@ -12627,6 +12706,17 @@ proto.GameStatus = {
   RUNNING: 1,
   ENDED: 2,
   SELECTING_BOUNTY: 3
+};
+
+/**
+ * @enum {number}
+ */
+proto.ItemStatus = {
+  ITEM_STATUS_UNDEFINED: 0,
+  ITEM_PICKED_UP: 1,
+  ITEM_USED: 2,
+  ITEM_ACTIVE: 3,
+  ITEM_EXPIRED: 4
 };
 
 /**

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -8316,7 +8316,8 @@ proto.Item.prototype.toObject = function(opt_includeInstance) {
  */
 proto.Item.toObject = function(includeInstance, msg) {
   var f, obj = {
-name: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f
+name: (f = jspb.Message.getField(msg, 2)) == null ? undefined : f,
+mechanicRadius: (f = jspb.Message.getOptionalFloatingPointField(msg, 3)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -8357,6 +8358,10 @@ proto.Item.deserializeBinaryFromReader = function(msg, reader) {
       var value = /** @type {string} */ (reader.readString());
       msg.setName(value);
       break;
+    case 3:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setMechanicRadius(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -8390,6 +8395,13 @@ proto.Item.serializeBinaryToWriter = function(message, writer) {
   if (f != null) {
     writer.writeString(
       2,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 3));
+  if (f != null) {
+    writer.writeFloat(
+      3,
       f
     );
   }
@@ -8429,6 +8441,42 @@ proto.Item.prototype.clearName = function() {
  */
 proto.Item.prototype.hasName = function() {
   return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional float mechanic_radius = 3;
+ * @return {number}
+ */
+proto.Item.prototype.getMechanicRadius = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 3, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.Item} returns this
+ */
+proto.Item.prototype.setMechanicRadius = function(value) {
+  return jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.Item} returns this
+ */
+proto.Item.prototype.clearMechanicRadius = function() {
+  return jspb.Message.setField(this, 3, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.Item.prototype.hasMechanicRadius = function() {
+  return jspb.Message.getField(this, 3) != null;
 };
 
 

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -6990,7 +6990,8 @@ mana: (f = jspb.Message.getField(msg, 17)) == null ? undefined : f,
 currentBasicAnimation: (f = jspb.Message.getField(msg, 18)) == null ? undefined : f,
 matchPosition: (f = jspb.Message.getField(msg, 19)) == null ? undefined : f,
 team: (f = jspb.Message.getField(msg, 20)) == null ? undefined : f,
-maxHealth: (f = jspb.Message.getField(msg, 21)) == null ? undefined : f
+maxHealth: (f = jspb.Message.getField(msg, 21)) == null ? undefined : f,
+blockedActions: (f = jspb.Message.getBooleanField(msg, 22)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -7117,6 +7118,10 @@ proto.Player.deserializeBinaryFromReader = function(msg, reader) {
     case 21:
       var value = /** @type {number} */ (reader.readUint64());
       msg.setMaxHealth(value);
+      break;
+    case 22:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setBlockedActions(value);
       break;
     default:
       reader.skipField();
@@ -7291,6 +7296,13 @@ proto.Player.serializeBinaryToWriter = function(message, writer) {
   if (f != null) {
     writer.writeUint64(
       21,
+      f
+    );
+  }
+  f = /** @type {boolean} */ (jspb.Message.getField(message, 22));
+  if (f != null) {
+    writer.writeBool(
+      22,
       f
     );
   }
@@ -8043,6 +8055,42 @@ proto.Player.prototype.clearMaxHealth = function() {
  */
 proto.Player.prototype.hasMaxHealth = function() {
   return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional bool blocked_actions = 22;
+ * @return {boolean}
+ */
+proto.Player.prototype.getBlockedActions = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 22, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.setBlockedActions = function(value) {
+  return jspb.Message.setField(this, 22, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.Player} returns this
+ */
+proto.Player.prototype.clearBlockedActions = function() {
+  return jspb.Message.setField(this, 22, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.Player.prototype.hasBlockedActions = function() {
+  return jspb.Message.getField(this, 22) != null;
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -587,6 +587,7 @@ defmodule GameClient.Protobuf.Item do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field(:name, 2, proto3_optional: true, type: :string)
+  field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
 end
 
 defmodule GameClient.Protobuf.Projectile do

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -20,6 +20,18 @@ defmodule GameClient.Protobuf.GameStatus do
   field(:SELECTING_BOUNTY, 3)
 end
 
+defmodule GameClient.Protobuf.ItemStatus do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field(:ITEM_STATUS_UNDEFINED, 0)
+  field(:ITEM_PICKED_UP, 1)
+  field(:ITEM_USED, 2)
+  field(:ITEM_ACTIVE, 3)
+  field(:ITEM_EXPIRED, 4)
+end
+
 defmodule GameClient.Protobuf.ProjectileStatus do
   @moduledoc false
 
@@ -588,6 +600,8 @@ defmodule GameClient.Protobuf.Item do
 
   field(:name, 2, proto3_optional: true, type: :string)
   field(:mechanic_radius, 3, proto3_optional: true, type: :float, json_name: "mechanicRadius")
+  field(:status, 4, type: GameClient.Protobuf.ItemStatus, enum: true)
+  field(:owner_id, 5, proto3_optional: true, type: :uint64, json_name: "ownerId")
 end
 
 defmodule GameClient.Protobuf.Projectile do

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -568,6 +568,7 @@ defmodule GameClient.Protobuf.Player do
   field(:match_position, 19, proto3_optional: true, type: :uint32, json_name: "matchPosition")
   field(:team, 20, proto3_optional: true, type: :uint32)
   field(:max_health, 21, proto3_optional: true, type: :uint64, json_name: "maxHealth")
+  field(:blocked_actions, 22, proto3_optional: true, type: :bool, json_name: "blockedActions")
 end
 
 defmodule GameClient.Protobuf.Effect do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -231,6 +231,16 @@ message Effect {
 message Item {
   optional string name = 2;
   optional float mechanic_radius = 3;
+  ItemStatus status = 4;
+  optional uint64 owner_id = 5;
+}
+
+enum ItemStatus {
+  ITEM_STATUS_UNDEFINED = 0;
+  ITEM_PICKED_UP = 1;
+  ITEM_USED = 2;
+  ITEM_ACTIVE = 3;
+  ITEM_EXPIRED = 4;
 }
 
 message Projectile {

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -230,6 +230,7 @@ message Effect {
 
 message Item {
   optional string name = 2;
+  optional float mechanic_radius = 3;
 }
 
 message Projectile {

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -219,6 +219,7 @@ message Player {
   optional uint32 match_position = 19;
   optional uint32 team = 20;
   optional uint64 max_health = 21;
+  optional bool blocked_actions = 22;
 }
 
 message Effect {

--- a/assets/node_modules/.package-lock.json
+++ b/assets/node_modules/.package-lock.json
@@ -4,9 +4,10 @@
   "requires": true,
   "packages": {
     "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     }
   }
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,13 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "google-protobuf": "^3.21.2"
+        "google-protobuf": "^3.21.4"
       }
     },
     "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     }
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "google-protobuf": "^3.21.2"
+    "google-protobuf": "^3.21.4"
   }
 }

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1560,6 +1560,46 @@ health_item_params = %{
 {:ok, _heal_item} =
   GameBackend.Items.create_consumable_item(health_item_params)
 
+silence_effect =
+  %{
+    name: "silence_effect",
+    duration_ms: 9000,
+    remove_on_action: false,
+    one_time_application: true,
+    disabled_outside_pool: false,
+    allow_multiple_effects: true,
+    effect_mechanics: [
+      %{
+        name: "silence",
+        execute_multiple_times: false,
+        effect_delay_ms: 0
+      }
+    ],
+    version_id: version.id
+  }
+
+silence_item_mechanic =
+  %{
+    name: "silence_item_mechanic",
+    type: "circle_hit",
+    damage: 0,
+    range: 1_000,
+    offset: 0,
+    effect: silence_effect,
+    version_id: version.id
+  }
+
+silence_item_params = %{
+  active: true,
+  name: "silence_item",
+  radius: 200.0,
+  mechanics: [silence_item_mechanic],
+  version_id: version.id
+}
+
+{:ok, _silence_item} =
+  GameBackend.Items.create_consumable_item(silence_item_params)
+
 _slow_field_effect = %{
   name: "slow_field_effect",
   duration_ms: 9000,


### PR DESCRIPTION
> [!Warning]
> Merge alongside https://github.com/lambdaclass/champions_of_mirra/pull/2401

## Motivation

We need more variation in-game.
Closes #1046 

## Summary of changes

- [Add silence_effect from item behavior](https://github.com/lambdaclass/mirra_backend/pull/1047/commits/69a20e50d9ba7b67ced13f5ab1baee293acea001)
- [Add silence_item in seeds](https://github.com/lambdaclass/mirra_backend/pull/1047/commits/6b40f07dea1a461a4f1fce0cda5001ce3a1f4d61)
- [Add item.mechanic_radius field to send it to the client](https://github.com/lambdaclass/mirra_backend/pull/1047/commits/4257eda9b968f3898478af3cb8d9b875ca595791)
- [Upgrade arena version](https://github.com/lambdaclass/mirra_backend/pull/1047/commits/625e2f7b661cc368926b2cc4e3dd748efb279665)

## How to test it?

Play a game with front-end branch and use the new silence item.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
