### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Application for Champions Of Mirra game. Has modules for:
   - Users - Handles logic for Users. Consumes from the Users app for general items logic.
 
 ### GameBackend
-Persistance layer and shared logic:
+Persistence layer and shared logic:
 - Users logic that's general among all games. This module is quite incomplete for now, since users are only made of a unique username.
 - Units logic that's general among all games. Defines the schemas for the characters of every game. These act like templates for Units, which are instances of them tied to a user or a campaign level.
 - Items logic that's general among all games. Defines the schemas for the item templates of every game. These act like templates for Items, which are instances of them that belong to a user and can be equipped to a unit.


### PR DESCRIPTION
## Motivation  
I found a typo in the documentation, where "Persistance" was used instead of the correct spelling "Persistence."

## Summary of changes  
Corrected the spelling of "Persistance" to "Persistence" in the documentation.

## How to test it?  
You can verify the change by reviewing the updated documentation, where the typo has been fixed.

## Checklist  
- [x] Tested the changes locally.  
- [x] Reviewed the changes on GitHub, line by line.  
- [ ] This change requires new documentation.  
  - [x] Documentation has been added/updated.