### PR TITLE
[GH-1059] - Send match's map to the client

### DIFF
--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -572,7 +572,9 @@ defmodule Arena.Entities do
   defp get_team(%{category: :player} = entity), do: entity.aditional_info.team
   defp get_team(%{category: :projectile} = entity), do: entity.aditional_info.owner_team
   defp get_team(%{category: :pool} = entity), do: entity.aditional_info.owner_team
+  defp get_team(%{category: :obstacle} = entity), do: entity.aditional_info.owner_team
   defp get_team(%{category: category} = _entity), do: category
+  defp get_team(%{aditional_info: %{team: :zone}}), do: :zone
 
   def update_entity(%{category: :player} = entity, game_state) do
     put_in(game_state, [:players, entity.id], entity)

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -572,7 +572,6 @@ defmodule Arena.Entities do
   defp get_team(%{category: :player} = entity), do: entity.aditional_info.team
   defp get_team(%{category: :projectile} = entity), do: entity.aditional_info.owner_team
   defp get_team(%{category: :pool} = entity), do: entity.aditional_info.owner_team
-  defp get_team(%{category: :obstacle} = entity), do: entity.aditional_info.team
   defp get_team(%{category: category} = _entity), do: category
   defp get_team(%{aditional_info: %{team: :zone}}), do: :zone
 

--- a/apps/arena/lib/arena/entities.ex
+++ b/apps/arena/lib/arena/entities.ex
@@ -572,7 +572,7 @@ defmodule Arena.Entities do
   defp get_team(%{category: :player} = entity), do: entity.aditional_info.team
   defp get_team(%{category: :projectile} = entity), do: entity.aditional_info.owner_team
   defp get_team(%{category: :pool} = entity), do: entity.aditional_info.owner_team
-  defp get_team(%{category: :obstacle} = entity), do: entity.aditional_info.owner_team
+  defp get_team(%{category: :obstacle} = entity), do: entity.aditional_info.team
   defp get_team(%{category: category} = _entity), do: category
   defp get_team(%{aditional_info: %{team: :zone}}), do: :zone
 

--- a/apps/arena/lib/arena/game/obstacle.ex
+++ b/apps/arena/lib/arena/game/obstacle.ex
@@ -100,7 +100,6 @@ defmodule Arena.Game.Obstacle do
         |> Map.put(:collisionable, next_status_params.make_obstacle_collisionable)
         |> Map.put(:collide_with_projectiles, next_status_params.make_obstacle_collisionable)
         |> Map.put(:time_until_transition_start, now + time_until_transition_ms + random_ms)
-        |> Map.put(:team, :neutral)
       end)
 
     Enum.reduce(next_status_params.on_activation_mechanics, game_state, fn mechanic, game_state ->

--- a/apps/arena/lib/arena/game/obstacle.ex
+++ b/apps/arena/lib/arena/game/obstacle.ex
@@ -100,6 +100,7 @@ defmodule Arena.Game.Obstacle do
         |> Map.put(:collisionable, next_status_params.make_obstacle_collisionable)
         |> Map.put(:collide_with_projectiles, next_status_params.make_obstacle_collisionable)
         |> Map.put(:time_until_transition_start, now + time_until_transition_ms + random_ms)
+        |> Map.put(:team, :neutral)
       end)
 
     Enum.reduce(next_status_params.on_activation_mechanics, game_state, fn mechanic, game_state ->

--- a/apps/arena/lib/arena/game_socket_handler.ex
+++ b/apps/arena/lib/arena/game_socket_handler.ex
@@ -41,7 +41,8 @@ defmodule Arena.GameSocketHandler do
     Logger.info("Websocket INIT called")
     Phoenix.PubSub.subscribe(Arena.PubSub, state.game_id)
 
-    {:ok, %{player_id: player_id, team: team, game_config: config, game_status: game_status, bounties: bounties}} =
+    {:ok,
+     %{player_id: player_id, team: team, game_config: config, game_status: game_status, bounties: bounties, map: map}} =
       GameUpdater.join(state.game_pid, state.client_id)
 
     state =
@@ -56,7 +57,13 @@ defmodule Arena.GameSocketHandler do
       GameEvent.encode(%GameEvent{
         event:
           {:joined,
-           %GameJoined{player_id: player_id, team: team, config: to_broadcast_config(config), bounties: bounties}}
+           %GameJoined{
+             player_id: player_id,
+             team: team,
+             config: to_broadcast_config(config),
+             bounties: bounties,
+             map: map
+           }}
       })
 
     :telemetry.execute([:arena, :clients], %{count: 1})

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -127,7 +127,8 @@ defmodule Arena.GameUpdater do
           team: player.aditional_info.team,
           game_config: state.game_config,
           game_status: state.game_state.status,
