### PR TITLE
1144 Add new workflow to deploy new Arena servers

### DIFF
--- a/.github/workflows/deploy-new-arena-server.yml
+++ b/.github/workflows/deploy-new-arena-server.yml
@@ -1,13 +1,10 @@
 name: Deploy new Arena server
 
 on:
-  push:
-    branches:
-      1144-add-makefile-commands-for-arena-deployment
   workflow_dispatch:
     inputs:
-      server_ip:
-        description: 'Server IP Address'
+      server_hostname:
+        description: 'Server Hostname or IP Address'
         required: true
 
 jobs:
@@ -27,7 +24,7 @@ jobs:
       - name: Create ssh private key file from env var
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
         run: |
           set -ex
           mkdir -p ~/.ssh/
@@ -38,7 +35,7 @@ jobs:
       - name: Add SSH Key to Server
         env:
           SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           printf "%s" "$SSH_PRIVATE_KEY" | ssh ${SSH_USERNAME}@${SSH_HOST} 'cat > ~/.ssh/id_ed25519 && chmod 600 ~/.ssh/id_ed25519'
@@ -46,14 +43,14 @@ jobs:
       - name: Clone the Repository
         env:
           SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
         run: |
           ssh ${SSH_USERNAME}@${SSH_HOST} << 'EOF'
             set -ex
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             cd /tmp
             rm -rf /tmp/mirra_backend
-            git clone git@github.com:lambdaclass/mirra_backend.git --branch 1144-add-makefile-commands-for-arena-deployment
+            git clone git@github.com:lambdaclass/mirra_backend.git
             rm -rf ~/mirra_backend/
             mv /tmp/mirra_backend ~/
           EOF
@@ -62,7 +59,7 @@ jobs:
         env:
           SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
           SSH_APP_USERNAME: ${{ vars.SSH_USERNAME }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           NEWRELIC_KEY: ${{ secrets.NEWRELIC_KEY }}
@@ -84,7 +81,7 @@ jobs:
       - name: Setup dependencies
         env:
           SSH_USERNAME: ${{ vars.SSH_USERNAME }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
         run: |
           ssh ${SSH_USERNAME}@${SSH_HOST} \
           'cd ~/mirra_backend && make app-setup-arena-server'
@@ -105,7 +102,7 @@ jobs:
       - name: Start Arena service
         env:
           SSH_USERNAME: ${{ vars.SSH_USERNAME }}
-          SSH_HOST: mirra-nico-testing
+          SSH_HOST: ${{ inputs.server_hostname }}
         run: |
           set -ex
           ssh ${SSH_USERNAME}@${SSH_HOST} \

--- a/.github/workflows/deploy-new-arena-server.yml
+++ b/.github/workflows/deploy-new-arena-server.yml
@@ -1,0 +1,114 @@
+name: Deploy new Arena server
+
+on:
+  push:
+    branches:
+      1144-add-makefile-commands-for-arena-deployment
+  workflow_dispatch:
+    inputs:
+      server_ip:
+        description: 'Server IP Address'
+        required: true
+
+jobs:
+  deploy-new-arena-server:
+    environment: DeployNewArenaServer
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Tailscale (admin)
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_ADMIN_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_ADMIN_OAUTH_SECRET }}
+          tags: tag:ci-admin
+
+      - name: Create ssh private key file from env var
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_HOST: mirra-nico-testing
+        run: |
+          set -ex
+          mkdir -p ~/.ssh/
+          sed -E 's/(-+(BEGIN|END) OPENSSH PRIVATE KEY-+) *| +/\1\n/g' <<< "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+          retries=5; until ssh-keyscan $SSH_HOST >> ~/.ssh/known_hosts || [ $retries -eq 0 ]; do ((retries--)); sleep 5; done
+
+      - name: Add SSH Key to Server
+        env:
+          SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
+          SSH_HOST: mirra-nico-testing
+          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          printf "%s" "$SSH_PRIVATE_KEY" | ssh ${SSH_USERNAME}@${SSH_HOST} 'cat > ~/.ssh/id_ed25519 && chmod 600 ~/.ssh/id_ed25519'
+
+      - name: Clone the Repository
+        env:
+          SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
+          SSH_HOST: mirra-nico-testing
+        run: |
+          ssh ${SSH_USERNAME}@${SSH_HOST} << 'EOF'
+            set -ex
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            cd /tmp
+            rm -rf /tmp/mirra_backend
+            git clone git@github.com:lambdaclass/mirra_backend.git --branch 1144-add-makefile-commands-for-arena-deployment
+            rm -rf ~/mirra_backend/
+            mv /tmp/mirra_backend ~/
+          EOF
+
+      - name: Setup dependencies (admin)
+        env:
+          SSH_USERNAME: ${{ vars.SSH_ADMIN_USERNAME }}
+          SSH_APP_USERNAME: ${{ vars.SSH_USERNAME }}
+          SSH_HOST: mirra-nico-testing
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          NEWRELIC_KEY: ${{ secrets.NEWRELIC_KEY }}
+        run: |
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+            SSH_APP_USERNAME=${SSH_APP_USERNAME} \
+            DATABASE_URL=${DATABASE_URL} \
+            SECRET_KEY_BASE=${SECRET_KEY_BASE} \
+            NEWRELIC_KEY=${NEWRELIC_KEY} \
+            /home/${SSH_USERNAME}/mirra_backend/devops/setup-admin-deps.sh
+
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Setup dependencies
+        env:
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          SSH_HOST: mirra-nico-testing
+        run: |
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+          'cd ~/mirra_backend && make app-setup-arena-server'
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ vars.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Setup Arena Server DNS in AWS
+        run: |
+          aws route53 change-resource-record-sets \
+          --hosted-zone-id "Z10155211PTW2X4H9NGDM" \
+          --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$(hostname).championsofmirra.com\",\"Type\":\"A\",\"TTL\":300,\"ResourceRecords\":[{\"Value\":\"$(curl -s ipinfo.io/ip)\"}]}}]}"
+
+      - name: Start Arena service
+        env:
+          SSH_USERNAME: ${{ vars.SSH_USERNAME }}
+          SSH_HOST: mirra-nico-testing
+        run: |
+          set -ex
+          ssh ${SSH_USERNAME}@${SSH_HOST} \
+          /home/${SSH_USERNAME}/mirra_backend/devops/arena-start.sh
+          
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps db run start format docs credo check generate-protos generate-arena-protos generate-game-client-protos
+.PHONY: deps db run start format docs credo check generate-protos generate-arena-protos generate-game-client-protos generate-arena-load-test-protos generate-bot-manager-protos
 
 deps:
 	cd apps/game_client/assets && npm install
