### PR TITLE
Fix db name and game client port

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -239,8 +239,8 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
-  port = String.to_integer(System.get_env("PORT") || "3000")
+  host = System.get_env("GAME_CLIENT_HOST") || "gameclient-example.com"
+  port = String.to_integer(System.get_env("GAME_CLIENT_PORT") || "3000")
 
   config :game_client, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=game_backend_dev
+      - POSTGRES_DB=game_backend
       - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
       - game_backend_data:/var/lib/postgresql/data/


### PR DESCRIPTION
## Motivation

DB names mismatch between prod and local.
mix tasks fail in servers because some apps override ports and hosts.

## Summary of changes

- [Add separate port and host for GameClient app](https://github.com/lambdaclass/mirra_backend/commit/7e16faff46793f54c86e4cc20a99b70c2bb8f431)
- [Update game_backend db name to match prod one](https://github.com/lambdaclass/mirra_backend/commit/7dfe0edeb411614afea252500134d7bac86fedd7)

## How to test it?

You can export every prod variable in a shell and run any mix task. It should end successfully.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
