### PR TITLE
[GH-1069] Trio Mode

### DIFF
--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -15,7 +15,8 @@ defmodule Arena.Application do
       {Finch, name: Arena.Finch},
       # Start game launcher genserver
       Arena.Matchmaking.GameLauncher,
-      Arena.Matchmaking.PairMode,
+      Arena.Matchmaking.DuoMode,
+      Arena.Matchmaking.TrioMode,
       Arena.Matchmaking.QuickGameMode,
       Arena.Matchmaking.DeathmatchMode,
       Arena.GameTracker,

--- a/apps/arena/lib/arena/matchmaking.ex
+++ b/apps/arena/lib/arena/matchmaking.ex
@@ -3,7 +3,8 @@ defmodule Arena.Matchmaking do
   Module that handles matchmaking queues
   """
   def get_queue("battle-royale"), do: Arena.Matchmaking.GameLauncher
-  def get_queue("pair"), do: Arena.Matchmaking.PairMode
+  def get_queue("duo"), do: Arena.Matchmaking.DuoMode
+  def get_queue("trio"), do: Arena.Matchmaking.TrioMode
   def get_queue("quick-game"), do: Arena.Matchmaking.QuickGameMode
   def get_queue("deathmatch"), do: Arena.Matchmaking.DeathmatchMode
   def get_queue(:undefined), do: Arena.Matchmaking.GameLauncher

--- a/apps/arena/lib/arena/matchmaking/duo_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/duo_mode.ex
@@ -1,4 +1,4 @@
-defmodule Arena.Matchmaking.PairMode do
+defmodule Arena.Matchmaking.DuoMode do
   @moduledoc false
   alias Arena.Utils
   alias Ecto.UUID
@@ -134,7 +134,7 @@ defmodule Arena.Matchmaking.PairMode do
   # Receives a list of clients.
   # Fills the given list with bots clients, creates a game and tells every client to join that game.
   defp create_game_for_clients(clients, game_params, map) do
-    game_params = Map.put(game_params, :game_mode, :PAIR)
+    game_params = Map.put(game_params, :game_mode, :DUO)
 
     bot_clients =
       if Enum.count(clients) < map.amount_of_players do

--- a/apps/arena/lib/arena/matchmaking/trio_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/trio_mode.ex
@@ -1,0 +1,160 @@
+defmodule Arena.Matchmaking.TrioMode do
+  @moduledoc false
+  alias Arena.Utils
+  alias Ecto.UUID
+
+  alias Arena.Matchmaking
+
+  use GenServer
+
+  # API
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def join(client_id, character_name, player_name) do
+    GenServer.call(__MODULE__, {:join, client_id, character_name, player_name})
+  end
+
+  def leave(client_id) do
+    GenServer.call(__MODULE__, {:leave, client_id})
+  end
+
+  # Callbacks
+  @impl true
+  def init(_) do
+    Process.send_after(self(), :launch_game?, 300)
+    Process.send_after(self(), :update_params, 20_000)
+    {:ok, %{clients: [], batch_start_at: 0}}
+  end
+
+  @impl true
+  def handle_call({:join, client_id, character_name, player_name}, {from_pid, _}, %{clients: clients} = state) do
+    batch_start_at = maybe_make_batch_start_at(state.clients, state.batch_start_at)
+
+    client = %{
+      client_id: client_id,
+      character_name: character_name,
+      name: player_name,
+      from_pid: from_pid,
+      type: :human
+    }
+
+    {:reply, :ok,
+     %{
+       state
+       | batch_start_at: batch_start_at,
+         clients: clients ++ [client]
+     }}
+  end
+
+  def handle_call({:leave, client_id}, _, state) do
+    clients = Enum.reject(state.clients, fn %{client_id: id} -> id == client_id end)
+    {:reply, :ok, %{state | clients: clients}}
+  end
+
+  @impl true
+  def handle_info(:launch_game?, %{clients: clients} = state) do
+    Process.send_after(self(), :launch_game?, 300)
+
+    state = Matchmaking.get_matchmaking_configuration(state, 3, "battle_royale")
+
+    diff = System.monotonic_time(:millisecond) - state.batch_start_at
+
+    if Map.has_key?(state, :game_mode_configuration) &&
+         (length(clients) >= state.current_map.amount_of_players or
+            (diff >= Utils.start_timeout_ms() and length(clients) > 0)) do
+      send(self(), :start_game)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(:start_game, state) do
+    {game_clients, remaining_clients} = Enum.split(state.clients, state.current_map.amount_of_players)
+    create_game_for_clients(game_clients, state.game_mode_configuration, state.current_map)
+
+    next_map = Enum.random(state.game_mode_configuration.map_mode_params)
+
+    {:noreply, %{state | clients: remaining_clients, current_map: next_map}}
+  end
+
+  def handle_info(:update_params, state) do
+    game_mode_configuration =
+      case Arena.Configuration.get_game_mode_configuration(3, "battle_royale") do
+        {:error, _} ->
+          state
+
+        {:ok, game_mode_configuration} ->
+          game_mode_configuration
+      end
+
+    Process.send_after(self(), :update_params, 5000)
+    {:noreply, Map.put(state, :game_mode_configuration, game_mode_configuration)}
+  end
+
+  def handle_info({:spawn_bot_for_player, bot_client, game_id}, state) do
+    spawn(fn ->
+      Finch.build(:get, Utils.get_bot_connection_url(game_id, bot_client))
+      |> Finch.request(Arena.Finch)
+    end)
+
+    {:noreply, state}
+  end
+
+  defp maybe_make_batch_start_at([], _) do
+    System.monotonic_time(:millisecond)
+  end
+
+  defp maybe_make_batch_start_at([_ | _], batch_start_at) do
+    batch_start_at
+  end
+
+  defp get_bot_clients(missing_clients) do
+    characters =
+      Arena.Configuration.get_game_config()
+      |> Map.get(:characters)
+      |> Enum.filter(fn character -> character.active end)
+
+    bot_names = Utils.list_bot_names(missing_clients)
+
+    Enum.map(1..missing_clients//1, fn i ->
+      client_id = UUID.generate()
+
+      %{client_id: client_id, character_name: Enum.random(characters).name, name: Enum.at(bot_names, i - 1), type: :bot}
+    end)
+  end
+
+  defp spawn_bot_for_player(bot_clients, game_id) do
+    Enum.each(bot_clients, fn %{client_id: bot_client_id} ->
+      send(self(), {:spawn_bot_for_player, bot_client_id, game_id})
+    end)
+  end
+
+  # Receives a list of clients.
+  # Fills the given list with bots clients, creates a game and tells every client to join that game.
+  defp create_game_for_clients(clients, game_params, map) do
+    game_params = Map.put(game_params, :game_mode, :TRIO)
+
+    bot_clients =
+      if Enum.count(clients) < map.amount_of_players do
+        get_bot_clients(map.amount_of_players - Enum.count(clients))
+      else
+        []
+      end
+
+    players = Utils.assign_teams_to_players(clients ++ bot_clients, :team, game_params)
+
+    {:ok, game_pid} =
+      GenServer.start(Arena.GameUpdater, %{players: players, game_params: game_params, map_mode_params: map})
+
+    game_id = game_pid |> :erlang.term_to_binary() |> Base58.encode()
+
+    spawn_bot_for_player(bot_clients, game_id)
+
+    Enum.each(clients, fn %{from_pid: from_pid} ->
+      Process.send(from_pid, {:join_game, game_id}, [])
+      Process.send(from_pid, :leave_waiting_game, [])
+    end)
+  end
+end

--- a/apps/arena/lib/arena/serialization/messages.pb.ex
+++ b/apps/arena/lib/arena/serialization/messages.pb.ex
@@ -5,8 +5,9 @@ defmodule Arena.Serialization.GameMode do
 
   field(:BATTLE, 0)
   field(:DEATHMATCH, 1)
-  field(:PAIR, 2)
+  field(:DUO, 2)
   field(:QUICK_GAME, 3)
+  field(:TRIO, 4)
 end
 
 defmodule Arena.Serialization.GameStatus do

--- a/apps/arena/mix.exs
+++ b/apps/arena/mix.exs
@@ -4,7 +4,7 @@ defmodule Arena.MixProject do
   def project do
     [
       app: :arena,
-      version: "0.17.1",
+      version: "0.18.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
+++ b/apps/arena_load_test/lib/arena_load_test/serialization/messages.pb.ex
@@ -5,8 +5,9 @@ defmodule ArenaLoadTest.Serialization.GameMode do
 
   field(:BATTLE, 0)
   field(:DEATHMATCH, 1)
-  field(:PAIR, 2)
+  field(:DUO, 2)
   field(:QUICK_GAME, 3)
+  field(:TRIO, 4)
 end
 
 defmodule ArenaLoadTest.Serialization.GameStatus do

--- a/apps/bot_manager/lib/protobuf/messages.pb.ex
+++ b/apps/bot_manager/lib/protobuf/messages.pb.ex
@@ -5,8 +5,9 @@ defmodule BotManager.Protobuf.GameMode do
 
   field(:BATTLE, 0)
   field(:DEATHMATCH, 1)
-  field(:PAIR, 2)
+  field(:DUO, 2)
   field(:QUICK_GAME, 3)
+  field(:TRIO, 4)
 end
 
 defmodule BotManager.Protobuf.GameStatus do

--- a/apps/game_client/assets/js/protobuf/messages_pb.js
+++ b/apps/game_client/assets/js/protobuf/messages_pb.js
@@ -12771,8 +12771,9 @@ proto.CurrencyReward.prototype.setAmount = function(value) {
 proto.GameMode = {
   BATTLE: 0,
   DEATHMATCH: 1,
-  PAIR: 2,
-  QUICK_GAME: 3
+  DUO: 2,
+  QUICK_GAME: 3,
+  TRIO: 4
 };
 
 /**

--- a/apps/game_client/lib/game_client/protobuf/messages.pb.ex
+++ b/apps/game_client/lib/game_client/protobuf/messages.pb.ex
@@ -5,8 +5,9 @@ defmodule GameClient.Protobuf.GameMode do
 
   field(:BATTLE, 0)
   field(:DEATHMATCH, 1)
-  field(:PAIR, 2)
+  field(:DUO, 2)
   field(:QUICK_GAME, 3)
+  field(:TRIO, 4)
 end
 
 defmodule GameClient.Protobuf.GameStatus do

--- a/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
+++ b/apps/game_client/lib/game_client_web/controllers/page_html/home.html.heex
@@ -3,7 +3,8 @@
     <.input field={f[:character]} name="character" label="Select a Character" type="select" options={["muflus", "h4ck", "uma", "valtimer", "kenzu", "otix", "shinko", "uren"]} value=""/>
     <.input field={f[:user_id]} name="user_id" type="hidden" value={assigns[:user_id]}/>
     <.button type="submit" name="game_mode" value="battle-royale">Play Battle Royal</.button>
-    <.button type="submit" name="game_mode" value="pair">Play Pair</.button>
+    <.button type="submit" name="game_mode" value="duo">Play Duo</.button>
+    <.button type="submit" name="game_mode" value="trio">Play Trio</.button>
     <.button type="submit" name="game_mode" value="quick-game">Quick Game</.button>
     <.button type="submit" name="game_mode" value="deathmatch">Deathmatch</.button>
   </.form>

--- a/apps/serialization/messages.proto
+++ b/apps/serialization/messages.proto
@@ -74,8 +74,9 @@ message Configuration {
 enum GameMode{
   BATTLE = 0;
   DEATHMATCH = 1;
-  PAIR = 2;
+  DUO = 2;
   QUICK_GAME = 3;
+  TRIO = 4;
 }
 
 message ConfigGame {

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -4468,7 +4468,7 @@ deathmatch_mode_params = %{
   ]
 }
 
-pair_mode_params = %{
+duo_mode_params = %{
   type: "battle_royale",
   zone_enabled: true,
   bots_enabled: true,
@@ -4498,12 +4498,44 @@ pair_mode_params = %{
   version_id: version.id
 }
 
+trio_mode_params = %{
+  type: "battle_royale",
+  zone_enabled: true,
+  bots_enabled: true,
+  match_duration_ms: 180_000,
+  respawn_time_ms: 5000,
+  team_size: 3,
+  map_mode_params: [
+    %{
+      amount_of_players: 12,
+      initial_positions: [
+        %{x: -5378, y: 4702},
+        %{x: -4871, y: 4691},
+        %{x: -4680, y: 4242},
+        %{x: 4758, y: 5226},
+        %{x: 5355, y: 4941},
+        %{x: 4820, y: 4505},
+        %{x: 4829, y: -4831},
+        %{x: 4394, y: -5153},
+        %{x: 5173, y: -5475},
+        %{x: -3979, y: -5396},
+        %{x: -4344, y: -5128},
+        %{x: -4803, y: -5521}
+      ],
+      map_id: merliot_map_configuration.id
+    }
+  ],
+  version_id: version.id
+}
+
 {:ok, _battle} = GameBackend.Configuration.create_game_mode_configuration(battle_mode_params)
 
 {:ok, _deathmatch} =
   GameBackend.Configuration.create_game_mode_configuration(deathmatch_mode_params)
 
-{:ok, _pair} = GameBackend.Configuration.create_game_mode_configuration(pair_mode_params)
+{:ok, _duo} = GameBackend.Configuration.create_game_mode_configuration(duo_mode_params)
+
+{:ok, _trio} = GameBackend.Configuration.create_game_mode_configuration(trio_mode_params)
 
 {:ok, _quick_game} = GameBackend.Configuration.create_game_mode_configuration(quick_game_params)
 


### PR DESCRIPTION
> [!Warning]
> This PR should be merged alongside https://github.com/lambdaclass/champions_of_mirra/pull/2472

## Motivation

Closes #1069

Handle a new game mode in the backend! since we already have supports for teams

## Summary of changes

- [feat: rename pair to duo and add trio mode to the protomessages](https://github.com/lambdaclass/mirra_backend/commit/95eaa71b131da575b6e4bf45213d812f7a84def4)
- [code: renamed pair mode to duo mode](https://github.com/lambdaclass/mirra_backend/commit/1bfa4d494d8cfa48566e65df061e8e7f51698f54)
- [feat: handle a new matchmaking for trio mode](https://github.com/lambdaclass/mirra_backend/commit/b527d740f0aa395a92c6ddedd1a73de3a23be065)

## How to test it?

You can play it either in the browser or client.

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
