### PR TITLE
Add new europe server workflow

### DIFF
--- a/.github/workflows/new-arena-europe-testing-deploy.yml
+++ b/.github/workflows/new-arena-europe-testing-deploy.yml
@@ -1,7 +1,6 @@
 name: "[NEW-TESTING-EUROPE] Deploy to Europe Arena testing"
 on:
   workflow_dispatch:
-on:
   push:
     branches: add-new-europe-server-workflow
 

--- a/.github/workflows/new-arena-europe-testing-deploy.yml
+++ b/.github/workflows/new-arena-europe-testing-deploy.yml
@@ -48,7 +48,7 @@ jobs:
           MIX_ENV: ${{ vars.MIX_ENV }}
           RELEASE: arena
           PHX_SERVER: ${{ vars.PHX_SERVER }}
-          PHX_HOST: ${{ vars.HOST }}
+          PHX_HOST: ${{ vars.NEW_HOST }}
           PORT: ${{ vars.ARENA_PORT }}
           GATEWAY_URL: ${{ vars.GATEWAY_URL }}
           BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}

--- a/.github/workflows/new-arena-europe-testing-deploy.yml
+++ b/.github/workflows/new-arena-europe-testing-deploy.yml
@@ -1,8 +1,6 @@
 name: "[NEW-TESTING-EUROPE] Deploy to Europe Arena testing"
 on:
   workflow_dispatch:
-  push:
-    branches: add-new-europe-server-workflow
 
 jobs:
   build-deploy:

--- a/.github/workflows/new-arena-europe-testing-deploy.yml
+++ b/.github/workflows/new-arena-europe-testing-deploy.yml
@@ -1,0 +1,80 @@
+name: "[NEW-TESTING-EUROPE] Deploy to Europe Arena testing"
+on:
+  workflow_dispatch:
+on:
+  push:
+    branches: add-new-europe-server-workflow
+
+jobs:
+  build-deploy:
+    name: Build and deploy to Europe testing
+    runs-on: ubuntu-22.04
+    environment:
+      name: testing-europe
+      url: https://new-arena-europe-testing.championsofmirra.com/
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Create ssh private key file from env var
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST: ${{ vars.TS_NEW_ARENA_HOST }}
+        run: |
+          set -ex
+          mkdir -p ~/.ssh/
+          sed -E 's/(-+(BEGIN|END) OPENSSH PRIVATE KEY-+) *| +/\1\n/g' <<< "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+          retries=5; until ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts || [ $retries -eq 0 ]; do ((retries--)); sleep 5; done
+
+      - name: Copy deploy script
+        env:
+          SSH_USERNAME: ${{ vars.SSH_NEW_USERNAME }}
+          SSH_HOST: ${{ vars.TS_NEW_ARENA_HOST }}
+        run: |
+          set -ex
+          rsync -avz --mkpath devops/deploy.sh ${SSH_USERNAME}@${SSH_HOST}:/home/${SSH_USERNAME}/deploy-script/
+
+      - name: Execute deploy script
+        env:
+          SSH_HOST: ${{ vars.TS_NEW_ARENA_HOST }}
+          SSH_USERNAME: ${{ vars.SSH_NEW_USERNAME }}
+          MIX_ENV: ${{ vars.MIX_ENV }}
+          RELEASE: arena
+          PHX_SERVER: ${{ vars.PHX_SERVER }}
+          PHX_HOST: ${{ vars.HOST }}
+          PORT: ${{ vars.ARENA_PORT }}
+          GATEWAY_URL: ${{ vars.GATEWAY_URL }}
+          BOT_MANAGER_PORT: ${{ vars.BOT_MANAGER_PORT }}
+          BOT_MANAGER_HOST: ${{ vars.BOT_MANAGER_HOST }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          NEWRELIC_APP_NAME: ${{ vars.NEWRELIC_APP_NAME }}
+          NEWRELIC_KEY: ${{ secrets.NEWRELIC_KEY }}
+          DBUS_SESSION_BUS_ADDRESS: ${{ vars.DBUS_SESSION_BUS_ADDRESS }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -ex
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+                BRANCH_NAME=${BRANCH_NAME} \
+                MIX_ENV=${MIX_ENV} \
+                RELEASE=${RELEASE} \
+                PHX_SERVER=${PHX_SERVER} \
+                PHX_HOST=${PHX_HOST} \
+                PORT=${PORT} \
+                GATEWAY_URL=${GATEWAY_URL} \
+                BOT_MANAGER_PORT=${BOT_MANAGER_PORT} \
+                BOT_MANAGER_HOST=${BOT_MANAGER_HOST} \
+                DATABASE_URL=${DATABASE_URL} \
+                SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+                NEWRELIC_APP_NAME=${NEWRELIC_APP_NAME} \
+                NEWRELIC_KEY=${NEWRELIC_KEY} \
+                DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS} \
+                /home/${SSH_USERNAME}/deploy-script/deploy.sh

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ debian-install-deps:
 	rm /tmp/elixir-otp-26.zip
 
 setup-caddy:
+	@read -p "Enter the server dns (e.g: 'arena-testing.championsofmirra.com'): " user_input; \
 	sudo ufw allow 80 \
 	sudo ufw allow 443 \
-	@read -p "Enter the server dns (e.g: 'arena-testing.championsofmirra.com'): " user_input; \
 	sudo sed -i "1i $$user_input {" /etc/caddy/Caddyfile; \
 	sudo sed -i "2i \	reverse_proxy localhost:4000" /etc/caddy/Caddyfile; \
 	sudo sed -i "3i }" /etc/caddy/Caddyfile;


### PR DESCRIPTION
## Motivation

We have a new bigger server in Europe.
Closes #1134 

## Summary of changes

- [Add new arena europe testing deploy workflow](https://github.com/lambdaclass/mirra_backend/commit/2e76abc091ddf63fc9f619586a15ead2c9e92b97)
- [Fix caddy setup script in Makefile](https://github.com/lambdaclass/mirra_backend/commit/e181329554347fa34260ffa7280cc0850936b005)

## How to test it?

It already worked here -> https://github.com/lambdaclass/mirra_backend/actions/runs/13999759864/job/39203316228
You can also open unity and play in this new server.

## Checklist
- [ ] Tested the changes locally.
- [ ] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
