### PR TITLE
1148 - Make GameTracker.start_tracking/1 message async to avoid message queue bottlenecks

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -88,7 +88,14 @@ defmodule Arena.GameUpdater do
     bot_clients_ids =
       Enum.filter(players, fn player -> player.type == :bot end) |> Enum.map(fn player -> player.client_id end)
 
-    :ok = GameTracker.start_tracking(match_id, game_state.client_to_player_map, game_state.players, clients_ids)
+    :ok =
+      GameTracker.start_tracking(%{
+        match_pid: self(),
+        match_id: match_id,
+        client_to_player_map: game_state.client_to_player_map,
+        players: game_state.players,
+        human_clients: clients_ids
+      })
 
     :telemetry.execute([:arena, :game], %{count: 1})
 


### PR DESCRIPTION
## Motivation

In recent loadtests we spotted a bottleneck in our processes' message queues
Closes #1148

## Summary of changes

[Make GameTracker.start_tracking/1 message async to avoid message bottlenecks](https://github.com/lambdaclass/mirra_backend/commit/4eec4d26013d6ea247b9406b21e02ad29b44352b)

## How to test it?

Just play a game, everything should work as usual.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
