### PR TITLE
1022 pathfinding visibility graph

### DIFF
--- a/apps/bot_manager/lib/astar_native.ex
+++ b/apps/bot_manager/lib/astar_native.ex
@@ -6,5 +6,7 @@ defmodule AStarNative do
   use Rustler, otp_app: :bot_manager, crate: "astarnative"
 
   # When your NIF is loaded, it will override this function.
-  def a_star_shortest_path(_from, _to), do: :erlang.nif_error(:nif_not_loaded)
+  def a_star_shortest_path(_from, _to, _collision_grid), do: :erlang.nif_error(:nif_not_loaded)
+
+  def build_collision_grid(_obstacles), do: :erlang.nif_error(:nif_not_loaded) 
 end

--- a/apps/bot_manager/lib/astar_native.ex
+++ b/apps/bot_manager/lib/astar_native.ex
@@ -8,5 +8,5 @@ defmodule AStarNative do
   # When your NIF is loaded, it will override this function.
   def a_star_shortest_path(_from, _to, _collision_grid), do: :erlang.nif_error(:nif_not_loaded)
 
-  def build_collision_grid(_obstacles), do: :erlang.nif_error(:nif_not_loaded) 
+  def build_collision_grid(_obstacles), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -220,6 +220,9 @@ defmodule BotManager.BotStateMachine do
     bot_state_machine =
       determine_position_to_move_to(bot_state_machine, safe_zone_radius, System.get_env("PATHFINDING_TEST") == "true")
 
+    IO.inspect(bot_state_machine.path_towards_position, label: "PATH")
+    IO.inspect(bot_state_machine.position_to_move_to, label: "TARGET POSITION")
+
     # TODO instead of using `get_distance_and_direction_to_positions, use the pathfinding module`
     cond do
       not is_nil(bot_state_machine.path_towards_position) and Enum.count(bot_state_machine.path_towards_position) > 0 ->
@@ -261,11 +264,16 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
+        IO.inspect("CALCULATING SHORTEST PATH")
+        IO.inspect(from, label: "FROM")
+        IO.inspect(to, label: "TO")
         shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+        |> IO.inspect(label: "SHORTEST PATH")
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
-          determine_position_to_move_to(bot_state_machine, safe_zone_radius, true)
+          Map.put(bot_state_machine, :path_towards_position, nil)
+          |> Map.put(:position_to_move_to, nil)
         else
           Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
           |> Map.put(
@@ -282,13 +290,16 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
-
+        IO.inspect("CALCULATING SHORTEST PATH")
+        # IO.inspect(from, label: "FROM")
+        # IO.inspect(to, label: "TO")
         shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
-
+        |> IO.inspect(label: "SHORTEST PATH")
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
-          determine_position_to_move_to(bot_state_machine, safe_zone_radius, true)
+          Map.put(bot_state_machine, :path_towards_position, nil)
+          |> Map.put(:position_to_move_to, nil)
         else
           Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
           |> Map.put(

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -256,7 +256,9 @@ defmodule BotManager.BotStateMachine do
 
   defp determine_position_to_move_to(bot_state_machine, safe_zone_radius, true = _pathfinding_on) do
     cond do
-      not is_nil(bot_state_machine.collision_grid) and is_nil(bot_state_machine.path_towards_position) ->
+      is_nil(bot_state_machine.collision_grid) ->
+        bot_state_machine
+      is_nil(bot_state_machine.path_towards_position) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
@@ -277,9 +279,8 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      not is_nil(bot_state_machine.collision_grid) and
-        BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
-          BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
+      BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
+        BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
@@ -300,8 +301,7 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      not is_nil(bot_state_machine.path_towards_position) and
-          BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
+      BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
 
       true ->

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -233,6 +233,7 @@ defmodule BotManager.BotStateMachine do
           action: determine_player_move_action(bot_player, direction),
           bot_state_machine: bot_state_machine
         }
+
       not is_nil(bot_state_machine.position_to_move_to) ->
         %{direction: direction} =
           Utils.get_distance_and_direction_to_positions(
@@ -276,7 +277,8 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      not is_nil(bot_state_machine.collision_grid) and BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
+      not is_nil(bot_state_machine.collision_grid) and
+        BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
           BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
@@ -298,7 +300,8 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      not is_nil(bot_state_machine.path_towards_position) and BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
+      not is_nil(bot_state_machine.path_towards_position) and
+          BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
 
       true ->

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -258,6 +258,7 @@ defmodule BotManager.BotStateMachine do
     cond do
       is_nil(bot_state_machine.collision_grid) ->
         bot_state_machine
+
       is_nil(bot_state_machine.path_towards_position) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
@@ -280,7 +281,7 @@ defmodule BotManager.BotStateMachine do
         end
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
-        BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
+          BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -248,14 +248,14 @@ defmodule BotManager.BotStateMachine do
 
   defp determine_position_to_move_to(bot_state_machine, safe_zone_radius, true = _pathfinding_on) do
     cond do
-      is_nil(bot_state_machine.path_towards_position) ->
+      not is_nil(bot_state_machine.collision_grid) and is_nil(bot_state_machine.path_towards_position) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
         shortest_path =
-          AStarNative.a_star_shortest_path(from, to)
+          AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
@@ -269,7 +269,7 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
+      not is_nil(bot_state_machine.collision_grid) and BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
           BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
@@ -277,7 +277,7 @@ defmodule BotManager.BotStateMachine do
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
         shortest_path =
-          AStarNative.a_star_shortest_path(from, to)
+          AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -221,28 +221,35 @@ defmodule BotManager.BotStateMachine do
       determine_position_to_move_to(bot_state_machine, safe_zone_radius, System.get_env("PATHFINDING_TEST") == "true")
 
     # TODO instead of using `get_distance_and_direction_to_positions, use the pathfinding module`
-    if not is_nil(bot_state_machine.path_towards_position) and Enum.count(bot_state_machine.path_towards_position) > 0 do
-      %{direction: direction} =
-        Utils.get_distance_and_direction_to_positions(
-          bot_state_machine.current_position,
-          hd(bot_state_machine.path_towards_position)
-        )
+    cond do
+      not is_nil(bot_state_machine.path_towards_position) and Enum.count(bot_state_machine.path_towards_position) > 0 ->
+        %{direction: direction} =
+          Utils.get_distance_and_direction_to_positions(
+            bot_state_machine.current_position,
+            hd(bot_state_machine.path_towards_position)
+          )
 
-      %{
-        action: determine_player_move_action(bot_player, direction),
-        bot_state_machine: bot_state_machine
-      }
-    else
-      %{direction: direction} =
-        Utils.get_distance_and_direction_to_positions(
-          bot_state_machine.current_position,
-          bot_state_machine.position_to_move_to
-        )
+        %{
+          action: determine_player_move_action(bot_player, direction),
+          bot_state_machine: bot_state_machine
+        }
+      not is_nil(bot_state_machine.position_to_move_to) ->
+        %{direction: direction} =
+          Utils.get_distance_and_direction_to_positions(
+            bot_state_machine.current_position,
+            bot_state_machine.position_to_move_to
+          )
 
-      %{
-        action: determine_player_move_action(bot_player, direction),
-        bot_state_machine: bot_state_machine
-      }
+        %{
+          action: determine_player_move_action(bot_player, direction),
+          bot_state_machine: bot_state_machine
+        }
+
+      true ->
+        %{
+          action: :idling,
+          bot_state_machine: bot_state_machine
+        }
     end
   end
 
@@ -254,8 +261,7 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
-        shortest_path =
-          AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
@@ -276,8 +282,9 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
-        shortest_path =
-          AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
+        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
@@ -291,7 +298,7 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
 
-      BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
+      not is_nil(bot_state_machine.path_towards_position) and BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
 
       true ->

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -220,9 +220,6 @@ defmodule BotManager.BotStateMachine do
     bot_state_machine =
       determine_position_to_move_to(bot_state_machine, safe_zone_radius, System.get_env("PATHFINDING_TEST") == "true")
 
-    IO.inspect(bot_state_machine.path_towards_position, label: "PATH")
-    IO.inspect(bot_state_machine.position_to_move_to, label: "TARGET POSITION")
-
     # TODO instead of using `get_distance_and_direction_to_positions, use the pathfinding module`
     cond do
       not is_nil(bot_state_machine.path_towards_position) and Enum.count(bot_state_machine.path_towards_position) > 0 ->
@@ -264,11 +261,7 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
-        IO.inspect("CALCULATING SHORTEST PATH")
-        IO.inspect(from, label: "FROM")
-        IO.inspect(to, label: "TO")
         shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
-        |> IO.inspect(label: "SHORTEST PATH")
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do
@@ -290,11 +283,7 @@ defmodule BotManager.BotStateMachine do
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: position_to_move_to.x, y: position_to_move_to.y}
 
-        IO.inspect("CALCULATING SHORTEST PATH")
-        # IO.inspect(from, label: "FROM")
-        # IO.inspect(to, label: "TO")
         shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
-        |> IO.inspect(label: "SHORTEST PATH")
 
         # If we don't have a path, retry finding new position in map
         if Enum.empty?(shortest_path) do

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -28,7 +28,8 @@ defmodule BotManager.BotStateMachineChecker do
           ranged_tracking_range: integer(),
           ranged_attack_distance: integer(),
           melee_attack_distance: integer(),
-          is_melee: boolean() | nil
+          is_melee: boolean() | nil,
+          collision_grid: binary() | nil
         }
 
   defstruct [
@@ -67,7 +68,9 @@ defmodule BotManager.BotStateMachineChecker do
     # The range that the bot has to attack a player in melee
     :melee_attack_distance,
     # The type of attack that the bot has
-    :is_melee
+    :is_melee,
+    # A collision grid used for pathfinding
+    :collision_grid
   ]
 
   @spec new() :: BotManager.BotStateMachineChecker.t()