@@ -70,34 +70,71 @@ generate-bot-manager-protos:
 		messages.proto
 
 # INFRA
+.PHONY: server-specs admin-setup-arena-server debian-install-deps setup-caddy create-env-file app-setup-arena-server debian-install-dev-deps
 ## Check server specs (loadtests)
 server-specs:
 	./devops/server_specs.sh
 
 ## New server. Setup dependencies.
-## Run these as admin
+## Run these as admin user
+
+admin-setup-arena-server: debian-install-deps setup-caddy create-env-file
+
 debian-install-deps:
 	sudo apt update -y
-	sudo apt install -y rsync libssl-dev libncurses5 libsctp1 wget systemd-timesyncd
+	sudo apt install -y rsync libssl-dev libncurses5 libsctp1 wget systemd-timesyncd ufw
 	wget -P /tmp/ http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
-	sudo dpkg -i /tmp/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
-	rm /tmp/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
 	wget -P /tmp/ https://binaries2.erlang-solutions.com/debian/pool/contrib/e/esl-erlang/esl-erlang_26.2.3-1~debian~buster_amd64.deb
-	sudo dpkg -i /tmp/esl-erlang_26.2.3-1~debian~buster_amd64.deb
-	rm /tmp/esl-erlang_26.2.3-1~debian~buster_amd64.deb
 	wget -P /tmp/ https://github.com/elixir-lang/elixir/releases/download/v1.16.3/elixir-otp-26.zip
-	sudo unzip -d /usr/ /tmp/elixir-otp-26.zip
+	cd ~/ \
+	sudo dpkg -i /tmp/libssl1.1_1.1.1w-0+deb11u1_amd64.deb \
+	sudo dpkg -i /tmp/esl-erlang_26.2.3-1~debian~buster_amd64.deb \
+	sudo unzip -qo /tmp/elixir-otp-26.zip
+	rm /tmp/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
+	rm /tmp/esl-erlang_26.2.3-1~debian~buster_amd64.deb
 	rm /tmp/elixir-otp-26.zip
 
 setup-caddy:
-	@read -p "Enter the server dns (e.g: 'arena-testing.championsofmirra.com'): " user_input; \
-	sudo ufw allow 80 \
-	sudo ufw allow 443 \
-	sudo sed -i "1i $$user_input {" /etc/caddy/Caddyfile; \
-	sudo sed -i "2i \	reverse_proxy localhost:4000" /etc/caddy/Caddyfile; \
-	sudo sed -i "3i }" /etc/caddy/Caddyfile;
+	sudo ufw allow 80
+	sudo ufw allow 443
+	sudo truncate -s 0 /etc/caddy/Caddyfile && \
+	echo "$$(hostname).championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
 	sudo systemctl restart caddy
 
