### PR TITLE
Add new on owner effect behavior

### DIFF
--- a/apps/configurator/assets/css/app.css
+++ b/apps/configurator/assets/css/app.css
@@ -39,4 +39,24 @@
     right: 10px;
   }
 
+/* Button class for components that aren't button (like .link) */
+.button {
+  border-radius: 0.5rem; /* rounded-lg */
+  background-color: #18181b; /* bg-zinc-900 */
+  padding: 12px 16px; /* py-3 px-4 */
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 600; /* font-semibold */
+  line-height: 1.5; /* leading-6 */
+  color: white; /* text-white */
+  transition: background-color 0.2s ease-in-out;
+}
+
+.button:hover {
+  background-color: #3f3f46; /* hover:bg-zinc-700 */
+}
+
+.button:active {
+  color: rgba(255, 255, 255, 0.8); /* active:text-white/80 */
+}
+
 /* This file is for your main application CSS */

--- a/apps/configurator/lib/configurator_web/components/custom_components.ex
+++ b/apps/configurator/lib/configurator_web/components/custom_components.ex
@@ -80,7 +80,7 @@ defmodule ConfiguratorWeb.CustomComponents do
                 type="select"
                 label="Effect mechanic name"
                 prompt="-- Choose a value --"
-                options={Ecto.Enum.values(GameBackend.CurseOfMirra.Effect.EffectMechanic, :name)}
+                options={Ecto.Enum.values(GameBackend.CurseOfMirra.Effects.Effect.EffectMechanic, :name)}
               />
               <.input field={mechanics_form[:modifier]} type="number" label="Modifier" step="any" />
               <.input field={mechanics_form[:force]} type="number" label="Force" step="any" />

--- a/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
@@ -57,7 +57,12 @@ defmodule ConfiguratorWeb.SkillController do
     skill = Skills.get_skill!(id)
 
     skill_params =
-      update_in(skill_params, ["mechanics", "0", "vertices"], fn vertices -> Jason.decode!(vertices) end)
+      update_in(skill_params, ["mechanics", "0", "vertices"], fn vertices ->
+        case vertices do
+          "" -> []
+          vertices -> Jason.decode!(vertices)
+          end
+         end)
 
     case Skills.update_skill(skill, skill_params) do
       {:ok, skill} ->

--- a/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
@@ -46,6 +46,13 @@ defmodule ConfiguratorWeb.SkillController do
     render(conn, :edit, skill: skill, changeset: changeset, version: version)
   end
 
+  def edit_on_owner_effect(conn, %{"id" => id}) do
+    skill = Skills.get_skill!(id)
+    changeset = Skills.change_skill(skill)
+    version = Configuration.get_version!(skill.version_id)
+    render(conn, :edit_on_owner_effect, skill: skill, effect: skill.on_owner_effect, changeset: changeset, version: version)
+  end
+
   def update(conn, %{"id" => id, "skill" => skill_params}) do
     skill = Skills.get_skill!(id)
 

--- a/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_controller.ex
@@ -50,7 +50,13 @@ defmodule ConfiguratorWeb.SkillController do
     skill = Skills.get_skill!(id)
     changeset = Skills.change_skill(skill)
     version = Configuration.get_version!(skill.version_id)
-    render(conn, :edit_on_owner_effect, skill: skill, effect: skill.on_owner_effect, changeset: changeset, version: version)
+
+    render(conn, :edit_on_owner_effect,
+      skill: skill,
+      effect: skill.on_owner_effect,
+      changeset: changeset,
+      version: version
+    )
   end
 
   def update(conn, %{"id" => id, "skill" => skill_params}) do
@@ -61,8 +67,8 @@ defmodule ConfiguratorWeb.SkillController do
         case vertices do
           "" -> []
           vertices -> Jason.decode!(vertices)
-          end
-         end)
+        end
+      end)
 
     case Skills.update_skill(skill, skill_params) do
       {:ok, skill} ->

