### PR TITLE
1123 use pathfinding in actual bot behavior

### DIFF
--- a/apps/arena/lib/arena/bots/bot.ex
+++ b/apps/arena/lib/arena/bots/bot.ex
@@ -125,10 +125,15 @@ defmodule Arena.Bots.Bot do
 
   defp update_block_attack_state(state), do: state
 
-  defp send_current_action(%{current_action: %{action: {:move, direction}, sent: false}, bot_player: bot_player} = state) do
+  defp send_current_action(
+         %{current_action: %{action: {:move, direction}, sent: false}, bot_player: bot_player} = state
+       ) do
     {:player, aditional_info} = bot_player.aditional_info
 
-    if Enum.all?(aditional_info.current_actions, fn current_action -> (current_action.action != :EXECUTING_SKILL_1 or not state.bot_skills.basic.block_movement) and (current_action.action != :EXECUTING_SKILL_2 or not state.bot_skills.ultimate.block_movement) end) do
+    if Enum.all?(aditional_info.current_actions, fn current_action ->
+         (current_action.action != :EXECUTING_SKILL_1 or not state.bot_skills.basic.block_movement) and
+           (current_action.action != :EXECUTING_SKILL_2 or not state.bot_skills.ultimate.block_movement)
+       end) do
       timestamp = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
       Arena.GameUpdater.move(state.game_pid, state.bot_player.id, direction, timestamp)
     end

--- a/apps/arena/lib/arena/bots/bot.ex
+++ b/apps/arena/lib/arena/bots/bot.ex
@@ -73,7 +73,7 @@ defmodule Arena.Bots.Bot do
   end
 
   defp maybe_update_state_params(state, game_state, config) do
-    if System.get_env("PATHFINDING_TEST") == "true" and is_nil(state.bot_state_machine.collision_grid) do
+    if is_nil(state.bot_state_machine.collision_grid) do
       PathfindingGrid.get_map_collision_grid(config.map.name, self())
     end
 
@@ -141,6 +141,6 @@ defmodule Arena.Bots.Bot do
     Logger.error("Bot #{state.bot_id} terminating: #{inspect(reason)}")
   end
 
-  defp min_decision_delay_ms(), do: if(System.get_env("PATHFINDING_TEST") == "true", do: 100, else: 750)
-  defp max_decision_delay_ms(), do: if(System.get_env("PATHFINDING_TEST") == "true", do: 150, else: 1250)
+  defp min_decision_delay_ms(), do: 100
+  defp max_decision_delay_ms(), do: 150
 end

--- a/apps/arena/lib/arena/bots/pathfinding_grid.ex
+++ b/apps/arena/lib/arena/bots/pathfinding_grid.ex
@@ -12,9 +12,7 @@ defmodule Arena.Bots.PathfindingGrid do
   end
 
   def init(_opts) do
-    if System.get_env("PATHFINDING_TEST") == "true" do
-      Process.send_after(self(), :update_config, 1_000)
-    end
+    Process.send_after(self(), :update_config, 1_000)
 
     {:ok, %{}}
   end

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -312,59 +312,46 @@ defmodule BotManager.BotStateMachine do
     end
   end
 
+  defp determine_position_to_move_to(%{collision_grid: nil} = bot_state_machine, _safe_zone_radius) do
+    bot_state_machine
+  end
+
   defp determine_position_to_move_to(bot_state_machine, safe_zone_radius) do
     cond do
-      is_nil(bot_state_machine.collision_grid) ->
-        bot_state_machine
-
       is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ->
-        position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
-
-        from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
-        to = %{x: position_to_move_to.x, y: position_to_move_to.y}
-
-        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
-
-        # If we don't have a path, retry finding new position in map
-        if Enum.empty?(shortest_path) do
-          Map.put(bot_state_machine, :path_towards_position, nil)
-          |> Map.put(:position_to_move_to, nil)
-        else
-          Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
-          |> Map.put(
-            :path_towards_position,
-            shortest_path
-          )
-          |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
-        end
+        try_pick_random_position_to_move_to(bot_state_machine, safe_zone_radius)
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and
           BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
-        position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
-
-        from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
-        to = %{x: position_to_move_to.x, y: position_to_move_to.y}
-
-        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
-
-        # If we don't have a path, retry finding new position in map
-        if Enum.empty?(shortest_path) do
-          Map.put(bot_state_machine, :path_towards_position, nil)
-          |> Map.put(:position_to_move_to, nil)
-        else
-          Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
-          |> Map.put(
-            :path_towards_position,
-            shortest_path
-          )
-          |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
-        end
+        try_pick_random_position_to_move_to(bot_state_machine, safe_zone_radius)
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
 
       true ->
         bot_state_machine
