### PR TITLE
1113 update loadtests code

### DIFF
--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -59,12 +59,12 @@ defmodule ArenaLoadTest.SocketHandler do
 
     case System.get_env("TARGET_SERVER") do
       nil ->
-        "ws://localhost:4000/join/#{player_id}/#{character}/#{player_name}"
+        "ws://localhost:4000/join/battle-royale/#{player_id}/#{character}/#{player_name}"
 
       target_server ->
         # TODO Replace this for a SSL connection using erlang credentials.
         # TODO https://github.com/lambdaclass/mirra_backend/issues/493
-        "ws://#{Utils.get_server_ip(target_server)}:4000/join/#{player_id}/#{character}/#{player_name}"
+        "ws://#{Utils.get_server_ip(target_server)}:4000/join/battle-royale/#{player_id}/#{character}/#{player_name}"
     end
   end
 

--- a/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
+++ b/apps/arena_load_test/lib/arena_load_test/socket_handler.ex
@@ -71,7 +71,7 @@ defmodule ArenaLoadTest.SocketHandler do
   # This is enough for now. Will request bots from the bots app in future iterations.
   # https://github.com/lambdaclass/mirra_backend/issues/410
   defp get_random_active_character() do
-    ["muflus", "h4ck", "uma", "valtimer", "kenzu", "otix", "shinko", "uren"]
+    ["h4ck", "valtimer", "kenzu", "otix"]
     |> Enum.random()
   end
 


### PR DESCRIPTION
## Motivation

Loadtests aren't working
Closes #1113

## Summary of changes

- [Ignore units from the database if jwt is overriden](https://github.com/lambdaclass/mirra_backend/pull/1114/commits/db5c5513eed10e5f99ab09e6db0a6c036968d9d8)
- [Update join endpoint. Hardcode it to battle-royale now](https://github.com/lambdaclass/mirra_backend/pull/1114/commits/0feb02d4fef9b7ca418a41ec45d7a019a5f839f6)
- [Update active characters list](https://github.com/lambdaclass/mirra_backend/pull/1114/commits/d92975a9d250b878eab02ea975400ba0fc8bde01)

## How to test it?

Just run some loadtests (read the README) and everything should work just fine.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