-## Run this as dev
+create-env-file:
+	sudo truncate -s0 /home/$$(SSH_APP_USERNAME)/.env
+	sudo echo "PHX_HOST=$$(hostname).championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "DATABASE_URL=$${DATABASE_URL}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_DATABASE_URL=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "PHX_SERVER=true" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "SECRET_KEY_BASE=$${SECRET_KEY_BASE}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "JWT_PRIVATE_KEY_BASE_64=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "PORT=4000" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "RELEASE_NODE=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "_SERVICE_SUFFIX=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "GATEWAY_URL=https://central-europe-testing.championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "METRICS_ENDPOINT_PORT=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "OVERRIDE_JWT=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "GOOGLE_CLIENT_ID=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "BOT_MANAGER_PORT=4003" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "BOT_MANAGER_HOST=bot-manager.championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_ID=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_SECRET=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "RELEASE=arena" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "TARGET_SERVER=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_EUROPE_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_BRAZIL_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_CHILE_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "NEWRELIC_APP_NAME=$$(hostname)" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "NEWRELIC_KEY=$${NEWRELIC_KEY}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+
+## Run this as app or dev user
+
+app-setup-arena-server: debian-install-dev-deps
+
 debian-install-dev-deps:
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ setup-caddy:
 	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
 	sudo systemctl restart caddy
 
-
 create-env-file:
 	sudo truncate -s0 /home/$(SSH_APP_USERNAME)/.env
 	sudo echo "PHX_HOST=$$(hostname).championsofmirra.com" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -104,33 +104,34 @@ setup-caddy:
 	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
 	sudo systemctl restart caddy
 
+
 create-env-file:
-	sudo truncate -s0 /home/$$(SSH_APP_USERNAME)/.env
-	sudo echo "PHX_HOST=$$(hostname).championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "DATABASE_URL=$${DATABASE_URL}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "CONFIGURATOR_DATABASE_URL=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "PHX_SERVER=true" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "SECRET_KEY_BASE=$${SECRET_KEY_BASE}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "JWT_PRIVATE_KEY_BASE_64=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "PORT=4000" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "RELEASE_NODE=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "_SERVICE_SUFFIX=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "GATEWAY_URL=https://central-europe-testing.championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "METRICS_ENDPOINT_PORT=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "OVERRIDE_JWT=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "GOOGLE_CLIENT_ID=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "BOT_MANAGER_PORT=4003" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "BOT_MANAGER_HOST=bot-manager.championsofmirra.com" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "CONFIGURATOR_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_ID=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_SECRET=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "RELEASE=arena" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "TARGET_SERVER=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "LOADTEST_EUROPE_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "LOADTEST_BRAZIL_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "LOADTEST_CHILE_HOST=" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "NEWRELIC_APP_NAME=$$(hostname)" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
-	sudo echo "NEWRELIC_KEY=$${NEWRELIC_KEY}" | sudo tee -a /home/$$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo truncate -s0 /home/$(SSH_APP_USERNAME)/.env
+	sudo echo "PHX_HOST=$$(hostname).championsofmirra.com" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "DATABASE_URL=$(DATABASE_URL)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_DATABASE_URL=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "PHX_SERVER=true" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "SECRET_KEY_BASE=$(SECRET_KEY_BASE)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "JWT_PRIVATE_KEY_BASE_64=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "PORT=4000" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "RELEASE_NODE=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "_SERVICE_SUFFIX=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "GATEWAY_URL=https://central-europe-testing.championsofmirra.com" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "METRICS_ENDPOINT_PORT=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "OVERRIDE_JWT=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "GOOGLE_CLIENT_ID=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "BOT_MANAGER_PORT=4003" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "BOT_MANAGER_HOST=bot-manager.championsofmirra.com" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_HOST=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_ID=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "CONFIGURATOR_GOOGLE_CLIENT_SECRET=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "RELEASE=arena" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "TARGET_SERVER=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_EUROPE_HOST=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_BRAZIL_HOST=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_CHILE_HOST=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "NEWRELIC_APP_NAME=$$(hostname)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "NEWRELIC_KEY=$(NEWRELIC_KEY)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
 
 ## Run this as app or dev user
 

--- a/apps/configurator/lib/configurator_web/controllers/arena_server_html/arena_server_form.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/arena_server_html/arena_server_form.html.heex
@@ -2,9 +2,8 @@
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
   </.error>
-  <.input field={f[:name]} type="text" label="Name" />
-  <.input field={f[:ip]} type="text" label="Ip" />
-  <.input field={f[:url]} type="text" label="Url" />
+  <.input field={f[:name]} type="text" label="Name, e.g. Europe" />
+  <.input field={f[:url]} type="text" label="Url, e.g. arena-europe-testing.championsofmirra.com" />
   <.input
     field={f[:gateway_url]}
     type="select"