--- a/apps/configurator/lib/configurator_web/controllers/skill_html.ex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html.ex
@@ -10,6 +10,7 @@ defmodule ConfiguratorWeb.SkillHTML do
   """
   attr :changeset, Ecto.Changeset, required: true
   attr :action, :string, required: true
+  attr :skill, Skill
   attr :version, GameBackend.Configuration.Version, required: true
 
   def skill_form(assigns)

--- a/apps/configurator/lib/configurator_web/controllers/skill_html.ex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html.ex
@@ -1,6 +1,7 @@
 defmodule ConfiguratorWeb.SkillHTML do
   use ConfiguratorWeb, :html
   alias GameBackend.Units.Skills.Mechanic
+  alias GameBackend.Units.Skills.Skill
 
   embed_templates "skill_html/*"
 
@@ -16,6 +17,7 @@ defmodule ConfiguratorWeb.SkillHTML do
   @doc """
   Renders the inputs for a mechanic inside a skill form.
   """
+  attr :skill, Skill
   attr :skill_form, Phoenix.HTML.FormField, required: true
 
   def skill_mechanic_inputs(assigns)

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/edit.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/edit.html.heex
@@ -3,6 +3,6 @@
   <:subtitle>Use this form to manage skill records in your database.</:subtitle>
 </.header>
 
-<.skill_form changeset={@changeset} action={~p"/versions/#{@version}/skills/#{@skill}"} version={@version} />
+<.skill_form changeset={@changeset} action={~p"/versions/#{@version}/skills/#{@skill}"} version={@version} skill={@skill} />
 
 <.back navigate={~p"/versions/#{@version}/skills"}>Back to skills</.back>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/edit.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/edit.html.heex
@@ -3,6 +3,11 @@
   <:subtitle>Use this form to manage skill records in your database.</:subtitle>
 </.header>
 
-<.skill_form changeset={@changeset} action={~p"/versions/#{@version}/skills/#{@skill}"} version={@version} skill={@skill} />
+<.skill_form
+  changeset={@changeset}
+  action={~p"/versions/#{@version}/skills/#{@skill}"}
+  version={@version}
+  skill={@skill}
+/>
 
 <.back navigate={~p"/versions/#{@version}/skills"}>Back to skills</.back>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/edit_on_owner_effect.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/edit_on_owner_effect.html.heex
@@ -1,0 +1,9 @@
+<.header>
+  Edit On Owner Effect for skill: <%= @skill.name %>
+</.header>
+
+<%= live_render(@conn, ConfiguratorWeb.EffectsLive.Form,
+          session: %{"effect" => @effect, "version" => @version, "skill" => @skill}
+        ) %>
+
+<.back navigate={~p"/versions/#{@version}/skills"}>Back to skills</.back>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/edit_on_owner_effect.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/edit_on_owner_effect.html.heex
@@ -3,7 +3,7 @@
 </.header>
 
 <%= live_render(@conn, ConfiguratorWeb.EffectsLive.Form,
-          session: %{"effect" => @effect, "version" => @version, "skill" => @skill}
-        ) %>
+  session: %{"effect" => @effect, "version" => @version, "skill" => @skill}
+) %>
 
 <.back navigate={~p"/versions/#{@version}/skills"}>Back to skills</.back>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/show.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/show.html.heex
@@ -12,6 +12,9 @@
     <.link href={~p"/versions/#{@version}/skills/#{@skill}/edit"}>
       <.button>Edit skill</.button>
     </.link>
+    <.link href={~p"/versions/#{@version}/skills/#{@skill}/edit_on_owner_effect"}>
+      <.button>Edit On Owner Effect</.button>
+    </.link>
     <.effect_show effect={@skill.on_owner_effect} label="On Owner Effect" />
   </:actions>
 </.header>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/skill_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/skill_form.html.heex
@@ -39,9 +39,9 @@
   <.input field={f[:mana_cost]} type="number" label="Mana cost" />
 
   <.skill_mechanic_inputs skill_form={f} />
-  <%= if f.data.on_owner_effect do %>
-    <.effect_form form={f} field={:on_owner_effect} />
-  <% end %>
+  <.link class="button" href={~p"/versions/#{@version}/skills/#{@skill}/edit_on_owner_effect"}>
+    Edit On Owner Effect
+  </.link>
 
   <:actions>
     <.button>Save Skill</.button>

--- a/apps/configurator/lib/configurator_web/controllers/skill_html/skill_mechanic_inputs.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/skill_mechanic_inputs.html.heex
@@ -34,10 +34,7 @@
   <% end %>
   <.input field={fp[:shape]} type="select" label="Shape of entity to spawn" options={["circle", "polygon"]} />
 
-  <%!-- TODO: Fix this because it breaks if its null --%>
-  <%!-- https://github.com/lambdaclass/mirra_backend/issues/1028 --%>
-  <.input field={fp[:vertices]} type="text" label="Vertices" value={[]} />
-  <%!-- END TODO --%>
+  <.input field={fp[:vertices]} type="text" label="Vertices" />
 
   <.button type="button" phx-click={show_modal("on-arrival-mechanic-modal")}>Edit on arrival mechanic</.button>
   <.modal id="on-arrival-mechanic-modal">

--- a/apps/configurator/lib/configurator_web/live/effects/form.ex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.ex
@@ -55,8 +55,6 @@ defmodule ConfiguratorWeb.EffectsLive.Form do
   end
 
   def handle_event("save", %{"effect" => effect_params}, socket) do
-    IO.inspect(effect_params, label: :aver_params)
-
     socket =
       case Skills.update_skill(socket.assigns.skill, %{on_owner_effect: effect_params}) do
         {:ok, skill} ->

--- a/apps/configurator/lib/configurator_web/live/effects/form.ex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.ex
@@ -1,5 +1,5 @@
 defmodule ConfiguratorWeb.EffectsLive.Form do
-alias GameBackend.Units.Skills
+  alias GameBackend.Units.Skills
   use ConfiguratorWeb, :live_view
 
   alias GameBackend.CurseOfMirra.Effects
@@ -27,14 +27,13 @@ alias GameBackend.Units.Skills
       ) do
     changeset = Effects.change_effect(effect)
 
-      socket = assign(socket, skill: skill, changeset: changeset, action: "save", version: version)
+    socket = assign(socket, skill: skill, changeset: changeset, action: "save", version: version)
     {:ok, socket}
   end
 
   def handle_event("validate", %{"effect" => effect_params}, socket) do
     changeset = socket.assigns.changeset
     changeset = Effect.changeset(changeset, effect_params)
-
 
     {:noreply, assign(socket, changeset: changeset, effect: changeset)}
   end
@@ -48,7 +47,6 @@ alias GameBackend.Units.Skills
   end
 
   def handle_event("remove_effect_mechanics", _params, socket) do
-
     changeset = socket.assigns.changeset
     effect_mechanics = Ecto.Changeset.get_field(changeset, :effect_mechanics) |> List.delete_at(-1)
     changeset = Ecto.Changeset.put_change(changeset, :effect_mechanics, effect_mechanics)
@@ -76,5 +74,4 @@ alias GameBackend.Units.Skills
 
     {:noreply, socket}
   end
-
 end

--- a/apps/configurator/lib/configurator_web/live/effects/form.ex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.ex
@@ -1,0 +1,80 @@
+defmodule ConfiguratorWeb.EffectsLive.Form do
+alias GameBackend.Units.Skills
+  use ConfiguratorWeb, :live_view
+
+  alias GameBackend.CurseOfMirra.Effects
+  alias GameBackend.CurseOfMirra.Effects.Effect
+  alias GameBackend.CurseOfMirra.Effects.Effect.EffectMechanic
+  alias GameBackend.Configuration
+
+  def mount(
+        _params,
+        %{"effect" => nil, "version" => version, "skill" => skill},
+        socket
+      ) do
+    changeset = Effects.change_effect(%Effect{effect_mechanics: [%EffectMechanic{}]})
+
+    socket =
+      assign(socket, skill: skill, changeset: changeset, action: "save", version: version)
+
+    {:ok, socket}
+  end
+
+  def mount(
+        _params,
+        %{"effect" => effect, "version" => version, "skill" => skill},
+        socket
+      ) do
+    changeset = Effects.change_effect(effect)
+
+      socket = assign(socket, skill: skill, changeset: changeset, action: "save", version: version)
+    {:ok, socket}
+  end
+
+  def handle_event("validate", %{"effect" => effect_params}, socket) do
+    changeset = socket.assigns.changeset
+    changeset = Effect.changeset(changeset, effect_params)
+
+
+    {:noreply, assign(socket, changeset: changeset, effect: changeset)}
+  end
+
+  def handle_event("add_effect_mechanics", _params, socket) do
+    changeset = socket.assigns.changeset
+    effect_mechanics = Ecto.Changeset.get_field(changeset, :effect_mechanics) || []
+    changeset = Ecto.Changeset.put_embed(changeset, :effect_mechanics, effect_mechanics ++ [%EffectMechanic{}])
+
+    {:noreply, assign(socket, changeset: changeset, effect: changeset)}
+  end
+
+  def handle_event("remove_effect_mechanics", _params, socket) do
+
+    changeset = socket.assigns.changeset
+    effect_mechanics = Ecto.Changeset.get_field(changeset, :effect_mechanics) |> List.delete_at(-1)
+    changeset = Ecto.Changeset.put_change(changeset, :effect_mechanics, effect_mechanics)
+
+    {:noreply, assign(socket, changeset: changeset, effect: changeset)}
+  end
+
+  def handle_event("save", %{"effect" => effect_params}, socket) do
+    IO.inspect(effect_params, label: :aver_params)
+
+    socket =
+      case Skills.update_skill(socket.assigns.skill, %{on_owner_effect: effect_params}) do
+        {:ok, skill} ->
+          socket
+          |> put_flash(:info, "Effect created successfully.")
+          |> redirect(to: ~p"/versions/#{skill.version_id}/skills/#{skill.id}")
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          version = Configuration.get_version!(effect_params["version_id"])
+
+          socket
+          |> put_flash(:error, "Please correct the errors below.")
+          |> assign(changeset: changeset, version: version)
+      end
+
+    {:noreply, socket}
+  end
+
+end

--- a/apps/configurator/lib/configurator_web/live/effects/form.html.heex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.html.heex
@@ -1,50 +1,38 @@
-
 <.simple_form :let={effect_f} for={@changeset} action={@action} phx-submit={@action} phx-change="validate">
-<.error :if={@changeset.action}>
+  <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
-      <%!-- <.inputs_for :let={effect_f} field={f[@field]}> --%>
-      <%!-- <.inputs_for :let={effect_f} field={@form[@field]}> --%>
-        <.input field={effect_f[:name]} type="text" label="Name" />
-        <.input field={effect_f[:duration_ms]} type="number" label="Effect duration" />
-        <.input field={effect_f[:remove_on_action]} type="checkbox" label="Remove effect on action" />
-        <.input field={effect_f[:one_time_application]} type="checkbox" label="Apply effect once" />
-        <.input field={effect_f[:disabled_outside_pool]} type="checkbox" label="Disabled outside pool" />
-        <.input field={effect_f[:allow_multiple_effects]} type="checkbox" label="Allow more that one effect instance" />
-        <.input field={effect_f[:consume_projectile]} type="checkbox" label="Consume projectile" />
+  <%!-- <.inputs_for :let={effect_f} field={f[@field]}> --%>
+  <%!-- <.inputs_for :let={effect_f} field={@form[@field]}> --%>
+  <.input field={effect_f[:name]} type="text" label="Name" />
+  <.input field={effect_f[:duration_ms]} type="number" label="Effect duration" />
+  <.input field={effect_f[:remove_on_action]} type="checkbox" label="Remove effect on action" />
+  <.input field={effect_f[:one_time_application]} type="checkbox" label="Apply effect once" />
+  <.input field={effect_f[:disabled_outside_pool]} type="checkbox" label="Disabled outside pool" />
+  <.input field={effect_f[:allow_multiple_effects]} type="checkbox" label="Allow more that one effect instance" />
+  <.input field={effect_f[:consume_projectile]} type="checkbox" label="Consume projectile" />
 
-        
-
-        <.inputs_for :let={mechanics_form} field={effect_f[:effect_mechanics]}>
-          <div class="w-full rounded overflow-hidden shadow-lg mt-4">
-            <div class="px-6 py-4">
-              <.input
-                field={mechanics_form[:name]}
-                type="select"
-                label="Effect mechanic name"
-                prompt="-- Choose a value --"
-                options={Ecto.Enum.values(GameBackend.CurseOfMirra.Effects.Effect.EffectMechanic, :name)}
-              />
-              <.input field={mechanics_form[:modifier]} type="number" label="Modifier" step="any" />
-              <.input field={mechanics_form[:force]} type="number" label="Force" step="any" />
-              <.input
-                field={mechanics_form[:execute_multiple_times]}
-                type="checkbox"
-                label="Execute mechanic multiple times"
-              />
-              <.input field={mechanics_form[:damage]} type="number" label="Damage amount" />
-              <.input field={mechanics_form[:effect_delay_ms]} type="number" label="Mechanic delay" />
-              <.input field={mechanics_form[:additive_duration_add_ms]} type="number" label="Additive duration to add ms" />
-              <.input
-                field={mechanics_form[:stat_multiplier]}
-                type="number"
-                label="Stat multiplier"
-                step="Start multiplier"
-              />
-            </div>
-          </div>
-        </.inputs_for>
-        <div class="flex items-center justify-between gap-6">
+  <.inputs_for :let={mechanics_form} field={effect_f[:effect_mechanics]}>
+    <div class="w-full rounded overflow-hidden shadow-lg mt-4">
+      <div class="px-6 py-4">
+        <.input
+          field={mechanics_form[:name]}
+          type="select"
+          label="Effect mechanic name"
+          prompt="-- Choose a value --"
+          options={Ecto.Enum.values(GameBackend.CurseOfMirra.Effects.Effect.EffectMechanic, :name)}
+        />
+        <.input field={mechanics_form[:modifier]} type="number" label="Modifier" step="any" />
+        <.input field={mechanics_form[:force]} type="number" label="Force" step="any" />
+        <.input field={mechanics_form[:execute_multiple_times]} type="checkbox" label="Execute mechanic multiple times" />
+        <.input field={mechanics_form[:damage]} type="number" label="Damage amount" />
+        <.input field={mechanics_form[:effect_delay_ms]} type="number" label="Mechanic delay" />
+        <.input field={mechanics_form[:additive_duration_add_ms]} type="number" label="Additive duration to add ms" />
+        <.input field={mechanics_form[:stat_multiplier]} type="number" label="Stat multiplier" step="Start multiplier" />
+      </div>
+    </div>
+  </.inputs_for>
+  <div class="flex items-center justify-between gap-6">
     <span
       phx-click="add_effect_mechanics"
       class="relative phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3 text-sm font-semibold leading-6 text-white active:text-white/80"
@@ -63,7 +51,7 @@
       </span>
     </div>
   <% end %>
-      <:actions>
+  <:actions>
     <.button>Save Game configuration</.button>
   </:actions>
 </.simple_form>

--- a/apps/configurator/lib/configurator_web/live/effects/form.html.heex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.html.heex
@@ -1,0 +1,69 @@
+
+<.simple_form :let={effect_f} for={@changeset} action={@action} phx-submit={@action} phx-change="validate">
+<.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+      <%!-- <.inputs_for :let={effect_f} field={f[@field]}> --%>
+      <%!-- <.inputs_for :let={effect_f} field={@form[@field]}> --%>
+        <.input field={effect_f[:name]} type="text" label="Name" />
+        <.input field={effect_f[:duration_ms]} type="number" label="Effect duration" />
+        <.input field={effect_f[:remove_on_action]} type="checkbox" label="Remove effect on action" />
+        <.input field={effect_f[:one_time_application]} type="checkbox" label="Apply effect once" />
+        <.input field={effect_f[:disabled_outside_pool]} type="checkbox" label="Disabled outside pool" />
+        <.input field={effect_f[:allow_multiple_effects]} type="checkbox" label="Allow more that one effect instance" />
+        <.input field={effect_f[:consume_projectile]} type="checkbox" label="Consume projectile" />
+
+        
+
+        <.inputs_for :let={mechanics_form} field={effect_f[:effect_mechanics]}>
+          <div class="w-full rounded overflow-hidden shadow-lg mt-4">
+            <div class="px-6 py-4">
+              <.input
+                field={mechanics_form[:name]}
+                type="select"
+                label="Effect mechanic name"
+                prompt="-- Choose a value --"
+                options={Ecto.Enum.values(GameBackend.CurseOfMirra.Effects.Effect.EffectMechanic, :name)}
+              />
+              <.input field={mechanics_form[:modifier]} type="number" label="Modifier" step="any" />
+              <.input field={mechanics_form[:force]} type="number" label="Force" step="any" />
+              <.input
+                field={mechanics_form[:execute_multiple_times]}
+                type="checkbox"
+                label="Execute mechanic multiple times"
+              />
+              <.input field={mechanics_form[:damage]} type="number" label="Damage amount" />
+              <.input field={mechanics_form[:effect_delay_ms]} type="number" label="Mechanic delay" />
+              <.input field={mechanics_form[:additive_duration_add_ms]} type="number" label="Additive duration to add ms" />
+              <.input
+                field={mechanics_form[:stat_multiplier]}
+                type="number"
+                label="Stat multiplier"
+                step="Start multiplier"
+              />
+            </div>
+          </div>
+        </.inputs_for>
+        <div class="flex items-center justify-between gap-6">
+    <span
+      phx-click="add_effect_mechanics"
+      class="relative phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3 text-sm font-semibold leading-6 text-white active:text-white/80"
+    >
+      Add Effect Mechanic
+    </span>
+  </div>
+
+  <%= if not is_nil(Ecto.Changeset.get_field(@changeset, :effect_mechanics)) do %>
+    <div class="flex items-center justify-between gap-6">
+      <span
+        phx-click="remove_effect_mechanics"
+        class="relative phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3 text-sm font-semibold leading-6 text-white active:text-white/80"
+      >
+        Remove Effect Mechanic
+      </span>
+    </div>
+  <% end %>
+      <:actions>
+    <.button>Save Game configuration</.button>
+  </:actions>
+</.simple_form>

--- a/apps/configurator/lib/configurator_web/live/effects/form.html.heex
+++ b/apps/configurator/lib/configurator_web/live/effects/form.html.heex
@@ -2,8 +2,6 @@
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
-  <%!-- <.inputs_for :let={effect_f} field={f[@field]}> --%>
-  <%!-- <.inputs_for :let={effect_f} field={@form[@field]}> --%>
   <.input field={effect_f[:name]} type="text" label="Name" />
   <.input field={effect_f[:duration_ms]} type="number" label="Effect duration" />
   <.input field={effect_f[:remove_on_action]} type="checkbox" label="Remove effect on action" />
@@ -52,6 +50,6 @@
     </div>
   <% end %>
   <:actions>
-    <.button>Save Game configuration</.button>
+    <.button>Save Effect</.button>
   </:actions>
 </.simple_form>

--- a/apps/configurator/lib/configurator_web/router.ex
+++ b/apps/configurator/lib/configurator_web/router.ex
@@ -65,6 +65,7 @@ defmodule ConfiguratorWeb.Router do
       scope "/:version_id" do
         resources "/characters", CharacterController
         resources "/skills", SkillController
+        get "/skills/:id/edit_on_owner_effect", SkillController, :edit_on_owner_effect
         resources "/game_configurations", GameConfigurationController
         resources "/game_mode_configurations", GameModeConfigurationController
         resources "/map_configurations", MapConfigurationController

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/Effects/effect.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/Effects/effect.ex
@@ -1,4 +1,4 @@
-defmodule GameBackend.CurseOfMirra.Effect do
+defmodule GameBackend.CurseOfMirra.Effects.Effect do
   @moduledoc """
   """
   use GameBackend.Schema
@@ -24,7 +24,7 @@ defmodule GameBackend.CurseOfMirra.Effect do
     field(:allow_multiple_effects, :boolean)
     field(:consume_projectile, :boolean)
     field(:disabled_outside_pool, :boolean)
-    embeds_many(:effect_mechanics, EffectMechanic)
+    embeds_many(:effect_mechanics, EffectMechanic, on_replace: :delete)
   end
 
   def changeset(position, attrs) do

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/effects.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/effects.ex
@@ -1,0 +1,20 @@
+defmodule GameBackend.CurseOfMirra.Effects do
+  @moduledoc """
+  Operations with skills.
+  """
+
+  alias GameBackend.CurseOfMirra.Effects.Effect
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking effect changes.
+
+  ## Examples
+
+      iex> change_effect(effect)
+      %Ecto.Changeset{data: %Effect{}}
+
+  """
+  def change_effect(%Effect{} = effect, attrs \\ %{}) do
+    Effect.changeset(effect, attrs)
+  end
+end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/map_configuration.ex
@@ -120,7 +120,7 @@ defmodule GameBackend.CurseOfMirra.MapConfiguration do
       field(:name, :string)
       field(:radius, :decimal)
       field(:shape, Ecto.Enum, values: [:circle, :polygon])