@@ -90,7 +93,8 @@ defmodule BotManager.BotStateMachineChecker do
       ranged_tracking_range: 1500,
       ranged_attack_distance: 1200,
       melee_attack_distance: 300,
-      is_melee: nil
+      is_melee: nil,
+      collision_grid: nil
     }
   end
 

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -151,24 +151,29 @@ defmodule BotManager.GameSocketHandler do
     obstacles =
       state.game_state.obstacles
       |> Enum.map(fn {obstacle_id, obstacle} ->
-         obstacle = obstacle
+        obstacle =
+          obstacle
           |> Map.from_struct()
           |> Map.take([
-           :id,
-           :shape,
-           :position,
-           :radius,
-           :vertices,
-           :speed,
-           :category,
-           :direction,
-           :is_moving,
-           :name
+            :id,
+            :shape,
+            :position,
+            :radius,
+            :vertices,
+            :speed,
+            :category,
+            :direction,
+            :is_moving,
+            :name
           ])
 
-        obstacle = obstacle
+        obstacle =
+          obstacle
           |> Map.put(:position, %{x: obstacle.position.x, y: obstacle.position.y})
-          |> Map.put(:vertices, Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end))
+          |> Map.put(
+            :vertices,
+            Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end)
+          )
           |> Map.put(:direction, %{x: obstacle.direction.x, y: obstacle.direction.y})
           |> Map.put(:shape, get_shape(obstacle.shape))
           |> Map.put(:category, get_category(obstacle.category))

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -100,7 +100,7 @@ defmodule BotManager.GameSocketHandler do
           # IO.inspect(obstacles, label: "OBSTACLES")
 
           update = %{
-            bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(new_state.config.map.radius, obstacles)),
+            bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(obstacles)),
           }
 
           new_state = Map.merge(new_state, update)
@@ -219,6 +219,7 @@ defmodule BotManager.GameSocketHandler do
   def terminate(close_reason, state) do
     Logger.error("Terminating bot with reason: #{inspect(close_reason)}")
     Logger.error("Terminating bot in state machine step: #{inspect(state.bot_state_machine)}")