+    end
+  end
+
+  defp try_pick_random_position_to_move_to(bot_state_machine, safe_zone_radius) do
+    position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
+
+    from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
+    to = %{x: position_to_move_to.x, y: position_to_move_to.y}
+
+    shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
+    # If we don't have a path, retry finding new position in map
+    if Enum.empty?(shortest_path) do
+      Map.put(bot_state_machine, :path_towards_position, nil)
+      |> Map.put(:position_to_move_to, nil)
+    else
+      Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
+      |> Map.put(
+        :path_towards_position,
+        shortest_path
+      )
+      |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
     end
   end
 end

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -78,6 +78,11 @@ defmodule BotManager.BotStateMachine do
     |> Map.put(:last_time_tracking_exited, :os.system_time(:millisecond))
   end
 
+  defp exit_state(bot_state_machine, :attacking) do
+    bot_state_machine
+    |> Map.put(:last_time_attacking_exited, :os.system_time(:millisecond))
+  end
+
   defp exit_state(bot_state_machine, _exited_state) do
     bot_state_machine
   end

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -19,7 +19,8 @@ defmodule BotManager.BotStateMachine do
     %{action: {:move, %{x: 0, y: 0}}, bot_state_machine: bot_state_machine}
   end
 
-  def decide_action(%{bot_player: %{aditional_info: {:player, %{health: health}}}, bot_state_machine: bot_state_machine}) when health <= 0 do
+  def decide_action(%{bot_player: %{aditional_info: {:player, %{health: health}}}, bot_state_machine: bot_state_machine})
+      when health <= 0 do
     %{action: {:move, %{x: 0, y: 0}}, bot_state_machine: bot_state_machine}
   end
 
@@ -224,6 +225,7 @@ defmodule BotManager.BotStateMachine do
       )
 
     new_progress = min(bot_state_machine.cap_for_basic_skill * 3, bot_state_machine.progress_for_basic_skill + distance)
+
     bot_state_machine =
       Map.put(bot_state_machine, :progress_for_basic_skill, new_progress)
 

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -141,7 +141,7 @@ defmodule BotManager.BotStateMachine do
       Utils.map_directions_to_players(
         game_state.players,
         bot_player,
-        Utils.get_action_distance_based_on_action_type(
+        Utils.get_action_distance_by_type(
           bot_state_machine.is_melee,
           bot_state_machine.melee_tracking_range,
           bot_state_machine.ranged_tracking_range
@@ -154,7 +154,6 @@ defmodule BotManager.BotStateMachine do
 
     cond do
       is_nil(bot_state_machine.path_towards_position) ->
-        IO.inspect("NIL PATH, setting new one")
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: closest_player.position.x, y: closest_player.position.y}
 
@@ -173,7 +172,6 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
       Enum.empty?(bot_state_machine.path_towards_position) && time_since_last_position_change >= bot_state_machine.time_amount_to_change_position ->
-        IO.inspect("EMPTY PATH, setting new one")
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: closest_player.position.x, y: closest_player.position.y}
 
@@ -192,7 +190,6 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
       Vector.distance(bot_state_machine.position_to_move_to, closest_player.position) > @path_recalculation_min_diff ->
-        IO.inspect("PLAYER MOVED, RECALCULATING PATH")
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: closest_player.position.x, y: closest_player.position.y}
 
@@ -209,8 +206,7 @@ defmodule BotManager.BotStateMachine do
           )
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
-      BotStateMachineChecker.current_waypoint_reached?(bot_player) ->
-        IO.inspect("GOING TO NEXT WAYPOINT")
+      BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
       true ->
         bot_state_machine
@@ -322,7 +318,7 @@ defmodule BotManager.BotStateMachine do
       is_nil(bot_state_machine.collision_grid) ->
         bot_state_machine
 
-      is_nil(bot_state_machine.path_towards_position) ->
+      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ->
         position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
 
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -10,7 +10,6 @@ defmodule BotManager.BotStateMachine do
 
   @skill_1_key "1"
   @skill_2_key "2"
-  # @dash_skill_key "3"
 
   # The minimum distance a tracked player has to move for the tracking path to get recalculated
   @path_recalculation_min_diff 300

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -19,6 +19,10 @@ defmodule BotManager.BotStateMachine do
     %{action: {:move, %{x: 0, y: 0}}, bot_state_machine: bot_state_machine}
   end
 
+  def decide_action(%{bot_player: %{aditional_info: {:player, %{health: health}}}, bot_state_machine: bot_state_machine}) when health <= 0 do
+    %{action: {:move, %{x: 0, y: 0}}, bot_state_machine: bot_state_machine}
+  end
+
   @doc """
   This function will decide the next action for the bot.
   """

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -130,7 +130,7 @@ defmodule BotManager.BotStateMachine do
 
   # This function will determine the direction and action the bot will take.
   defp determine_player_move_action(bot_player, direction) do
-    {:player, bot_player_info} = bot_player.aditional_info
+    {:player, _bot_player_info} = bot_player.aditional_info
 
     # TODO: consider if we want to dash in the desired direction instead of just moving
     {:move, direction}

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -147,13 +147,17 @@ defmodule BotManager.BotStateMachine do
           bot_state_machine.ranged_tracking_range
         )
       )