-      embeds_one(:effect, GameBackend.CurseOfMirra.Effect)
+      embeds_one(:effect, GameBackend.CurseOfMirra.Effects.Effect)
       embeds_one(:position, Position)
       embeds_many(:vertices, Position)
     end

--- a/apps/game_backend/lib/game_backend/items/consumable_item.ex
+++ b/apps/game_backend/lib/game_backend/items/consumable_item.ex
@@ -19,7 +19,7 @@ defmodule GameBackend.Items.ConsumableItem do
     belongs_to(:version, Version)
     has_many(:mechanics, Mechanic)
 
-    embeds_one(:effect, GameBackend.CurseOfMirra.Effect)
+    embeds_one(:effect, GameBackend.CurseOfMirra.Effects.Effect)
 
     timestamps(type: :utc_datetime)
   end

--- a/apps/game_backend/lib/game_backend/units/skills/mechanic.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/mechanic.ex
@@ -54,7 +54,7 @@ defmodule GameBackend.Units.Skills.Mechanic do
     belongs_to(:on_arrival_mechanic, __MODULE__)
     belongs_to(:parent_mechanic, __MODULE__, foreign_key: :parent_mechanic_id)
     embeds_one(:on_collide_effect, OnCollideEffect)
-    embeds_one(:effect, GameBackend.CurseOfMirra.Effect)
+    embeds_one(:effect, GameBackend.CurseOfMirra.Effects.Effect)
   end
 
   def mechanic_types(), do: [:apply_effects_to, :passive_effects]

