### PR TITLE
Override google sign in in :dev environment

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
@@ -1,4 +1,4 @@
-<%= if @current_user do %>
+<%= if not is_nil(@current_user) or Mix.env() == :dev do %>
   <.header>
     Welcome to Champions of Mirra Configurator
   </.header>

--- a/apps/configurator/lib/configurator_web/user_auth.ex
+++ b/apps/configurator/lib/configurator_web/user_auth.ex
@@ -201,7 +201,7 @@ defmodule ConfiguratorWeb.UserAuth do
   they use the application at all, here would be a good place.
   """
   def require_authenticated_user(conn, _opts) do
-    if get_session(conn, :current_user) do
+    if not is_nil(get_session(conn, :current_user)) or Mix.env() == :dev do
       conn
     else
       conn


### PR DESCRIPTION
## Motivation

Non-google users should be able to use the configurator in :dev environment.
Closes #1142

## Summary of changes

[Override google sign in in :dev environment](https://github.com/lambdaclass/mirra_backend/commit/b9ccb5cf972e26602720d9ed4e0e766185708cc9)

## How to test it?

Start the app and go to localhost:4100. Everything should work just fine without needing to log-in with google.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