+
     closest_player = Enum.min_by(players_with_distances, & &1.distance)
 
     cond do
-      is_nil(bot_state_machine.path_towards_position) or Enum.empty?(bot_state_machine.path_towards_position) or Vector.distance(bot_state_machine.position_to_move_to, closest_player.position) > @path_recalculation_min_diff ->
+      is_nil(bot_state_machine.path_towards_position) or Enum.empty?(bot_state_machine.path_towards_position) or
+          Vector.distance(bot_state_machine.position_to_move_to, closest_player.position) > @path_recalculation_min_diff ->
         try_pathing_towards(bot_state_machine, closest_player.position)
+
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
+
       true ->
         bot_state_machine
     end
@@ -164,7 +168,9 @@ defmodule BotManager.BotStateMachine do
       move(bot_player, bot_state_machine, game_state.zone.radius)
     else
       current_waypoint = hd(bot_state_machine.path_towards_position)
-      direction = Vector.sub(current_waypoint, bot_player.position)
+
+      direction =
+        Vector.sub(current_waypoint, bot_player.position)
         |> Vector.normalize()
 
       %{

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -286,7 +286,8 @@ defmodule BotManager.BotStateMachine do
 
   defp determine_position_to_move_to(bot_state_machine, safe_zone_radius) do
     cond do
-      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ->
+      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) || 
+        Vector.distance(%{x: 0, y: 0}, bot_state_machine.position_to_move_to) > safe_zone_radius ->
         try_pick_random_position_to_move_to(bot_state_machine, safe_zone_radius)
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -34,7 +34,7 @@ defmodule BotManager.BotStateMachine do
 
     case next_state do
       :moving ->
-        move(bot_player, bot_state_machine, game_state.zone.radius)
+        move(bot_state_machine, game_state.zone.radius)
 
       :attacking ->
         use_skill(%{
@@ -81,7 +81,7 @@ defmodule BotManager.BotStateMachine do
           )
 
         if Enum.empty?(players_with_distances) do
-          move(bot_player, bot_state_machine, game_state.zone.radius)
+          move(bot_state_machine, game_state.zone.radius)
         else
           bot_state_machine =
             Map.put(
@@ -108,7 +108,7 @@ defmodule BotManager.BotStateMachine do
           )
 
         if Enum.empty?(players_with_distances) do
-          move(bot_player, bot_state_machine, game_state.zone.radius)
+          move(bot_state_machine, game_state.zone.radius)
         else
           bot_state_machine =
             Map.put(
@@ -124,7 +124,7 @@ defmodule BotManager.BotStateMachine do
         end
 
       true ->
-        move(bot_player, bot_state_machine, game_state.zone.radius)
+        move(bot_state_machine, game_state.zone.radius)
     end
   end
 
@@ -157,7 +157,7 @@ defmodule BotManager.BotStateMachine do
 
   defp track_player(game_state, bot_player, bot_state_machine) do
     if is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) do
-      move(bot_player, bot_state_machine, game_state.zone.radius)
+      move(bot_state_machine, game_state.zone.radius)
     else
       current_waypoint = hd(bot_state_machine.path_towards_position)
 
@@ -218,7 +218,7 @@ defmodule BotManager.BotStateMachine do
     end
   end
 
-  defp move(bot_player, bot_state_machine, safe_zone_radius) do
+  defp move(bot_state_machine, safe_zone_radius) do
     bot_state_machine =
       determine_position_to_move_to(bot_state_machine, safe_zone_radius)
 

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -286,8 +286,8 @@ defmodule BotManager.BotStateMachine do
 
   defp determine_position_to_move_to(bot_state_machine, safe_zone_radius) do
     cond do
-      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) || 
-        Vector.distance(%{x: 0, y: 0}, bot_state_machine.position_to_move_to) > safe_zone_radius ->
+      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ||
+          Vector.distance(%{x: 0, y: 0}, bot_state_machine.position_to_move_to) > safe_zone_radius ->
         try_pick_random_position_to_move_to(bot_state_machine, safe_zone_radius)
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) and

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -29,25 +29,22 @@ defmodule BotManager.BotStateMachine do
     bot_state_machine = preprocess_bot_state(bot_state_machine, bot_player)
     next_state = BotStateMachineChecker.move_to_next_state(bot_player, bot_state_machine, game_state.players)
 
-    if System.get_env("PATHFINDING_TEST") == "true" do
-      move(bot_player, bot_state_machine, game_state.zone.radius)
-    else
-      case next_state do
-        :moving ->
-          move(bot_player, bot_state_machine, game_state.zone.radius)
+    case next_state do
+      :moving ->
+        move(bot_player, bot_state_machine, game_state.zone.radius)
 
