### PR TITLE
Shinko Ultimate: decrease abilitie duration

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1047,7 +1047,7 @@ skills = [
     "attack_type" => "melee",
     "cooldown_mechanism" => "time",
     "cooldown_ms" => 10000,
-    "execution_duration_ms" => 525,
+    "execution_duration_ms" => 400,
     "activation_delay_ms" => 0,
     "is_passive" => false,
     "autoaim" => false,
@@ -1266,7 +1266,7 @@ otix_params = %{
 
 shinko_params = %{
   name: "shinko",
-  active: true,
+  active: false,
   base_speed: 0.65,
   base_size: 100.0,
   base_health: 400,

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1384,7 +1384,6 @@ shinko_basic_params = %{
   kenzu_basic_params,
   otix_corrupt_underground,
   otix_basic_params,
-  shinko_basic_params,
   muflus_basic_params
 ]
 |> Enum.each(fn skin_params -> Characters.insert_skin(skin_params) end)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1391,7 +1391,8 @@ shinko_basic_params = %{
   kenzu_basic_params,
   otix_corrupt_underground,
   otix_basic_params,
-  muflus_basic_params
+  muflus_basic_params,
+  shinko_basic_params
 ]
 |> Enum.each(fn skin_params -> Characters.insert_skin(skin_params) end)
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1266,7 +1266,7 @@ otix_params = %{
 
 shinko_params = %{
   name: "shinko",
-  active: false,
+  active: true,
   base_speed: 0.65,
   base_size: 100.0,
   base_health: 400,
@@ -1368,6 +1368,12 @@ otix_basic_params = %{
   character_id: Enum.find(characters, fn c -> c.name == "otix" end).id
 }
 
+shinko_basic_params = %{
+  is_default: true,
+  name: "Basic",
+  character_id: Enum.find(characters, fn c -> c.name == "shinko" end).id
+}
+
 # Insert skins
 [
   h4ck_fenix_params,
@@ -1378,6 +1384,7 @@ otix_basic_params = %{
   kenzu_basic_params,
   otix_corrupt_underground,
   otix_basic_params
+  shinko_basic_params,
 ]
 |> Enum.each(fn skin_params -> Characters.insert_skin(skin_params) end)
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1383,8 +1383,9 @@ shinko_basic_params = %{
   kenzu_black_lotus_params,
   kenzu_basic_params,
   otix_corrupt_underground,
-  otix_basic_params
+  otix_basic_params,
   shinko_basic_params,
+  muflus_basic_params
 ]
 |> Enum.each(fn skin_params -> Characters.insert_skin(skin_params) end)
 


### PR DESCRIPTION
## Summary of changes

- Modify Shinko's ultimate skill duration. 550ms > 400ms

## How to test it?

Turn on Shinko in: 
Backend repo -> seeds.exs

```
# Characters params
muflus_params = %{
  name: "shinko",
  active: **true**,
  ...
```

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
