### PR TITLE
Upgrade tailscale gh action version

### DIFF
--- a/.github/workflows/arena-argentina-testing-deploy.yaml
+++ b/.github/workflows/arena-argentina-testing-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/arena-chile-testing-deploy.yml
+++ b/.github/workflows/arena-chile-testing-deploy.yml
@@ -1,7 +1,5 @@
 name: "[TESTING-CHILE] Deploy to Chile Arena Testing"
 on:
-  push:
-    branches: upgrade-tailscale-gh-action-version
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/arena-chile-testing-deploy.yml
+++ b/.github/workflows/arena-chile-testing-deploy.yml
@@ -1,5 +1,7 @@
 name: "[TESTING-CHILE] Deploy to Chile Arena Testing"
 on:
+  push:
+    branches: upgrade-tailscale-gh-action-version
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/arena-chile-testing-deploy.yml
+++ b/.github/workflows/arena-chile-testing-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/arena-europe-testing-deploy.yml
+++ b/.github/workflows/arena-europe-testing-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/arena-usa-testing-deploy.yml
+++ b/.github/workflows/arena-usa-testing-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/bot-manager-deploy.yml
+++ b/.github/workflows/bot-manager-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/central-europe-staging-deploy.yml
+++ b/.github/workflows/central-europe-staging-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/central-europe-testing-deploy.yml
+++ b/.github/workflows/central-europe-testing-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/deploy-new-arena-server.yml
+++ b/.github/workflows/deploy-new-arena-server.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
           
       - name: Tailscale (admin)
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_ADMIN_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_ADMIN_OAUTH_SECRET }}
@@ -72,7 +72,7 @@ jobs:
             /home/${SSH_USERNAME}/mirra_backend/devops/setup-admin-deps.sh
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/loadtest-europe-client-deploy.yml
+++ b/.github/workflows/loadtest-europe-client-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}

--- a/.github/workflows/new-arena-europe-testing-deploy.yml
+++ b/.github/workflows/new-arena-europe-testing-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v3
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}


### PR DESCRIPTION
## Motivation

v2 version had a vulnerability.

## Summary of changes

[Upgrade tailscale gh action version](https://github.com/lambdaclass/mirra_backend/pull/1151/commits/aedac63b6b68185ac47a87fd7e41dc811593079c)

## How to test it?

*You can explain how you tested it or suggest a way to do so.*

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