--- a/apps/game_backend/lib/game_backend/units/skills/mechanics/on_collide_effect.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/mechanics/on_collide_effect.ex
@@ -10,7 +10,7 @@ defmodule GameBackend.Units.Skills.Mechanics.OnCollideEffect do
   @primary_key false
   embedded_schema do
     field(:apply_effect_to_entity_type, {:array, :string})
-    embeds_one(:effect, GameBackend.CurseOfMirra.Effect)
+    embeds_one(:effect, GameBackend.CurseOfMirra.Effects.Effect)
   end
 
   @doc false

--- a/apps/game_backend/lib/game_backend/units/skills/skill.ex
+++ b/apps/game_backend/lib/game_backend/units/skills/skill.ex
@@ -35,7 +35,7 @@ defmodule GameBackend.Units.Skills.Skill do
     belongs_to(:next_skill, __MODULE__)
     has_many(:mechanics, Mechanic, on_replace: :delete)
     belongs_to(:version, Version)
-    embeds_one(:on_owner_effect, GameBackend.CurseOfMirra.Effect)
+    embeds_one(:on_owner_effect, GameBackend.CurseOfMirra.Effects.Effect, on_replace: :delete)
 
     timestamps()
   end


### PR DESCRIPTION
## Motivation

We need to balance Kenzu and we can't modify the effects gained when spinning.
Closes #1098
Closes #1099 

## Summary of changes
This is a 1st step closer to modify all efects, which should be done re-using this liveview in the future

- [Add Effect and EffectMechanics liveview](https://github.com/lambdaclass/mirra_backend/pull/1097/commits/4eb8e2988ac81b4a757317b33673b53cded7b4e1)
- [Move Effect schema inside folder and create effects module](https://github.com/lambdaclass/mirra_backend/pull/1097/commits/f08d823d06d56949341142e9f62302381a352b53)
- [Add new Edit On Owner Effect button in skill show and edit views](https://github.com/lambdaclass/mirra_backend/pull/1097/commits/2a4f72ce777e22524e4548deeb284f2e34c0a235)
- [Add css style to make other buttons outside .button component look li…](https://github.com/lambdaclass/mirra_backend/pull/1097/commits/51ddcf1c2b8b321d31091532055b096840421589) 
- [Fix vertices TODO: error](https://github.com/lambdaclass/mirra_backend/pull/1097/commits/b7ca4e7b10bb6176625d3db238d246c92a09c099)

## How to test it?

Just open the configurator and see if you can modify all effects. Specially the one fixed by this PR.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
