### PR TITLE
Fix daily quests

### DIFF
--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -18,7 +18,6 @@ defmodule Arena.Application do
       Arena.Matchmaking.PairMode,
       Arena.Matchmaking.QuickGameMode,
       Arena.Matchmaking.DeathmatchMode,
-      Arena.GameBountiesFetcher,
       Arena.GameTracker,
       Arena.Authentication.GatewaySigner,
       # Start a worker by calling: Arena.Worker.start_link(arg)

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -115,9 +115,8 @@ defmodule Arena.GameUpdater do
       nil ->
         {:reply, :not_a_client, state}
 
-      player = Map.get(state.game_state.players, player_id)
-
       player_id ->
+        player = Map.get(state.game_state.players, player_id)
         response = %{
           player_id: player_id,
           team: player.aditional_info.team,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -117,6 +117,7 @@ defmodule Arena.GameUpdater do
 
       player_id ->
         player = Map.get(state.game_state.players, player_id)
+
         response = %{
           player_id: player_id,
           team: player.aditional_info.team,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -115,6 +115,8 @@ defmodule Arena.GameUpdater do
       nil ->
         {:reply, :not_a_client, state}
 
+      player = Map.get(state.game_state.players, player_id)
+
       player_id ->
         response = %{
           player_id: player_id,

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -7,7 +7,6 @@ defmodule Arena.GameUpdater do
   use GenServer
   alias Arena.Game.Obstacle
   alias Arena.Game.Bounties
-  alias Arena.GameBountiesFetcher
   alias Arena.GameTracker
   alias Arena.Game.Crate
   alias Arena.Game.Effect
@@ -117,20 +116,15 @@ defmodule Arena.GameUpdater do
         {:reply, :not_a_client, state}
 
       player_id ->
-        bounties =
-          GameBountiesFetcher.get_bounties()
-          |> Enum.shuffle()
-          |> Enum.take(state.game_config.game.bounties_options_amount)
-
         response = %{
           player_id: player_id,
           game_config: state.game_config,
           game_status: state.game_state.status,
-          bounties: bounties
+          bounties: []
         }
 
         state =
-          put_in(state, [:game_state, :players, player_id, :aditional_info, :bounties], bounties)
+          put_in(state, [:game_state, :players, player_id, :aditional_info, :bounties], [])
 
         {:reply, {:ok, response}, state}
     end

--- a/apps/game_backend/lib/game_backend/users.ex
+++ b/apps/game_backend/lib/game_backend/users.ex
@@ -746,9 +746,7 @@ defmodule GameBackend.Users do
 
     milestone_quest_result = Repo.insert(changeset)
 
-    {active_quests_params, remaining_quests} = Enum.split(available_quests, 3)
-
-    {inactive_quests_params, _remaining_quests} = Enum.split(remaining_quests, 3)
+    active_quests_params = Enum.take(available_quests, 3)
 
     active_quests =
       Enum.map(active_quests_params, fn
@@ -765,21 +763,7 @@ defmodule GameBackend.Users do
           Repo.insert(changeset)
       end)
 
-    inactive_quests =
-      Enum.map(inactive_quests_params, fn
-        quest_params ->
-          attrs = %{
-            user_id: user.id,
-            quest_id: quest_params.id,
-            status: "available"
-          }
-
-          changeset = UserQuest.changeset(%UserQuest{}, attrs)
-
-          Repo.insert(changeset)
-      end)
-
-    (active_quests ++ inactive_quests ++ [milestone_quest_result])
+    (active_quests ++ [milestone_quest_result])
     |> Enum.find(fn {result, _quest} -> result == :error end)
     |> case do
       nil -> {:ok, :quests_inserted}

--- a/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
+++ b/apps/game_backend/priv/curse_of_mirra/quests_descriptions.json
@@ -1,11 +1,11 @@
 [
     {
         "config_id": 1,
-        "description": "Win three matches with Muflus",
+        "description": "Win a match with Muflus",
         "type": "daily",
         "objective": {
             "match_tracking_field": "result",
-            "value": 3,
+            "value": 1,
             "comparison": "greater_or_equal",
             "scope": "match"
         },
@@ -23,28 +23,28 @@
         ],
         "reward": {
             "currency": "Gold",
-            "amount": 444
+            "amount": 200
         }
     },
     {
         "config_id": 2,
-        "description": "Get 44 kills",
+        "description": "Get 5 kills",
         "type": "daily",
         "objective": {
             "match_tracking_field": "kills",
-            "value": 44,
+            "value": 5,
             "comparison": "greater_or_equal",
             "scope": "day"
         },
         "conditions": [],
         "reward": {
             "currency": "Gold",
-            "amount": 444
+            "amount": 200
         }
     },
     {
         "config_id": 3,
-        "description": "This is champions of mirra, lose a match",
+        "description": "Win a match with Uma",
         "type": "daily",
         "objective": {
             "match_tracking_field": "result",
@@ -54,14 +54,19 @@
         },
         "conditions": [
             {
+                "match_tracking_field": "character",
+                "value": "uma",
+                "comparison": "equal"
+            },
+            {
                 "match_tracking_field": "result",
-                "value": "loss",
+                "value": "win",
                 "comparison": "equal"
             }
         ],
         "reward": {
             "currency": "Gold",
-            "amount": 444
+            "amount": 200
         }
     },
     {
@@ -175,61 +180,12 @@
         }
     },
     {
-        "config_id": 10,
-        "description": "Finish a match in less than 1 minute",
+        "config_id": 12,
+        "description": "Win a match with Valtimer",
         "type": "daily",
         "objective": {
             "match_tracking_field": "result",
             "value": 1,
-            "comparison": "greater_or_equal",
-            "scope": "match"
-        },
-        "conditions": [
-            {
-                "match_tracking_field": "duration_ms",
-                "value": 60000,
-                "comparison": "lesser_or_equal"
-            }
-        ],
-        "reward": {
-            "currency": "Gold",
-            "amount": 444
-        }
-    },
-    {
-        "config_id": 11,
-        "description": "Win three matches with Uma",
-        "type": "daily",
-        "objective": {
-            "match_tracking_field": "result",
-            "value": 3,
-            "comparison": "greater_or_equal",
-            "scope": "match"
-        },
-        "conditions": [
-            {
-                "match_tracking_field": "character",
-                "value": "uma",
-                "comparison": "equal"
-            },
-            {
-                "match_tracking_field": "result",
-                "value": "win",
-                "comparison": "equal"
-            }
-        ],
-        "reward": {
-            "currency": "Gold",
-            "amount": 444
-        }
-    },
-    {
-        "config_id": 12,
-        "description": "Win three matches with Valtimer",
-        "type": "daily",
-        "objective": {
-            "match_tracking_field": "result",
-            "value": 3,
             "comparison": "greater_or_equal",
             "scope": "match"
         },
@@ -247,23 +203,23 @@
         ],
         "reward": {
             "currency": "Gold",
-            "amount": 444
+            "amount": 200
         }
     },
     {
         "config_id": 13,
-        "description": "Complete 6 Daily Quests",
+        "description": "Complete all Daily Quests",
         "type": "milestone",
         "objective": {
             "match_tracking_field": "quest",
-            "value": 6,
-            "comparison": "greater_or_equal",
+            "value": 3,
+            "comparison": "equal",
             "scope": "match"
         },
         "conditions": [],
         "reward": {
             "currency": "Gold",
-            "amount": 10000
+            "amount": 1000
         }
     }
 ]


### PR DESCRIPTION
> [!Warning]
> Merge alongside https://github.com/lambdaclass/champions_of_mirra/pull/2414

## Motivation

Quests are too complex and aren't working properly.
Closes #1053 

## Summary of changes

- [Not start GameBountiesFetcher genserver and always send a bounties empty list](https://github.com/lambdaclass/mirra_backend/pull/1056/commits/1aa3b9e3a49d73d79146a3d610694daed24f17b2)
- [Delete inactive quests behavior and only send 3 daily quests to the users](https://github.com/lambdaclass/mirra_backend/pull/1056/commits/cf1e61207dec433e5c3e9c4222ce05f991a36e5a)
- [Balance quests and make them more reasonable](https://github.com/lambdaclass/mirra_backend/pull/1056/commits/756b34de9c5bada4188c4799472cc991255a51a4)

## How to test it?

Just play with the [front branch](https://github.com/lambdaclass/champions_of_mirra/pull/2414) and complete the quests.
To test faster, you can change the quest_descriptions.json and make them all 1 kill to complete.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
