### PR TITLE
[WIP] Manage SSL termination directly from Elixir

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -87,11 +87,22 @@ if config_env() == :prod do
 
   host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "3000")
+  port_ssl = String.to_integer(System.get_env("PORT_SSL") || "443")
 
   config :arena, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :arena, ArenaWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [
+      scheme: "https",
+      port: port_ssl,
+      host: host
+    ],
+    https: [
+      port: port_ssl,
+      cipher_suite: :strong,
+      keyfile: System.get_env("KEYFILE_PATH"),
+      certfile: System.get_env("CERTFILE_PATH")
+    ],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
## Motivation

To remove caddy (or any reverse proxy) as middleman.

## Summary of changes

* [`config/runtime.exs:90`](https://github.com/lambdaclass/mirra_backend/commit/226dd0cd9d7cce54592d4ae8c6b3383c3bf425c7#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092R90) parametrize SSL port as elixir and environment variables
*  [`config/runtime.exs:95-105`](https://github.com/lambdaclass/mirra_backend/commit/226dd0cd9d7cce54592d4ae8c6b3383c3bf425c7#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092R95-R105): configure SSL endpoint on the port_ssl set before, and parametrizing the SSL certificates' paths as environment variables

NOTE: this only affects the `arena` release, and only when it's been built with `MIX_ENV=prod`

## How to test it?

1. Build the arena application as a release (with `MIX_ENV=prod`)
2. Export all needed environment variables
3. For this to work (bind port 443), the release/binary has to either:
  * be run as root
  * be given capabilities to bind privileged ports (<10000)
    - we currently do this with this command (in Linux):
      ```shell
      sudo setcap CAP_NET_BIND_SERVICE=+eip /path/to/repo/mirra_backend/_build/prod/rel/arena/erts-13.2.2.12/bin/beam.smp
      ```
FYI: there are other ways in Linux to give this kind of capabilities ([link](https://stackoverflow.com/questions/413807/is-there-a-way-for-non-root-processes-to-bind-to-privileged-ports-on-linux))

NOTE: currently it is not working (tested on NixOS 24.11). The server is joined successfully from an iPhone but as soon as a any **game** is joined, "Your connection to the server has been lost", and the logs on the server are:
```
15:45:21.377 request_id=GCEVoxiPv3SU6XEAAAmC [info] GET /api/version
15:45:21.378 request_id=GCEVoxiPv3SU6XEAAAmC [info] Sent 200 in 366µs
15:45:24.127 request_id=GCEVo7x7KfNCBZcAAAnC [info] GET /join/deathmatch/1761798857/h4ck/klaus
15:45:24.128 [error] #PID<0.3033.0> running ArenaWeb.Endpoint (connection #PID<0.3031.0>, stream id 1) terminated
Server: klaus-mirra.lambdaclass.com:443 (https)
Request: GET /join/deathmatch/1761798857/h4ck/klaus?gateway_jwt=eyJhbGciOiJFZDI1NTE5IiwidHlwIjoiSldUIn0.eyJkZXYiOiJPN1hXSXJWa3V0N1BhTVVTblJkWXRKdFNOVUYwZmh4QkhRNDdlU2J2SFA0PSIsImV4cCI6MTczODcwMTkyMSwiaWF0IjoxNzM4Njk0NzIxLCJqdGkiOiIzMGdoYjhwOXFyMTE1aWJmbGMwMDA5YmkiLCJuYmYiOjE3Mzg2OTQ3MjEsInN1YiI6IjljNzYwMTZlLWNkOWUtNGM1Zi1iMGVhLWI5OGY0NzU2M2JlYiJ9.hJ9RnVnBZnhlnzlpXh_QBkRIKW_QO9qC3llTw3jmijS3xsOJQm3y8UJjtZwn4BkDcnJ0APi4EV8iocH3W1TOCQ
** (exit) an exception was raised:
    ** (ArgumentError) no "404" html template defined for ArenaWeb.ErrorHTML  (the module does not exist)
        (phoenix_template 1.0.4) lib/phoenix/template.ex:248: Phoenix.Template.render_with_fallback/4
        (phoenix_template 1.0.4) lib/phoenix/template.ex:126: Phoenix.Template.render_to_iodata/4
        (phoenix 1.7.11) lib/phoenix/controller.ex:1008: anonymous fn/5 in Phoenix.Controller.template_render_to_iodata/4
        (telemetry 1.2.1) /home/admin/mirra_backend/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
        (phoenix 1.7.11) lib/phoenix/controller.ex:974: Phoenix.Controller.render_and_send/4
        (phoenix 1.7.11) lib/phoenix/endpoint/render_errors.ex:86: Phoenix.Endpoint.RenderErrors.instrument_render_and_send/5
        (phoenix 1.7.11) lib/phoenix/endpoint/render_errors.ex:63: Phoenix.Endpoint.RenderErrors.__catch__/5
        (plug_cowboy 2.7.0) lib/plug/cowboy/handler.ex:11: Plug.Cowboy.Handler.init/2
```

## Checklist
- [ ] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [X] This change requires new documentation.
  - [ ] Documentation has been added/updated.