+    Logger.error("Stack trace: #{inspect(Process.info(self(), :current_stacktrace) )}")
   end
 
   defp get_shape("polygon"), do: :polygon

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -92,18 +92,50 @@ defmodule BotManager.GameSocketHandler do
         new_state = Map.merge(state, update)
 
         # # only load collision grid once
-        if state.can_build_map && is_nil(new_state.bot_state_machine.collision_grid) and not is_nil(new_state.game_state) and not is_nil(new_state.game_state.obstacles) and not Enum.empty?(new_state.game_state.obstacles) do
-          obstacles = new_state.game_state.obstacles
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.take(Map.from_struct(obstacle), [:id, :shape, :position, :radius, :vertices, :speed, :category, :direction, :is_moving, :name])} end)
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :position, %{x: obstacle.position.x, y: obstacle.position.y})} end)
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :vertices, Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end))} end)
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :direction, %{x: obstacle.direction.x, y: obstacle.direction.y})} end)
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :shape, get_shape(obstacle.shape))} end)
-            |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :category, get_category(obstacle.category))} end)
+        if state.can_build_map && is_nil(new_state.bot_state_machine.collision_grid) and
+             not is_nil(new_state.game_state) and not is_nil(new_state.game_state.obstacles) and
+             not Enum.empty?(new_state.game_state.obstacles) do
+          obstacles =
+            new_state.game_state.obstacles
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id,
+               Map.take(Map.from_struct(obstacle), [
+                 :id,
+                 :shape,
+                 :position,
+                 :radius,
+                 :vertices,
+                 :speed,
+                 :category,
+                 :direction,
+                 :is_moving,
+                 :name
+               ])}
+            end)
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id, Map.put(obstacle, :position, %{x: obstacle.position.x, y: obstacle.position.y})}
+            end)
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id,
+               Map.put(
+                 obstacle,
+                 :vertices,
+                 Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end)
+               )}
+            end)
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id, Map.put(obstacle, :direction, %{x: obstacle.direction.x, y: obstacle.direction.y})}
+            end)
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id, Map.put(obstacle, :shape, get_shape(obstacle.shape))}
+            end)
+            |> Enum.map(fn {obstacle_id, obstacle} ->
+              {obstacle_id, Map.put(obstacle, :category, get_category(obstacle.category))}
+            end)
             |> Map.new()
 
           update = %{
-            bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(obstacles)),
+            bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(obstacles))
           }
 
           new_state = Map.merge(new_state, update)
@@ -228,7 +260,7 @@ defmodule BotManager.GameSocketHandler do
   def terminate(close_reason, state) do
     Logger.error("Terminating bot with reason: #{inspect(close_reason)}")
     Logger.error("Terminating bot in state machine step: #{inspect(state.bot_state_machine)}")
-    Logger.error("Stack trace: #{inspect(Process.info(self(), :current_stacktrace) )}")
+    Logger.error("Stack trace: #{inspect(Process.info(self(), :current_stacktrace))}")
   end
 
   defp get_shape("polygon"), do: :polygon

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -26,6 +26,8 @@ defmodule BotManager.GameSocketHandler do
     end
   end
 
+  @delay_before_map_grid_building_ms 1000
+
   @action_delay_ms 30
 
   def start_link(%{"bot_client" => bot_client, "game_id" => game_id} = params) do
@@ -55,7 +57,7 @@ defmodule BotManager.GameSocketHandler do
     # This delay ensures we give some time to the board liveview to join on time before the game starts.
     # Ideally we should make the collision grid building NIF faster instead of doing this so that we don't have problems
     # running everything on the same machine (for example when testing locally)
-    Process.send_after(self(), :allow_map_build, Enum.random(1000..2000))
+    Process.send_after(self(), :allow_map_build, @delay_before_map_grid_building_ms)
     {:ok, state}
   end
 

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -99,8 +99,6 @@ defmodule BotManager.GameSocketHandler do
             |> Enum.map(fn {obstacle_id, obstacle} -> {obstacle_id, Map.put(obstacle, :category, get_category(obstacle.category))} end)
             |> Map.new()
 
-          # IO.inspect(obstacles, label: "OBSTACLES")
-
           update = %{
             bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(obstacles)),
           }

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -134,22 +134,24 @@ defmodule BotManager.GameSocketHandler do
             end)
             |> Map.new()
 
-          new_state = case AStarNative.build_collision_grid(obstacles) do
-            {:ok, collision_grid} ->
-              update = %{
-                bot_state_machine: Map.put(bot_state_machine, :collision_grid, collision_grid)
-              }
+          new_state =
+            case AStarNative.build_collision_grid(obstacles) do
+              {:ok, collision_grid} ->
+                update = %{
+                  bot_state_machine: Map.put(bot_state_machine, :collision_grid, collision_grid)
+                }
 
-              Map.merge(new_state, update)
-            {:error, reason} ->
-              Logger.error("Grid construction failed with reason: #{inspect(reason)}")
+                Map.merge(new_state, update)
 
-              update = %{
-                can_build_map: false,
-              }
+              {:error, reason} ->
+                Logger.error("Grid construction failed with reason: #{inspect(reason)}")
 
-              Map.merge(new_state, update)
-          end
+                update = %{
+                  can_build_map: false
+                }
+
+                Map.merge(new_state, update)
+            end
 
           {:ok, new_state}
         else

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -134,11 +134,23 @@ defmodule BotManager.GameSocketHandler do
             end)
             |> Map.new()
 
-          update = %{
-            bot_state_machine: Map.put(bot_state_machine, :collision_grid, AStarNative.build_collision_grid(obstacles))
-          }
+          new_state = case AStarNative.build_collision_grid(obstacles) do
+            {:ok, collision_grid} ->
+              update = %{
+                bot_state_machine: Map.put(bot_state_machine, :collision_grid, collision_grid)
+              }
 