-        :attacking ->
-          use_skill(%{
-            bot_player: bot_player,
-            bot_state_machine: bot_state_machine,
-            game_state: game_state,
-            attack_blocked: attack_blocked,
-            bot_skills: skills
-          })
+      :attacking ->
+        use_skill(%{
+          bot_player: bot_player,
+          bot_state_machine: bot_state_machine,
+          game_state: game_state,
+          attack_blocked: attack_blocked,
+          bot_skills: skills
+        })
 
-        :tracking_player ->
-          track_player(game_state, bot_player, bot_state_machine)
-      end
+      :tracking_player ->
+        bot_state_machine = maybe_set_tracking_path(game_state, bot_player, bot_state_machine)
+        track_player(game_state, bot_player, bot_state_machine)
     end
   end
 
@@ -132,18 +129,11 @@ defmodule BotManager.BotStateMachine do
   defp determine_player_move_action(bot_player, direction) do
     {:player, bot_player_info} = bot_player.aditional_info
 
-    if System.get_env("PATHFINDING_TEST") == "true" do
-      {:move, direction}
-    else
-      if Map.has_key?(bot_player_info.cooldowns, @dash_skill_key) do
-        {:move, direction}
-      else
-        {:use_skill, @dash_skill_key, bot_player.direction}
-      end
-    end
+    # TODO: consider if we want to dash in the desired direction instead of just moving
+    {:move, direction}
   end
 
-  defp track_player(game_state, bot_player, bot_state_machine) do
+  defp maybe_set_tracking_path(game_state, bot_player, bot_state_machine) do
     players_with_distances =
       Utils.map_directions_to_players(
         game_state.players,
@@ -154,16 +144,68 @@ defmodule BotManager.BotStateMachine do
           bot_state_machine.ranged_tracking_range
         )
       )
+    closest_player = Enum.min_by(players_with_distances, & &1.distance)
 
-    if Enum.empty?(players_with_distances) do
-      move(bot_player, bot_state_machine, game_state.zone.radius)
-    else
-      closest_player = Enum.min_by(players_with_distances, & &1.distance)
+    current_time = :os.system_time(:millisecond)
+    time_since_last_position_change = current_time - bot_state_machine.last_time_position_changed
 
-      %{
-        action: determine_player_move_action(bot_player, closest_player.direction),
-        bot_state_machine: bot_state_machine
-      }
+    cond do
+      is_nil(bot_state_machine.path_towards_position) ->
+        from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
+        to = %{x: closest_player.position.x, y: closest_player.position.y}
+
+        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
+        # If we don't have a path, retry finding new position in map
+        if Enum.empty?(shortest_path) do
+          Map.put(bot_state_machine, :path_towards_position, nil)
+          |> Map.put(:position_to_move_to, nil)
+        else
+          Map.put(bot_state_machine, :position_to_move_to, closest_player.position)
+          |> Map.put(
+            :path_towards_position,
+            shortest_path
+          )
+          |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
+        end
+      Enum.empty?(bot_state_machine.path_towards_position) && time_since_last_position_change >= bot_state_machine.time_amount_to_change_position ->
+        from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
+        to = %{x: closest_player.position.x, y: closest_player.position.y}
+
+        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
+        # If we don't have a path, retry finding new position in map
+        if Enum.empty?(shortest_path) do
+          Map.put(bot_state_machine, :path_towards_position, nil)
+          |> Map.put(:position_to_move_to, nil)
+        else
+          Map.put(bot_state_machine, :position_to_move_to, closest_player.position)
+          |> Map.put(
+            :path_towards_position,
+            shortest_path
+          )
+          |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
+        end
+      BotStateMachineChecker.current_waypoint_reached?(bot_player) ->
+        Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
+      true ->
+        bot_state_machine
+    end
+  end
+
+  defp track_player(game_state, bot_player, bot_state_machine) do
+    cond do 
+      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ->
+        move(bot_player, bot_state_machine, game_state.zone.radius)
+      true ->
+        current_waypoint = hd(bot_state_machine.path_towards_position)
+        direction = Vector.sub(current_waypoint, bot_player.position)
+          |> Vector.normalize()
+
+        %{
+          action: determine_player_move_action(bot_player, direction),
+          bot_state_machine: bot_state_machine
+        }
     end
   end
 
@@ -215,7 +257,7 @@ defmodule BotManager.BotStateMachine do
 
   defp move(bot_player, bot_state_machine, safe_zone_radius) do
     bot_state_machine =
-      determine_position_to_move_to(bot_state_machine, safe_zone_radius, System.get_env("PATHFINDING_TEST") == "true")
+      determine_position_to_move_to(bot_state_machine, safe_zone_radius)
 
     # TODO instead of using `get_distance_and_direction_to_positions, use the pathfinding module`
     cond do
@@ -251,7 +293,7 @@ defmodule BotManager.BotStateMachine do
     end
   end
 
