### PR TITLE
auto export env var and update readme to reflect change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,6 @@ The objective is to split the project into multiple applications (modules) based
 
 ## Requirements
 
-- **Protobuf:**
-To serialize our websocket messages, we use Protobuf.
-Install running:
-```bash
-brew install protobuf
-mix escript.install hex protobuf # Remember to add escripts folder to your $PATH
-# JS protobuf for game_client app.
-cd assets
-npm install google-protobuf
-npm install -g protoc-gen-js
-```
-
 - **Nix:**
 You can install the Nix package manager by running the following command in your terminal:
 ```bash
@@ -68,6 +56,18 @@ Install the last elixir package manager inside the repo folder and devenv shell:
 cd mirra_backend
 devenv shell
 mix archive.install github hexpm/hex branch latest
+```
+
+- **Protobuf:**
+To serialize our websocket messages, we use Protobuf.
+Install running:
+```bash
+brew install protobuf
+mix escript.install hex protobuf # Remember to add escripts folder to your $PATH. This step is not needed if you use devenv.
+# JS protobuf for game_client app.
+cd assets
+npm install google-protobuf
+npm install -g protoc-gen-js
 ```
 
 ## Start applications

--- a/devenv.nix
+++ b/devenv.nix
@@ -49,4 +49,9 @@
       ];
     };
   };
+
+  # automatically export mix scripts (needed for protobuf to work)
+  enterShell = ''
+    export PATH="$HOME/.mix/escripts:$PATH"
+  '';
 }


### PR DESCRIPTION
## Motivation

Makes project setup a bit easier bc you have less steps to perform

## Summary of changes

Make devenv export the env var with the path of mix scripts (required for protobuf to work). I took the line from [devenv's documentation](https://devenv.sh/common-patterns/#add-a-directory-to-path). I updated the readme and also reordered the dependencies since I needed to first install devenv and elixir before installing protobuf

## How to test it?

I tested it as I was setting the project for the first time. 

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