-          bounties: []
+          bounties: [],
+          map: state.game_state.map_mode_params.map.name
         }
 
         state =
@@ -893,7 +894,8 @@ defmodule Arena.GameUpdater do
       start_game_timestamp: initial_timestamp + config.game.start_game_time_ms + config.game.bounty_pick_time_ms,
       positions: %{},
       traps: %{},
-      respawn_queue: %{}
+      respawn_queue: %{},
+      map_mode_params: Enum.random(config.game.map_mode_params)
     }
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -128,7 +128,7 @@ defmodule Arena.GameUpdater do
           game_config: state.game_config,
           game_status: state.game_state.status,
           bounties: [],
-          map: state.game_state.map_mode_params.map.name
+          map: state.game_config.map_mode_params.map.name
         }
 
         state =
@@ -664,13 +664,23 @@ defmodule Arena.GameUpdater do
     item_config = Enum.random(state.game_config.items)
 
     position =
-      random_position_in_square(
-        item_config.radius,
-        state.game_state.external_wall,
-        state.game_state.obstacles,
-        state.game_state.external_wall.position,
-        state.game_state.square_wall
-      )
+      if is_nil(state.game_state.square_wall) do
+        random_position_in_map(
+          item_config.radius,
+          state.game_state.external_wall,
+          state.game_state.obstacles,
+          state.game_state.external_wall.position,
+          state.game_state.external_wall.radius
+        )
+      else
+        random_position_in_square(
+          item_config.radius,
+          state.game_state.external_wall,
+          state.game_state.obstacles,
+          state.game_state.external_wall.position,
+          state.game_state.square_wall
+        )
+      end
 
     item = Entities.new_item(last_id, position, item_config)
 
@@ -894,8 +904,7 @@ defmodule Arena.GameUpdater do
       start_game_timestamp: initial_timestamp + config.game.start_game_time_ms + config.game.bounty_pick_time_ms,
       positions: %{},
       traps: %{},
-      respawn_queue: %{},
-      map_mode_params: Enum.random(config.game.map_mode_params)
+      respawn_queue: %{}
     }
   end
 

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -225,6 +225,7 @@ defmodule Arena.Serialization.GameJoined do
   field(:config, 2, type: Arena.Serialization.Configuration)
   field(:bounties, 3, repeated: true, type: Arena.Serialization.BountyInfo)
   field(:team, 4, type: :uint32)
+  field(:map, 5, type: :string)
 end
 
 defmodule Arena.Serialization.Configuration do

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.16.1",
+      version: "0.17.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -230,6 +230,7 @@ defmodule ArenaLoadTest.Serialization.GameJoined do
   field(:config, 2, type: ArenaLoadTest.Serialization.Configuration)
   field(:bounties, 3, repeated: true, type: ArenaLoadTest.Serialization.BountyInfo)
   field(:team, 4, type: :uint32)
+  field(:map, 5, type: :string)
 end
 
 defmodule ArenaLoadTest.Serialization.Configuration do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -225,6 +225,7 @@ defmodule BotManager.Protobuf.GameJoined do
   field(:config, 2, type: BotManager.Protobuf.Configuration)
   field(:bounties, 3, repeated: true, type: BotManager.Protobuf.BountyInfo)
   field(:team, 4, type: :uint32)
+  field(:map, 5, type: :string)
 end
 
 defmodule BotManager.Protobuf.Configuration do

--- a/apps/game_backend/lib/game_backend/configuration.ex
+++ b/apps/game_backend/lib/game_backend/configuration.ex
@@ -628,6 +628,9 @@ defmodule GameBackend.Configuration do
             [basic_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]],
             [ultimate_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]],
             [dash_skill: [mechanics: [:on_arrival_mechanic, :on_explode_mechanics, :parent_mechanic]]]
+          ],
+          game_mode_configurations: [
+            map_mode_params: :map
           ]
         ]
       )

--- a/apps/game_backend/lib/game_backend/configuration/version.ex
+++ b/apps/game_backend/lib/game_backend/configuration/version.ex
@@ -10,6 +10,7 @@ defmodule GameBackend.Configuration.Version do
   alias GameBackend.Units.Skills.Skill
   alias GameBackend.CurseOfMirra.MapConfiguration
   alias GameBackend.CurseOfMirra.GameConfiguration
+  alias GameBackend.CurseOfMirra.GameModeConfiguration
 
   schema "versions" do
     field(:name, :string)
@@ -20,6 +21,7 @@ defmodule GameBackend.Configuration.Version do
     has_many(:skills, Skill)
     has_many(:map_configurations, MapConfiguration)
     has_one(:game_configuration, GameConfiguration)