-  defp determine_position_to_move_to(bot_state_machine, safe_zone_radius, true = _pathfinding_on) do
+  defp determine_position_to_move_to(bot_state_machine, safe_zone_radius) do
     cond do
       is_nil(bot_state_machine.collision_grid) ->
         bot_state_machine
@@ -301,26 +343,6 @@ defmodule BotManager.BotStateMachine do
 
       BotStateMachineChecker.current_waypoint_reached?(bot_state_machine) ->
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
-
-      true ->
-        bot_state_machine
-    end
-  end
-
-  defp determine_position_to_move_to(bot_state_machine, safe_zone_radius, false = _pathfinding_on) do
-    cond do
-      is_nil(bot_state_machine.position_to_move_to) ||
-          not Utils.position_within_radius(bot_state_machine.position_to_move_to, safe_zone_radius) ->
-        position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
-
-        Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
-        |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
-
-      BotStateMachineChecker.should_bot_move_to_another_position?(bot_state_machine) ->
-        position_to_move_to = BotManager.Utils.random_position_within_safe_zone_radius(floor(safe_zone_radius))
-
-        Map.put(bot_state_machine, :position_to_move_to, position_to_move_to)
-        |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
 
       true ->
         bot_state_machine

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -128,14 +128,6 @@ defmodule BotManager.BotStateMachine do
     end
   end
 
-  # This function will determine the direction and action the bot will take.
-  defp determine_player_move_action(bot_player, direction) do
-    {:player, _bot_player_info} = bot_player.aditional_info
-
-    # TODO: consider if we want to dash in the desired direction instead of just moving
-    {:move, direction}
-  end
-
   defp maybe_set_tracking_path(game_state, bot_player, bot_state_machine) do
     players_with_distances =
       Utils.map_directions_to_players(
@@ -174,7 +166,7 @@ defmodule BotManager.BotStateMachine do
         |> Vector.normalize()
 
       %{
-        action: determine_player_move_action(bot_player, direction),
+        action: {:move, direction},
         bot_state_machine: bot_state_machine
       }
     end
@@ -240,7 +232,7 @@ defmodule BotManager.BotStateMachine do
           )
 
         %{
-          action: determine_player_move_action(bot_player, direction),
+          action: {:move, direction},
           bot_state_machine: bot_state_machine
         }
 
@@ -252,7 +244,7 @@ defmodule BotManager.BotStateMachine do
           )
 
         %{
-          action: determine_player_move_action(bot_player, direction),
+          action: {:move, direction},
           bot_state_machine: bot_state_machine
         }
 

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -218,8 +218,9 @@ defmodule BotManager.BotStateMachine do
         bot_state_machine.current_position
       )
 
+    new_progress = min(bot_state_machine.cap_for_basic_skill * 3, bot_state_machine.progress_for_basic_skill + distance)
     bot_state_machine =
-      Map.put(bot_state_machine, :progress_for_basic_skill, bot_state_machine.progress_for_basic_skill + distance)
+      Map.put(bot_state_machine, :progress_for_basic_skill, new_progress)
 
     cond do
       Vector.distance(bot_state_machine.previous_position, bot_state_machine.current_position) < 100 &&

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -214,18 +214,17 @@ defmodule BotManager.BotStateMachine do
   end
 
   defp track_player(game_state, bot_player, bot_state_machine) do
-    cond do 
-      is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) ->
-        move(bot_player, bot_state_machine, game_state.zone.radius)
-      true ->
-        current_waypoint = hd(bot_state_machine.path_towards_position)
-        direction = Vector.sub(current_waypoint, bot_player.position)
-          |> Vector.normalize()
+    if is_nil(bot_state_machine.path_towards_position) || Enum.empty?(bot_state_machine.path_towards_position) do
+      move(bot_player, bot_state_machine, game_state.zone.radius)
+    else
+      current_waypoint = hd(bot_state_machine.path_towards_position)
+      direction = Vector.sub(current_waypoint, bot_player.position)
+        |> Vector.normalize()
 
-        %{
-          action: determine_player_move_action(bot_player, direction),
-          bot_state_machine: bot_state_machine
-        }
+      %{
+        action: determine_player_move_action(bot_player, direction),
+        bot_state_machine: bot_state_machine
+      }
     end
   end
 

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -11,7 +11,8 @@ defmodule BotManager.BotStateMachine do
   @skill_1_key "1"
   @skill_2_key "2"
 
-  # The minimum distance a tracked player has to move for the tracking path to get recalculated
+  # The minimum distance a tracked player has to move for the tracking path to
+  # get recalculated
   @path_recalculation_min_diff 300
 
   def decide_action(%{bots_enabled?: false, bot_state_machine: bot_state_machine}) do

--- a/apps/bot_manager/lib/bot_state_machine.ex
+++ b/apps/bot_manager/lib/bot_state_machine.ex
@@ -10,9 +10,12 @@ defmodule BotManager.BotStateMachine do
 
   @skill_1_key "1"
   @skill_2_key "2"
