### PR TITLE
Add reset combo params

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/skill_html/skill_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/skill_html/skill_form.html.heex
@@ -20,6 +20,7 @@
     options={Ecto.Enum.values(GameBackend.Units.Skills.Skill, :attack_type)}
   />
   <.input field={f[:activation_delay_ms]} type="number" label="Activation delay (ms)" />
+  <.input field={f[:reset_combo_ms]} type="number" label="Reset combo (ms)" />
   <.input field={f[:autoaim]} type="checkbox" label="Autoaim" />
   <.input field={f[:block_movement]} type="checkbox" label="Block movement" />
   <.input field={f[:can_pick_destination]} type="checkbox" label="Can pick destination" />


### PR DESCRIPTION
## Motivation

We need combo params to balance kenzu

## Summary of changes

Add combo params.

## How to test it?

Open configurator and see kenzu_quickslash_second skill.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