+    has_many(:game_mode_configurations, GameModeConfiguration)
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -2935,7 +2935,8 @@ playerId: jspb.Message.getFieldWithDefault(msg, 1, 0),
 config: (f = msg.getConfig()) && proto.Configuration.toObject(includeInstance, f),
 bountiesList: jspb.Message.toObjectList(msg.getBountiesList(),
     proto.BountyInfo.toObject, includeInstance),
-team: jspb.Message.getFieldWithDefault(msg, 4, 0)
+team: jspb.Message.getFieldWithDefault(msg, 4, 0),
+map: jspb.Message.getFieldWithDefault(msg, 5, "")
   };
 
   if (includeInstance) {
@@ -2989,6 +2990,10 @@ proto.GameJoined.deserializeBinaryFromReader = function(msg, reader) {
     case 4:
       var value = /** @type {number} */ (reader.readUint32());
       msg.setTeam(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setMap(value);
       break;
     default:
       reader.skipField();
@@ -3046,6 +3051,13 @@ proto.GameJoined.serializeBinaryToWriter = function(message, writer) {
   if (f !== 0) {
     writer.writeUint32(
       4,
+      f
+    );
+  }
+  f = message.getMap();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
       f
     );
   }
@@ -3160,6 +3172,24 @@ proto.GameJoined.prototype.getTeam = function() {
  */
 proto.GameJoined.prototype.setTeam = function(value) {
   return jspb.Message.setProto3IntField(this, 4, value);
+};
+
+
+/**
+ * optional string map = 5;
+ * @return {string}
+ */
+proto.GameJoined.prototype.getMap = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.GameJoined} returns this
+ */
+proto.GameJoined.prototype.setMap = function(value) {
+  return jspb.Message.setProto3StringField(this, 5, value);
 };
 
 

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -225,6 +225,7 @@ defmodule GameClient.Protobuf.GameJoined do
   field(:config, 2, type: GameClient.Protobuf.Configuration)
   field(:bounties, 3, repeated: true, type: GameClient.Protobuf.BountyInfo)
   field(:team, 4, type: :uint32)
+  field(:map, 5, type: :string)
 end
 
 defmodule GameClient.Protobuf.Configuration do

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -61,6 +61,7 @@ message GameJoined {
   Configuration config = 2;
   repeated BountyInfo bounties = 3;
   uint32 team = 4;
+  string map = 5;
 }
 
 message Configuration {

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -4348,7 +4348,7 @@ merliot_map_config = %{
   }
 }
 
-{:ok, _araban_map_configuration} =
+{:ok, araban_map_configuration} =
   GameBackend.Configuration.create_map_configuration(araban_map_config)
 
 {:ok, merliot_map_configuration} =
@@ -4450,6 +4450,20 @@ deathmatch_mode_params = %{
         %{x: -5047, y: 853}
       ],
       map_id: merliot_map_configuration.id
+    },
+    %{
+      amount_of_players: 7,
+      initial_positions: [
+        %{x: 5400, y: -400.0},
+        %{x: -5300, y: 400.0},
+        %{x: 1100, y: 5100},
+        %{x: 3200, y: -4300},
+        %{x: -3400, y: 3600},
+        %{x: -1900, y: -5100},
+        %{x: 4200, y: 3200}
+      ],
+      team_team_initial_positions: [],
+      map_id: araban_map_configuration.id
     }
   ]
 }

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1614,7 +1614,7 @@ _slow_field_effect = %{
 araban_map_config = %{
   name: "Araban",
   radius: 5520.0,
-  active: false,
+  active: true,
   initial_positions: [
     %{
       x: 5400,


### PR DESCRIPTION
> [!Warning]
> This PR should be merged alongside https://github.com/lambdaclass/champions_of_mirra/pull/2457

## Motivation
Closes #1059 

## Summary of changes

- [feat: add new map params](https://github.com/lambdaclass/mirra_backend/pull/1064/commits/3b987142e6e9cf89575b560d0bfa73ea4243dd57)
- [feat: send the game modes with the version](https://github.com/lambdaclass/mirra_backend/pull/1064/commits/1737aa1c425e81f32201e67784d1f0c47a94a204)
- [feat: send the map to the client and add araban to deathmatch](https://github.com/lambdaclass/mirra_backend/pull/1064/commits/0ab9e6037efa022dc30012d3be2cb2b4a13ccd84)
- [fix: errors that haven arisen when enabling araban](https://github.com/lambdaclass/mirra_backend/pull/1064/commits/ed535526489c420040dda1a2ce8ebf9d3a40cf9f)

DISCLAIMER: This PR increases arena version

## How to test it?

Playtested it with the PR mentioned above and try to find Araban while playing deathmatch!

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