-  @dash_skill_key "3"
+  # @dash_skill_key "3"
 
-  def decide_action(%{enabled?: false, bot_state_machine: bot_state_machine}) do
+  # The minimum distance a tracked player has to move for the tracking path to get recalculated
+  @path_recalculation_min_diff 300
+
+  def decide_action(%{bots_enabled?: false, bot_state_machine: bot_state_machine}) do
     %{action: {:move, %{x: 0, y: 0}}, bot_state_machine: bot_state_machine}
   end
 
@@ -151,6 +154,7 @@ defmodule BotManager.BotStateMachine do
 
     cond do
       is_nil(bot_state_machine.path_towards_position) ->
+        IO.inspect("NIL PATH, setting new one")
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: closest_player.position.x, y: closest_player.position.y}
 
@@ -169,6 +173,7 @@ defmodule BotManager.BotStateMachine do
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
       Enum.empty?(bot_state_machine.path_towards_position) && time_since_last_position_change >= bot_state_machine.time_amount_to_change_position ->
+        IO.inspect("EMPTY PATH, setting new one")
         from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
         to = %{x: closest_player.position.x, y: closest_player.position.y}
 
@@ -186,7 +191,26 @@ defmodule BotManager.BotStateMachine do
           )
           |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
         end
+      Vector.distance(bot_state_machine.position_to_move_to, closest_player.position) > @path_recalculation_min_diff ->
+        IO.inspect("PLAYER MOVED, RECALCULATING PATH")
+        from = %{x: bot_state_machine.current_position.x, y: bot_state_machine.current_position.y}
+        to = %{x: closest_player.position.x, y: closest_player.position.y}
+
+        shortest_path = AStarNative.a_star_shortest_path(from, to, bot_state_machine.collision_grid)
+
+        # If we don't have a path, keep the old one
+        if Enum.empty?(shortest_path) do
+          bot_state_machine
+        else
+          Map.put(bot_state_machine, :position_to_move_to, closest_player.position)
+          |> Map.put(
+            :path_towards_position,
+            shortest_path
+          )
+          |> Map.put(:last_time_position_changed, :os.system_time(:millisecond))
+        end
       BotStateMachineChecker.current_waypoint_reached?(bot_player) ->
+        IO.inspect("GOING TO NEXT WAYPOINT")
         Map.put(bot_state_machine, :path_towards_position, tl(bot_state_machine.path_towards_position))
       true ->
         bot_state_machine

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -154,19 +154,20 @@ defmodule BotManager.BotStateMachineChecker do
 
     {:player, aditional_info} = bot_player.aditional_info
 
-    players_nearby_to_attack = if aditional_info.available_stamina > 0 do
-      Utils.map_directions_to_players(
-        players,
-        bot_player,
-        Utils.get_action_distance_by_type(
-          bot_state_machine.is_melee,
-          bot_state_machine.melee_attack_distance,
-          bot_state_machine.ranged_attack_distance
+    players_nearby_to_attack =
+      if aditional_info.available_stamina > 0 do
+        Utils.map_directions_to_players(
+          players,
+          bot_player,
+          Utils.get_action_distance_by_type(
+            bot_state_machine.is_melee,
+            bot_state_machine.melee_attack_distance,
+            bot_state_machine.ranged_attack_distance
+          )
         )
-      )
-    else
-      []
-    end
+      else
+        []
+      end
 
     Enum.empty?(players_nearby_to_attack) && not Enum.empty?(players_nearby_to_follow) &&
       bot_can_turn_aggresive?(bot_state_machine) && not bot_stuck?(bot_state_machine)

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -105,7 +105,7 @@ defmodule BotManager.BotStateMachineChecker do
       is_melee: nil,
       collision_grid: nil,
       last_time_state_changed: 0,
-      last_time_tracking_exited: 0,
+      last_time_tracking_exited: 0
     }
   end
 
@@ -163,7 +163,8 @@ defmodule BotManager.BotStateMachineChecker do
         )
       )
 
