### PR TITLE
Take user quest date from the correct place

### DIFF
--- a/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/quests.ex
@@ -295,7 +295,7 @@ defmodule GameBackend.CurseOfMirra.Quests do
     |> Repo.transaction()
   end
 
-  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :milestone} = milestone_quest}, user) do
+  def get_user_quest_progress(%UserQuest{quest: %Quest{type: :milestone}} = milestone_quest, user) do
     user.user_quests
     |> Enum.count(fn %UserQuest{} = user_quest ->
       NaiveDateTime.diff(user_quest.inserted_at, milestone_quest.inserted_at, :day) == 0 and


### PR DESCRIPTION
## Motivation

Milestone progress isn't moving from 0 in prod.
Closes #1153  

## Summary of changes

[Take user quest date from the correct place](https://github.com/lambdaclass/mirra_backend/pull/1150/commits/fef56453fc93dad70e45f59c3bbbfbc6716bc50c)

## How to test it?

It worked before locally, the thing is that we were taking the quest inserted_at date instead of the UserQuest inserted_at date.
So you can start the DB, move a few days forward and try to complete the quests. The milestone progress should start moving along with your completed daily quests.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