@@ -14,6 +13,7 @@
       "https://central-europe-testing.championsofmirra.com",
       "https://central-europe-staging.championsofmirra.com"
     ]}
+    value="https://central-europe-testing.championsofmirra.com"
   />
   <.input
     field={f[:status]}
@@ -21,6 +21,7 @@
     label="Status"
     prompt="Choose a value"
     options={Ecto.Enum.values(GameBackend.ArenaServers.ArenaServer, :status)}
+    value={:active}
   />
   <.input
     field={f[:environment]}
@@ -28,6 +29,7 @@
     label="Environment"
     prompt="Choose a value"
     options={Ecto.Enum.values(GameBackend.ArenaServers.ArenaServer, :environment)}
+    value={:development}
   />
   <:actions>
     <.button>Save Arena server</.button>

--- a/devops/arena-start.sh
+++ b/devops/arena-start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+. "$HOME/.cargo/env"
+set -e
+set +x  # Disable debug mode
+export $(cat $HOME/.env | xargs)
+set -x  # Re-enable debug mode
+
+cd mirra_backend/
+chmod +x devops/entrypoint.sh
+mix local.hex --force && mix local.rebar --force
+mix deps.get --only prod
+MIX_ENV=prod mix release arena --overwrite
+
+mkdir -p $HOME/.config/systemd/user/
+
+cat <<EOF >$HOME/.config/systemd/user/arena.service
+[Unit]
+Description=$arena
+
+[Service]
+WorkingDirectory=$HOME/mirra_backend
+Restart=on-failure
+ExecStart=$HOME/mirra_backend/devops/entrypoint.sh
+ExecReload=/bin/kill -HUP
+KillSignal=SIGTERM
+EnvironmentFile=$HOME/.env
+LimitNOFILE=100000
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user stop arena
+systemctl --user daemon-reload
+systemctl --user start arena
+
+set +x; echo -e "\nNew Arena server is up and running!\nGo to configurator.championsofmirra.com and add a new Arena Server\nIn URL field, enter: $(hostname).championsofmirra.com"

--- a/devops/setup-admin-deps.sh
+++ b/devops/setup-admin-deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export SSH_APP_USERNAME=$SSH_APP_USERNAME
+export DATABASE_URL=$DATABASE_URL
+export SECRET_KEY_BASE=$SECRET_KEY_BASE
+export NEWRELIC_KEY=$NEWRELIC_KEY
+
+cd ~/mirra_backend && make admin-setup-arena-server
+
+sudo rm -rf /home/$SSH_APP_USERNAME/mirra_backend
+sudo mv ~/mirra_backend /home/$SSH_APP_USERNAME/
+sudo chown -R $SSH_APP_USERNAME:$SSH_APP_USERNAME /home/$SSH_APP_USERNAME/mirra_backend
+
+sudo mv ~/.ssh/id_ed25519 /home/$SSH_APP_USERNAME/.ssh/
+sudo chown $SSH_APP_USERNAME:$SSH_APP_USERNAME /home/$SSH_APP_USERNAME/.ssh/id_ed25519

--- a/devops/setup-admin-deps.sh
+++ b/devops/setup-admin-deps.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+: "${SSH_APP_USERNAME:?SSH_APP_USERNAME is not set}"
+: "${DATABASE_URL:?DATABASE_URL is not set}"
+: "${SECRET_KEY_BASE:?SECRET_KEY_BASE is not set}"
+: "${NEWRELIC_KEY:?NEWRELIC_KEY is not set}"
+
 set -ex
 
 export SSH_APP_USERNAME=$SSH_APP_USERNAME


### PR DESCRIPTION
## Motivation

We need an easy way to deploy new Arena Servers, we are doing a lot of manual work.
Closes #1144

## Summary of changes

- [Add new Arena server deployment workflow](https://github.com/lambdaclass/mirra_backend/pull/1145/commits/01cdf22b3441a83c32fcf520b398ab2a6e2e029a) 
- [Make arena servers form more user-friendly](https://github.com/lambdaclass/mirra_backend/pull/1145/commits/121a4ad51370235c25e443cfe16815fb7536a546)
- [Remove on-push trigger and fixed branch that were added for testing purposes](https://github.com/lambdaclass/mirra_backend/pull/1145/commits/d3861ebd266f5cc8deccd5b6e315d8097de2a5a1) 
d3861eb

## How to test it?

I already tested the workflow A LOT. You can see all the deployments in the PR history or actions tab.
Last one was this: https://github.com/lambdaclass/mirra_backend/actions/runs/14246490944/job/39928755013
After the merge, we can test this by interacting via the actions tab, writing the server hostname or ip. 
Docs will be added in a separate notion.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
