### PR TITLE
Handle game mode not found error to avoid dying matchmaking process

### DIFF
--- a/apps/arena/lib/arena/configuration.ex
+++ b/apps/arena/lib/arena/configuration.ex
@@ -21,6 +21,9 @@ defmodule Arena.Configuration do
 
     case Finch.build(:get, url, [{"content-type", "application/json"}])
          |> Finch.request(Arena.Finch) do
+      {:ok, %{status: 404, body: "Game mode not found"}} ->
+        {:error, %{}}
+
       {:ok, payload} ->
         {:ok,
          Jason.decode!(payload.body, [{:keys, :atoms}])


### PR DESCRIPTION
## Motivation

Some matchmaking queues are dying at start
Closes #1075 

## Summary of changes

- [Handle game mode not found error to avoid dying matchmaking process](https://github.com/lambdaclass/mirra_backend/commit/a7567e9874849d679d24090ad5f1e0b670350aa4)

## How to test it?

Run make start in main, you should get an error in one of the launch_game? functions.
Here you won't.

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