-          new_state = Map.merge(new_state, update)
+              Map.merge(new_state, update)
+            {:error, reason} ->
+              Logger.error("Grid construction failed with reason: #{inspect(reason)}")
+
+              update = %{
+                can_build_map: false,
+              }
+
+              Map.merge(new_state, update)
+          end
+
           {:ok, new_state}
         else
           {:ok, new_state}

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -52,6 +52,9 @@ defmodule BotManager.GameSocketHandler do
       |> Map.put(:bot_state_machine, BotStateMachineChecker.new())
       |> Map.put(:can_build_map, false)
 
+    # This delay ensures we give some time to the board liveview to join on time before the game starts.
+    # Ideally we should make the collision grid building NIF faster instead of doing this so that we don't have problems
+    # running everything on the same machine (for example when testing locally)
     Process.send_after(self(), :allow_map_build, Enum.random(1000..2000))
     {:ok, state}
   end

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -84,7 +84,21 @@ defmodule BotManager.GameSocketHandler do
           bot_state_machine: bot_state_machine
         }
 
-        {:ok, Map.merge(state, update)}
+        new_state = Map.merge(state, update)
+
+        # only load collision grid once
+        if is_nil(new_state.bot_state_machine.collision_grid) and Map.has_key?(new_state.game_state, :game_state) and Map.has_key?(new_state.game_state, :obstacles) do
+          update = %{
+            bot_state_machine: %{
+              collision_grid: AStarNative.build_collision_grid(state.game_state.obstacles),
+            }
+          }
+
+          new_state = Map.merge(new_state, update)
+          {:ok, new_state}
+        else
+          {:ok, new_state}
+        end
 
       %{event: {:joined, joined}} ->
         {:ok, Map.merge(state, joined)}

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -274,7 +274,6 @@ defmodule BotManager.GameSocketHandler do
   def terminate(close_reason, state) do
     Logger.error("Terminating bot with reason: #{inspect(close_reason)}")
     Logger.error("Terminating bot in state machine step: #{inspect(state.bot_state_machine)}")
-    Logger.error("Stack trace: #{inspect(Process.info(self(), :current_stacktrace))}")
   end
 
   defp get_shape("polygon"), do: :polygon

--- a/apps/bot_manager/lib/game_socket_handler.ex
+++ b/apps/bot_manager/lib/game_socket_handler.ex
@@ -149,8 +149,9 @@ defmodule BotManager.GameSocketHandler do
     obstacles =
       state.game_state.obstacles
       |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id,
-         Map.take(Map.from_struct(obstacle), [
+         obstacle = obstacle
+          |> Map.from_struct()
+          |> Map.take([
            :id,
            :shape,
            :position,
@@ -161,27 +162,16 @@ defmodule BotManager.GameSocketHandler do
            :direction,
            :is_moving,
            :name
-         ])}
-      end)
-      |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id, Map.put(obstacle, :position, %{x: obstacle.position.x, y: obstacle.position.y})}
-      end)
-      |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id,
-         Map.put(
-           obstacle,
-           :vertices,
-           Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end)
-         )}
-      end)
-      |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id, Map.put(obstacle, :direction, %{x: obstacle.direction.x, y: obstacle.direction.y})}
-      end)
-      |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id, Map.put(obstacle, :shape, get_shape(obstacle.shape))}
-      end)
-      |> Enum.map(fn {obstacle_id, obstacle} ->
-        {obstacle_id, Map.put(obstacle, :category, get_category(obstacle.category))}
+          ])
+
+        obstacle = obstacle
+          |> Map.put(:position, %{x: obstacle.position.x, y: obstacle.position.y})
+          |> Map.put(:vertices, Enum.map(obstacle.vertices.positions, fn position -> %{x: position.x, y: position.y} end))
+          |> Map.put(:direction, %{x: obstacle.direction.x, y: obstacle.direction.y})
+          |> Map.put(:shape, get_shape(obstacle.shape))
+          |> Map.put(:category, get_category(obstacle.category))
+
+        {obstacle_id, obstacle}
       end)
       |> Map.new()
 

--- a/apps/bot_manager/native/astarnative/src/collision_detection.rs
+++ b/apps/bot_manager/native/astarnative/src/collision_detection.rs
@@ -9,30 +9,6 @@ pub(crate) fn point_circle_collision(point: &Entity, circle: &Entity) -> bool {
     let distance = calculate_distance(&point.position, &circle.position);
     distance <= circle.radius
 }
