### PR TITLE
Handle float pattern-match for normalize function

### DIFF
--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -80,6 +80,10 @@ defmodule Arena.Utils do
     %{x: 0, y: 0}
   end
 
+  def normalize(%{x: 0.0, y: 0.0}) do
+    %{x: 0, y: 0}
+  end
+
   def normalize(%{x: x, y: y}) do
     length = :math.sqrt(x * x + y * y)
     %{x: x / length, y: y / length}

--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -80,8 +80,8 @@ defmodule Arena.Utils do
     %{x: 0, y: 0}
   end
 
-  def normalize(%{x: 0.0, y: 0.0}) do
-    %{x: 0, y: 0}
+  def normalize(%{x: x, y: y} = direction) when x == 0.0 and y == 0.0 do
+    direction
   end
 
   def normalize(%{x: x, y: y}) do


### PR DESCRIPTION
## Motivation

There's an error when the direction is 0 as float.
Closes #1050 

## Summary of changes

- [Handle float pattern-match for normalize function](https://github.com/lambdaclass/mirra_backend/commit/76ff449ac712075d63225db593ed47dd5353bcac)

## How to test it?

It's hard to trigger, but you can see in the issue how the function was called. If you do `Arena.Utils.normalize(%{x: 0.0, y: 0.0})` you get the error.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