-    players_nearby_to_attack = Utils.map_directions_to_players(
+    players_nearby_to_attack =
+      Utils.map_directions_to_players(
         players,
         bot_player,
         Utils.get_action_distance_by_type(
@@ -173,11 +174,13 @@ defmodule BotManager.BotStateMachineChecker do
         )
       )
 
-    current_time = :os.system_time(:millisecond) 
+    current_time = :os.system_time(:millisecond)
     time_since_tracking_started = current_time - bot_state_machine.last_time_state_changed
     time_since_last_tracking_ended = current_time - bot_state_machine.last_time_tracking_exited
 
-    tracking_timed_out = bot_state_machine.state == :tracking_player && time_since_tracking_started > @tracking_timeout_ms
+    tracking_timed_out =
+      bot_state_machine.state == :tracking_player && time_since_tracking_started > @tracking_timeout_ms
+
     tracking_in_cooldown = time_since_last_tracking_ended <= @tracking_cooldown_ms
 
     Enum.empty?(players_nearby_to_attack) && not Enum.empty?(players_nearby_to_follow) &&

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -88,7 +88,7 @@ defmodule BotManager.BotStateMachineChecker do
       state: :idling,
       progress_for_basic_skill: 0,
       progress_for_ultimate_skill: 0,
-      cap_for_basic_skill: 100,
+      cap_for_basic_skill: 250,
       cap_for_ultimate_skill: 3,
       previous_position: nil,
       current_position: nil,

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -8,7 +8,7 @@ defmodule BotManager.BotStateMachineChecker do
   @time_stuck_in_position 400
   @distance_threshold 100
 
-  @tracking_timeout_ms 10000
+  @tracking_timeout_ms 10_000
   @tracking_cooldown_ms 4000
 
   @type state_step() :: :attacking | :moving | :tracking_player | :idling

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -146,15 +146,21 @@ defmodule BotManager.BotStateMachineChecker do
     distance <= @distance_threshold
   end
 
-  @spec bot_can_turn_aggresive?(BotManager.BotStateMachine.bot_player(), BotManager.BotStateMachineChecker.t()) :: boolean()
+  @spec bot_can_turn_aggresive?(BotManager.BotStateMachine.bot_player(), BotManager.BotStateMachineChecker.t()) ::
+          boolean()
   defp bot_can_turn_aggresive?(bot_player, bot_state_machine) do
     {:player, bot_player_info} = bot_player.aditional_info
 
     current_time = :os.system_time(:millisecond)
     time_since_last_attack = current_time - bot_state_machine.last_time_attacking_exited
 
-    bot_state_machine.state != :attacking && ((bot_state_machine.progress_for_basic_skill >= bot_state_machine.cap_for_basic_skill && Enum.all?(bot_player_info.current_actions, fn current_action -> current_action.action != :EXECUTING_SKILL_1 end)) ||
-      bot_state_machine.progress_for_ultimate_skill >= bot_state_machine.cap_for_ultimate_skill) && time_since_last_attack > @min_time_between_attacks
+    bot_state_machine.state != :attacking &&
+      ((bot_state_machine.progress_for_basic_skill >= bot_state_machine.cap_for_basic_skill &&
+          Enum.all?(bot_player_info.current_actions, fn current_action ->
+            current_action.action != :EXECUTING_SKILL_1
+          end)) ||
+         bot_state_machine.progress_for_ultimate_skill >= bot_state_machine.cap_for_ultimate_skill) &&
+      time_since_last_attack > @min_time_between_attacks
   end
 
   @spec bot_can_follow_a_player?(

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -8,8 +8,8 @@ defmodule BotManager.BotStateMachineChecker do
   @time_stuck_in_position 400
   @distance_threshold 100
 
-  @tracking_timeout_ms 7000
-  @tracking_cooldown_ms 5000
+  @tracking_timeout_ms 10000
+  @tracking_cooldown_ms 4000
 
   @type state_step() :: :attacking | :moving | :tracking_player | :idling
 

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -8,9 +8,17 @@ defmodule BotManager.BotStateMachineChecker do
   @time_stuck_in_position 400
   @distance_threshold 100
 
+  # Bots will track a player for at most @tracking_timeout_ms milliseconds
+  # after which it will transition to another state
   @tracking_timeout_ms 10_000
+
+  # There is a cooldown on tracking of @tracking_cooldown_ms milliseconds to
+  # control the agressiveness of bots. Otherwise they'd chase infinitely
   @tracking_cooldown_ms 4000
 
+  # Adds a small cooldown between attacks of @min_time_between_attacks
+  # milliseconds so that the bot doesn't try to attack too fast, again to
+  # control the aggresiveness of the bot.
   @min_time_between_attacks 1500
 
   @type state_step() :: :attacking | :moving | :tracking_player | :idling

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -104,27 +104,17 @@ defmodule BotManager.BotStateMachineChecker do
           BotManager.BotStateMachine.players()
         ) :: state_step()
   def move_to_next_state(bot_player, bot_state_machine, players) do
-    if System.get_env("PATHFINDING_TEST") == "true" do
-      :moving
-    else
-      cond do
-        bot_stuck?(bot_state_machine) -> :moving
-        bot_can_follow_a_player?(bot_player, bot_state_machine, players) -> :tracking_player
-        bot_can_turn_aggresive?(bot_state_machine) -> :attacking
-        true -> :moving
-      end
+    cond do
+      bot_stuck?(bot_state_machine) -> :moving
+      bot_state_machine.state != :tracking_player && bot_can_follow_a_player?(bot_player, bot_state_machine, players) -> :tracking_player
+      bot_can_turn_aggresive?(bot_state_machine) -> :attacking
+      true -> :moving
     end
   end
 
   @spec should_bot_move_to_another_position?(BotManager.BotStateMachineChecker.t()) :: boolean()
   def should_bot_move_to_another_position?(bot_state_machine) do
-    if System.get_env("PATHFINDING_TEST") == "true" do
-      is_nil(bot_state_machine.path_towards_position) or Enum.count(bot_state_machine.path_towards_position) <= 1
-    else
-      current_time = :os.system_time(:millisecond)
-      time_since_last_position_change = current_time - bot_state_machine.last_time_position_changed
-      time_since_last_position_change >= bot_state_machine.time_amount_to_change_position
-    end
+    is_nil(bot_state_machine.path_towards_position) or Enum.count(bot_state_machine.path_towards_position) <= 1
   end
 
   @spec current_waypoint_reached?(BotManager.BotStateMachineChecker.t()) :: boolean()

--- a/apps/bot_manager/lib/bot_state_machine_checker.ex
+++ b/apps/bot_manager/lib/bot_state_machine_checker.ex
@@ -152,22 +152,15 @@ defmodule BotManager.BotStateMachineChecker do
         )
       )
 