-pub(crate) fn point_polygon_collision(point: &Entity, polygon: &Entity) -> bool {
-    let mut collision = false;
-    for current in 0..polygon.vertices.len() {
-        let mut next = current + 1;
-        if next == polygon.vertices.len() {
-            next = 0
-        };
-
-        let current_vertex = polygon.vertices[current];
-        let next_vertex = polygon.vertices[next];
-
-        if ((current_vertex.y >= point.position.y && next_vertex.y < point.position.y)
-            || (current_vertex.y < point.position.y && next_vertex.y >= point.position.y))
-            && (point.position.x
-                < (next_vertex.x - current_vertex.x) * (point.position.y - current_vertex.y)
-                    / (next_vertex.y - current_vertex.y)
-                    + current_vertex.x)
-        {
-            collision = !collision;
-        }
-    }
-
-    collision
-}
 
 /*
  * Determines if a collision has occured between a line and a circle
@@ -79,44 +55,6 @@ pub(crate) fn line_circle_collision(line: &Entity, circle: &Entity) -> bool {
 }
 
 /*
- * Determines if a collision has occured between two circles
- * If the distance between the centers of the circles is less than
- * the sum of the radius, a collision has occured
- */
-pub(crate) fn circle_circle_collision(circle_1: &Entity, circle_2: &Entity) -> bool {
-    let distance = calculate_distance(&circle_1.position, &circle_2.position);
-    distance <= circle_1.radius + circle_2.radius
-}
-
-/*
- * Determines if a collision has occured between a circle and a polygon
- *
- */
-pub(crate) fn circle_polygon_collision(circle: &Entity, polygon: &Entity) -> bool {
-    // For each line in the polygon, check if there is a collision between the line and the circle
-    // If there is a collision, return true
-    for current in 0..polygon.vertices.len() {
-        let mut next = current + 1;
-        if next == polygon.vertices.len() {
-            next = 0
-        };
-
-        let current_line =
-            Entity::new_line(0, vec![polygon.vertices[current], polygon.vertices[next]]);
-
-        let collision = line_circle_collision(&current_line, circle);
-        if collision {
-            return true;
-        };
-    }
-
-    // Check if the center of the circle is inside the polygon
-    // If you doesn't want to check if the circle is inside the polygon,
-    // return false instead of calling point_polygon_colision
-    point_polygon_colision(circle, polygon)
-}
-
-/*
  * Determines if a collision has occured between a line and a polygon
  * If the distance between vertex 1 and the point and vertex 2 and the point
  * is equal (with a little bufer) to the distance between vertex 1 and vertex 2,
@@ -130,34 +68,6 @@ pub(crate) fn line_point_colision(line: &Entity, point: &Entity) -> bool {
     let buffer = 0.1;
 
     d1 + d2 >= line_length - buffer && d1 + d2 <= line_length + buffer
-}
-
-/*
- * Determines if a collision has occured between a point and a polygon
- */
-pub(crate) fn point_polygon_colision(point: &Entity, polygon: &Entity) -> bool {
-    let mut collision = false;
-    for current in 0..polygon.vertices.len() {
-        let mut next = current + 1;
-        if next == polygon.vertices.len() {
-            next = 0
-        };
-
-        let current_vertex = polygon.vertices[current];
-        let next_vertex = polygon.vertices[next];
-
-        if ((current_vertex.y >= point.position.y && next_vertex.y < point.position.y)
-            || (current_vertex.y < point.position.y && next_vertex.y >= point.position.y))
-            && (point.position.x
-                < (next_vertex.x - current_vertex.x) * (point.position.y - current_vertex.y)
-                    / (next_vertex.y - current_vertex.y)
-                    + current_vertex.x)
-        {
-            collision = !collision;
-        }
-    }
-
-    collision
 }
 
 pub(crate) fn line_polygon_collision(line: &Entity, polygon: &Entity) -> bool {

--- a/apps/bot_manager/native/astarnative/src/collision_detection.rs
+++ b/apps/bot_manager/native/astarnative/src/collision_detection.rs
@@ -1,0 +1,216 @@
+use crate::{Entity, Position};
+
+/*
+ * Determines if a collision has occured between a point and a circle
+ * If the distance between the point and the center of the circle is less
+ * than the radius of the circle, a collision has occured
+ */
+pub(crate) fn point_circle_collision(point: &Entity, circle: &Entity) -> bool {
+    let distance = calculate_distance(&point.position, &circle.position);
+    distance <= circle.radius
+}
+pub(crate) fn point_polygon_collision(point: &Entity, polygon: &Entity) -> bool {
+    let mut collision = false;
+    for current in 0..polygon.vertices.len() {
+        let mut next = current + 1;
+        if next == polygon.vertices.len() {
+            next = 0
+        };
+
+        let current_vertex = polygon.vertices[current];
+        let next_vertex = polygon.vertices[next];
+
+        if ((current_vertex.y >= point.position.y && next_vertex.y < point.position.y)
+            || (current_vertex.y < point.position.y && next_vertex.y >= point.position.y))
+            && (point.position.x
+                < (next_vertex.x - current_vertex.x) * (point.position.y - current_vertex.y)
+                    / (next_vertex.y - current_vertex.y)
+                    + current_vertex.x)
+        {
+            collision = !collision;
+        }
+    }
+
+    collision
+}
+
+/*
+ * Determines if a collision has occured between a line and a circle
+ * If the distance between the center of the circle and the closest point
+ * of the line is less than the radius of the circle, a collision has occured
+ * Also that closest point should be on the segment
+ */
+pub(crate) fn line_circle_collision(line: &Entity, circle: &Entity) -> bool {
+    // Check if the vertices are inside the circle
+    let point_1 = Entity::new_point(0, line.vertices[0]);
+    let inside_1 = point_circle_collision(&point_1, circle);
+    let point_2 = Entity::new_point(0, line.vertices[1]);
+    let inside_2 = point_circle_collision(&point_2, circle);
+    if inside_1 || inside_2 {
+        return true;
+    };
+
+    // Find the closest point on the line to the circle
+    let dist_x = point_1.position.x - point_2.position.x;
+    let dist_y = point_1.position.y - point_2.position.y;
+    let line_length = ((dist_x * dist_x) + (dist_y * dist_y)).sqrt();
+
+    let dot = (((circle.position.x - point_1.position.x)
+        * (point_2.position.x - point_1.position.x))
+        + ((circle.position.y - point_1.position.y) * (point_2.position.y - point_1.position.y)))
+        / line_length.powi(2);
+
+    let closest_point = Entity::new_point(
+        0,
+        Position {
+            x: point_1.position.x + (dot * (point_2.position.x - point_1.position.x)),
+            y: point_1.position.y + (dot * (point_2.position.y - point_1.position.y)),
+        },
+    );
+
+    // Check if the closest point is on the line
+    let on_line = line_point_colision(line, &closest_point);
+    if !on_line {
+        return false;
+    };
+
+    // Check if the closest point is inside the circle
+    point_circle_collision(&closest_point, circle)
+}
+
+/*
+ * Determines if a collision has occured between two circles
+ * If the distance between the centers of the circles is less than
+ * the sum of the radius, a collision has occured
+ */
+pub(crate) fn circle_circle_collision(circle_1: &Entity, circle_2: &Entity) -> bool {
+    let distance = calculate_distance(&circle_1.position, &circle_2.position);
+    distance <= circle_1.radius + circle_2.radius
+}
+
+/*
+ * Determines if a collision has occured between a circle and a polygon
+ *
+ */
+pub(crate) fn circle_polygon_collision(circle: &Entity, polygon: &Entity) -> bool {
+    // For each line in the polygon, check if there is a collision between the line and the circle
+    // If there is a collision, return true
+    for current in 0..polygon.vertices.len() {
+        let mut next = current + 1;
+        if next == polygon.vertices.len() {
+            next = 0
+        };
+
+        let current_line =
+            Entity::new_line(0, vec![polygon.vertices[current], polygon.vertices[next]]);
+
+        let collision = line_circle_collision(&current_line, circle);
+        if collision {
+            return true;
+        };
+    }
+
+    // Check if the center of the circle is inside the polygon
+    // If you doesn't want to check if the circle is inside the polygon,
+    // return false instead of calling point_polygon_colision
+    point_polygon_colision(circle, polygon)
+}
+
+/*
+ * Determines if a collision has occured between a line and a polygon
+ * If the distance between vertex 1 and the point and vertex 2 and the point
+ * is equal (with a little bufer) to the distance between vertex 1 and vertex 2,
+ * a collision has occured
+ */
+pub(crate) fn line_point_colision(line: &Entity, point: &Entity) -> bool {
+    let d1 = calculate_distance(&point.position, &line.vertices[0]);
+    let d2 = calculate_distance(&point.position, &line.vertices[1]);
+    let line_length = calculate_distance(&line.vertices[0], &line.vertices[1]);
+
+    let buffer = 0.1;
+
+    d1 + d2 >= line_length - buffer && d1 + d2 <= line_length + buffer
+}
+
+/*
+ * Determines if a collision has occured between a point and a polygon
+ */
+pub(crate) fn point_polygon_colision(point: &Entity, polygon: &Entity) -> bool {
+    let mut collision = false;
+    for current in 0..polygon.vertices.len() {
+        let mut next = current + 1;
+        if next == polygon.vertices.len() {
+            next = 0
+        };
+
+        let current_vertex = polygon.vertices[current];
+        let next_vertex = polygon.vertices[next];
+
+        if ((current_vertex.y >= point.position.y && next_vertex.y < point.position.y)
+            || (current_vertex.y < point.position.y && next_vertex.y >= point.position.y))
+            && (point.position.x
+                < (next_vertex.x - current_vertex.x) * (point.position.y - current_vertex.y)
+                    / (next_vertex.y - current_vertex.y)
+                    + current_vertex.x)
+        {
+            collision = !collision;
+        }
+    }
+
+    collision
+}
+
+pub(crate) fn line_polygon_collision(line: &Entity, polygon: &Entity) -> bool {
+    for current_vertex_index in 0..polygon.vertices.len() {
+        let mut next_vertex_index = current_vertex_index + 1;
+        if next_vertex_index == polygon.vertices.len() {
+            next_vertex_index = 0
+        };
+        let current_vertex = polygon.vertices[current_vertex_index];
+        let next_vertex = polygon.vertices[next_vertex_index];
+
+        let polygon_line = Entity::new_line(1, vec![current_vertex, next_vertex]);
+
+        if line_line_collision(line, &polygon_line) {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub(crate) fn line_line_collision(line: &Entity, other_line: &Entity) -> bool {
+    let line_first_vertex = line.vertices[0];
+    let line_second_vertex = line.vertices[1];
+    let other_line_first_vertex = other_line.vertices[0];
+    let other_line_second_vertex = other_line.vertices[1];
+
+    let uA = ((other_line_second_vertex.x - other_line_first_vertex.x)
+        * (line_first_vertex.y - other_line_first_vertex.y)
+        - (other_line_second_vertex.y - other_line_first_vertex.y)
+            * (line_first_vertex.x - other_line_first_vertex.x))
+        / ((other_line_second_vertex.y - other_line_first_vertex.y)
+            * (line_second_vertex.x - line_first_vertex.x)
+            - (other_line_second_vertex.x - other_line_first_vertex.x)
+                * (line_second_vertex.y - line_first_vertex.y));
+
+    let uB = ((line_second_vertex.x - line_first_vertex.x)
+        * (line_first_vertex.y - other_line_first_vertex.y)
+        - (line_second_vertex.y - line_first_vertex.y)
+            * (line_first_vertex.x - other_line_first_vertex.x))
+        / ((other_line_second_vertex.y - other_line_first_vertex.y)
+            * (line_second_vertex.x - line_first_vertex.x)
+            - (other_line_second_vertex.x - other_line_first_vertex.x)
+                * (line_second_vertex.y - line_first_vertex.y));
+
+    (0.0..=1.0).contains(&uA) && (0.0..=1.0).contains(&uB)
+}
+
+/*
+ * Calculates the distance between two positions
+ */
+pub(crate) fn calculate_distance(a: &Position, b: &Position) -> f32 {
+    let x = a.x - b.x;
+    let y = a.y - b.y;
+    (x.powi(2) + y.powi(2)).sqrt()
+}

--- a/apps/bot_manager/native/astarnative/src/entity.rs
+++ b/apps/bot_manager/native/astarnative/src/entity.rs
@@ -78,21 +78,6 @@ impl Entity {
         }
     }
 
-    pub fn new_polygon(id: u64, vertices: Vec<Position>) -> Entity {
-        Entity {
-            id,
-            shape: Shape::Polygon,
-            position: Position { x: 0.0, y: 0.0 },
-            radius: 0.0,
-            vertices,
-            speed: 0.0,
-            category: Category::Obstacle,
-            direction: Direction { x: 0.0, y: 0.0 },
-            is_moving: false,
-            name: format!("{}{}", "Polygon ", id),
-        }
-    }
-
     pub fn collides_with(&mut self, entities: &Vec<Entity>) -> Vec<u64> {
         let mut result = Vec::new();
 

--- a/apps/bot_manager/native/astarnative/src/entity.rs
+++ b/apps/bot_manager/native/astarnative/src/entity.rs
@@ -1,0 +1,125 @@
+use super::Position;
+use rustler::{NifMap, NifTaggedEnum};
+use serde::Deserialize;
+
+use crate::collision_detection::{
+    line_circle_collision, line_polygon_collision,
+};
+
+#[derive(NifMap, Clone, Copy)]
+pub struct Direction {
+    pub(crate) x: f32,
+    pub(crate) y: f32,
+}
+
+#[derive(NifMap, Clone)]
+pub struct Entity {
+    pub id: u64,
+    pub shape: Shape,
+    pub position: Position,
+    pub radius: f32,
+    pub vertices: Vec<Position>,
+    pub speed: f32,
+    pub category: Category,
+    pub direction: Direction,
+    pub is_moving: bool,
+    pub name: String,
+}
+
+#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq)]
+pub enum Shape {
+    Circle,
+    Polygon,
+    Point,
+    Line,
+}
+
+#[derive(Deserialize, NifTaggedEnum, Clone, PartialEq)]
+pub enum Category {
+    Player,
+    Projectile,
+    Obstacle,
+    PowerUp,
+    Pool,
+    Item,
+    Bush,
+    Crate,
+    Trap,
+}
+
+impl Entity {
+    pub fn new_point(id: u64, position: Position) -> Entity {
+        Entity {
+            id,
+            shape: Shape::Point,
+            position,
+            radius: 0.0,
+            vertices: Vec::new(),
+            speed: 0.0,
+            category: Category::Obstacle,
+            direction: Direction { x: 0.0, y: 0.0 },
+            is_moving: false,
+            name: format!("{}{}", "Point ", id),
+        }
+    }
+
+    pub fn new_line(id: u64, vertices: Vec<Position>) -> Entity {
+        Entity {
+            id,
+            shape: Shape::Line,
+            position: Position { x: 0.0, y: 0.0 },
+            radius: 0.0,
+            vertices,
+            speed: 0.0,
+            category: Category::Obstacle,
+            direction: Direction { x: 0.0, y: 0.0 },
+            is_moving: false,
+            name: format!("{}{}", "Line ", id),
+        }
+    }
+
+    pub fn new_polygon(id: u64, vertices: Vec<Position>) -> Entity {
+        Entity {
+            id,
+            shape: Shape::Polygon,
+            position: Position { x: 0.0, y: 0.0 },
+            radius: 0.0,
+            vertices,
+            speed: 0.0,
+            category: Category::Obstacle,
+            direction: Direction { x: 0.0, y: 0.0 },
+            is_moving: false,
+            name: format!("{}{}", "Polygon ", id),
+        }
+    }
+
+    pub fn collides_with(&mut self, entities: &Vec<Entity>) -> Vec<u64> {
+        let mut result = Vec::new();
+
+        for entity in entities {
+            if entity.id == self.id {
+                continue;
+            }
+
+            let self_shape = self.shape.clone();
+            let entity_shape = entity.shape.clone();
+
+            match (self_shape, entity_shape) {
+                (Shape::Line, Shape::Circle) => {
+                    if line_circle_collision(self, entity) {
+                        result.push(entity.id);
+                    }
+                }
+
+                (Shape::Line, Shape::Polygon) => {
+                    if line_polygon_collision(self, entity) {
+                        result.push(entity.id);
+                    }
+                }
+                _ => todo!("Collision matching not implemented"),
+            }
+        }
+
+        result
+    }
+}

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -11,7 +11,7 @@ use position::Position;
 use entity::Entity;
 use rustler::{Binary, OwnedBinary};
 
-const GRID_CELL_SIZE: f32 = 50.0;
+const GRID_CELL_SIZE: f32 = 100.0;
 const WORLD_RADIUS: f32 = 15000.0;
 const NUM_ROWS: i64 = (WORLD_RADIUS * 2.0 / GRID_CELL_SIZE) as i64;
 const NUM_COLS: i64 = (WORLD_RADIUS * 2.0 / GRID_CELL_SIZE) as i64;

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -37,7 +37,7 @@ fn a_star_shortest_path<'a>(from: Position, to: Position, collision_grid: Binary
     if let AStarPathResult::Found(path_in_grid) = a_star_find_path(start, goal, grid) {
         path_in_grid
             .iter()
-            .map(grid_to_world)
+            .map(|grid_position| Position::add(&grid_to_world(grid_position), &Position {x: GRID_CELL_SIZE / 2.0, y: GRID_CELL_SIZE / 2.0}))
             .collect::<Vec<Position>>()
     } else {
         Vec::new()

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -169,13 +169,4 @@ fn grid_to_world(grid_pos: &(i64, i64)) -> Position {
     }
 }
 
-/// Check players inside the player_id radius
-/// Return a list of the players id inside the radius Vec<player_id>
-fn check_collisions(entity: Entity, entities: HashMap<u64, Entity>) -> Vec<u64> {
-    let mut entity: Entity = entity;
-    let ent = entities.into_values().collect();
-
-    entity.collides_with(&ent)
-}
-
 rustler::init!("Elixir.AStarNative", [a_star_shortest_path, build_collision_grid]);

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -179,4 +179,4 @@ fn check_collisions(entity: Entity, entities: HashMap<u64, Entity>) -> Vec<u64> 
     entity.collides_with(&ent)
 }
 
-rustler::init!("Elixir.AStarNative", [a_star_shortest_path]);
+rustler::init!("Elixir.AStarNative", [a_star_shortest_path, build_collision_grid]);

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -11,7 +11,7 @@ use position::Position;
 use entity::Entity;
 use rustler::{Binary, OwnedBinary};
 
-const GRID_CELL_SIZE: f32 = 100.0;
+const GRID_CELL_SIZE: f32 = 150.0;
 const WORLD_RADIUS: f32 = 15000.0;
 const NUM_ROWS: i64 = (WORLD_RADIUS * 2.0 / GRID_CELL_SIZE) as i64;
 const NUM_COLS: i64 = (WORLD_RADIUS * 2.0 / GRID_CELL_SIZE) as i64;

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -45,7 +45,7 @@ fn a_star_shortest_path<'a>(from: Position, to: Position, collision_grid: Binary
 }
 
 #[rustler::nif()]
-fn build_collision_grid<'a>(env: rustler::Env<'a>, obstacles: HashMap<u64, Entity>) -> Result<Binary<'a>, String>  {
+fn build_collision_grid<'a>(env: Env<'a>, obstacles: HashMap<u64, Entity>) -> Result<Binary<'a>, String>  {
     let grid : Option<OwnedBinary> = OwnedBinary::new(NUM_COLS as usize * NUM_ROWS as usize);
 
     if grid.is_none() {

--- a/apps/bot_manager/native/astarnative/src/lib.rs
+++ b/apps/bot_manager/native/astarnative/src/lib.rs
@@ -48,7 +48,6 @@ fn a_star_shortest_path<'a>(from: Position, to: Position, collision_grid: Binary
 fn build_collision_grid(obstacles: HashMap<u64, Entity>) -> OwnedBinary {
     // TODO: remove unwrap
     let mut grid : OwnedBinary = OwnedBinary::new(NUM_COLS as usize * NUM_ROWS as usize).unwrap();
-    let mut collisions_grid: Vec<Vec<bool>> = vec![vec![false; NUM_ROWS as usize]; NUM_COLS as usize];
     let obstacles = obstacles.into_values().collect::<Vec<_>>();
 
     for j in 0..NUM_COLS {
@@ -69,8 +68,6 @@ fn build_collision_grid(obstacles: HashMap<u64, Entity>) -> OwnedBinary {
             grid[j as usize * NUM_COLS as usize + i as usize] |= (!line2.collides_with(&obstacles).is_empty()) as u8;
             grid[j as usize * NUM_COLS as usize + i as usize] |= (!line3.collides_with(&obstacles).is_empty()) as u8;
             grid[j as usize * NUM_COLS as usize + i as usize] |= (!line4.collides_with(&obstacles).is_empty()) as u8;
-
-            collisions_grid[j as usize][i as usize] = grid[j as usize * NUM_COLS as usize + i as usize] == 1;
         }
     }
 

--- a/apps/bot_manager/native/astarnative/src/position.rs
+++ b/apps/bot_manager/native/astarnative/src/position.rs
@@ -7,36 +7,11 @@ pub struct Position {
 }
 
 impl Position {
-    pub fn normalize(&mut self) {
-        let length = (self.x.powi(2) + self.y.powi(2)).sqrt();
-        self.x /= length;
-        self.y /= length;
-    }
-
     pub fn add(a: &Position, b: &Position) -> Position {
         Position {
             x: a.x + b.x,
             y: a.y + b.y,
         }
-    }
-    pub fn sub(a: &Position, b: &Position) -> Position {
-        Position {
-            x: a.x - b.x,
-            y: a.y - b.y,
-        }
-    }
-
-    pub fn mult(a: &Position, mult: f32) -> Position {
-        Position {
-            x: a.x * mult,
-            y: a.y * mult,
-        }
-    }
-
-    pub fn distance_to_position(&self, other_position: &Position) -> f32 {
-        let x = self.x - other_position.x;
-        let y = self.y - other_position.y;
-        (x.powi(2) + y.powi(2)).sqrt()
     }
 }
 

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -75,7 +75,7 @@ export const BoardGame = function () {
 
       // Grid properties
       const worldRadius = 15000;
-      const gridCellSize = 100;  // Size of each cell in the grid (in pixels)
+      const gridCellSize = 100 / 5;  // Size of each cell in the grid (in pixels)
       const numRows = 2 * worldRadius / gridCellSize;
       const numCols = 2 * worldRadius / gridCellSize;      
 

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -74,10 +74,15 @@ export const BoardGame = function () {
       pathfindingGrid.lineStyle(1, 0x000000, 1);
 
       // Grid properties
+      
+      // Web board is smaller than actual world radius so we need to rescale
+      const mocked_board_radius = 3000;
       const worldRadius = 15000;
-      const gridCellSize = 150 / 5;  // Size of each cell in the grid (in pixels)
-      const numRows = 2 * worldRadius / gridCellSize;
-      const numCols = 2 * worldRadius / gridCellSize;      
+
+      const back_size_to_front_ratio = mocked_board_radius / worldRadius;
+      const gridCellSize = 150 * back_size_to_front_ratio;  // Size of each cell in the grid (in pixels)
+      const numRows = 2 * mocked_board_radius / gridCellSize;
+      const numCols = 2 * mocked_board_radius / gridCellSize;      
 
       // Draw the grid lines
       for (let row = 0; row <= numRows; row++) {

--- a/apps/game_client/assets/js/hooks/board_game.js
+++ b/apps/game_client/assets/js/hooks/board_game.js
@@ -75,7 +75,7 @@ export const BoardGame = function () {
 
       // Grid properties
       const worldRadius = 15000;
-      const gridCellSize = 100 / 5;  // Size of each cell in the grid (in pixels)
+      const gridCellSize = 150 / 5;  // Size of each cell in the grid (in pixels)
       const numRows = 2 * worldRadius / gridCellSize;
       const numCols = 2 * worldRadius / gridCellSize;      
 


### PR DESCRIPTION
## Motivation

On #1112 the a* pathfinding algorithm was added but the terrain was hardcoded. We need to take the server's obstacles and use that instead.

Closes #1022

## Summary of changes

- Added new NIF to compute collisions grid, for each cell it tells whether there is an obstacle overlapping with the grid or not.
  - Now the A* function takes the collision grid as part of the input
  - The grid is built only once at the start of the game
- Fixed a small issue with displaying the grid on the arena web liveview (we were not taking into account the scaling factor to map the backend positions into frontend positions and so we were seing a grid different than the actual one)
- Also offsetted the A* path waypoints to be in the middle of tiles

> [!NOTE]  
> When testing locally I was having an issue where the liveview of the board would repeatedly crash. After debugging a bit I found out this was due to the collisions grid building being a bit too slow which in turn was preventing the liveview to mount and missing the first updates. This exposed another issue which is that clients that connect late receive only a diff instead of the full state and have errors because that's not contemplated (and they need at least one full snapshot anyways). Created issue to track this > #1128

## How to test it?

1. run `export PATHFINDING_TEST=true` before starting the server
2. start the server and launch a game using either unity or the web client
3. watch bots wander around

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
