### PR TITLE
Set all winners as 1st position

### DIFF
--- a/apps/arena/docs/player-match-positions.md
+++ b/apps/arena/docs/player-match-positions.md
@@ -1,0 +1,19 @@
+# Player Match Positions
+
+Every time a player dies, we assign them a position.  
+When the game ends, we set the winners to position **1**.
+
+## Positioning Rules
+
+- **Solo Mode:**  
+  Player positions range from **N to 1**, where **1** is the winner and **N** is the first player to die.  
+
+- **Team Modes:**  
+  Player positions range from **N to 1**, where **1** is assigned to **all players on the winning team**.  
+  The remaining players are ranked from **N to 2**, based on the order in which they died.
+
+## Potential Issue
+
+A possible bug occurs when a player initially receives a position (e.g., **6**) upon dying.  
+If their team later wins, their position is overridden to **1**, leaving the **6th position empty**.
+


### PR DESCRIPTION
> [!Warning]
> Merge alongside https://github.com/lambdaclass/champions_of_mirra/pull/2570

## Motivation

We're currently sending the winners positions as 1 to M, being M the winners length.
Closes #1086

## Summary of changes

[Set all winners as 1st position](https://github.com/lambdaclass/mirra_backend/pull/1086/commits/8d2dc55f6dbaeb78421b048ae198ab1cd64978d6)

## How to test it?

Test alongside https://github.com/lambdaclass/champions_of_mirra/pull/2570.
Play a team mode match, everything should work just fine.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