-    {:player, aditional_info} = bot_player.aditional_info
-
-    players_nearby_to_attack =
-      if aditional_info.available_stamina > 0 do
-        Utils.map_directions_to_players(
-          players,
-          bot_player,
-          Utils.get_action_distance_by_type(
-            bot_state_machine.is_melee,
-            bot_state_machine.melee_attack_distance,
-            bot_state_machine.ranged_attack_distance
-          )
+    players_nearby_to_attack = Utils.map_directions_to_players(
+        players,
+        bot_player,
+        Utils.get_action_distance_by_type(
+          bot_state_machine.is_melee,
+          bot_state_machine.melee_attack_distance,
+          bot_state_machine.ranged_attack_distance
         )
-      else
-        []
-      end
+      )
 
     Enum.empty?(players_nearby_to_attack) && not Enum.empty?(players_nearby_to_follow) &&
       bot_can_turn_aggresive?(bot_state_machine) && not bot_stuck?(bot_state_machine)

--- a/apps/bot_manager/lib/math/vector.ex
+++ b/apps/bot_manager/lib/math/vector.ex
@@ -64,8 +64,4 @@ defmodule BotManager.Math.Vector do
   def deg2rad(deg) do
     deg * :math.pi() / 180
   end
-
-  def distance(%{x: x1, y: y1}, %{x: x2, y: y2}) do
-    :math.sqrt(:math.pow(x2 - x1, 2) + :math.pow(y2 - y1, 2))
-  end
 end

--- a/apps/bot_manager/lib/math/vector.ex
+++ b/apps/bot_manager/lib/math/vector.ex
@@ -56,12 +56,11 @@ defmodule BotManager.Math.Vector do
     }
   end
 
-  def distance(x, y) do
-    sub(x, y)
-    |> norm()
-  end
-
   def deg2rad(deg) do
     deg * :math.pi() / 180
+  end
+
+  def distance(%{x: x1, y: y1}, %{x: x2, y: y2}) do
+    :math.sqrt(:math.pow(x2 - x1, 2) + :math.pow(y2 - y1, 2))
   end
 end

--- a/apps/bot_manager/lib/math/vector.ex
+++ b/apps/bot_manager/lib/math/vector.ex
@@ -56,6 +56,11 @@ defmodule BotManager.Math.Vector do
     }
   end
 
+  def distance(x, y) do
+    sub(x, y)
+    |> norm()
+  end
+
   def deg2rad(deg) do
     deg * :math.pi() / 180
   end


### PR DESCRIPTION
## Motivation

On #1112  and #1119 we introduced a pathfinding module and used it on bot behavior but under a flag but we were not using it for anything relevant. 

Closes #1123

## Summary of changes

On this PR we remove the pathfinding flag and restore the pre-existing bot behavior (`:move`, `track`, `attack`) but consuming the pathfinding module instead of naively moving towards a direction.

Besides this, I noticed a bug by which the bot was never entering the `:tracking_player` state, this was because it was using the attack distance instead of the track distance.

> [!NOTE]  
> Dashing won't be used when tracking the player or moving for now as it adds complexity to pathfinding and path following. I openned an issue to re-introduce it but with another intention > #1137

> [!NOTE]  
> The bot state machine states are instant, we don't differenciate things to do when entering / exiting a state or behaviors to keep over the duration of a state (for example, when we attack we should wait at least until the character finished casting the attack before attempting to add new input > #1159. This is something the unity client already does). Also the back is not performing any validations regarding this, so it's possible for the bots to instantly cast multiple abilities which shouldn't be possible and also is not possible for the unity client > #1160

## How to test it?

Start the backend locally. Either on the web client or on Unity (selecting localhost as the server), run a new game. Check that now bots can actually chase you down, though now they can attack (like before the pathfinding PoC changes). 

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
