### PR TITLE
add env to configurator config and consume from home

### DIFF
--- a/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
+++ b/apps/configurator/lib/configurator_web/controllers/home_html/home.html.heex
@@ -1,4 +1,4 @@
-<%= if not is_nil(@current_user) or Mix.env() == :dev do %>
+<%= if not is_nil(@current_user) or Application.get_env(:configurator, :env) == :dev do %>
   <.header>
     Welcome to Champions of Mirra Configurator
   </.header>

--- a/config/config.exs
+++ b/config/config.exs
@@ -193,6 +193,7 @@ config :gateway, Gateway.Endpoint,
 # App configuration: configurator #
 ###################################
 config :configurator,
+  env: config_env(),
   ecto_repos: [Configurator.Repo],
   generators: [timestamp_type: :utc_datetime]
 


### PR DESCRIPTION
## Motivation

on #1143 we added a way to override the google login on dev environments. That works, but the problem is that we used `Mix.env/0` which works perfectly to work on a local environment but is not included in a release build. This means that if you are not logged in you will always get an internal server error

The error I was getting:

```elixir
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]: ** (UndefinedFunctionError) function Mix.env/0 is undefined (module Mix is not available)
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     Mix.env()
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (configurator 0.1.0) lib/configurator_web/controllers/home_html/home.html.heex:1: anonymous fn/2 in ConfiguratorWeb.HomeHTML.home/1
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (phoenix_live_view 0.20.3) lib/phoenix_live_view/engine.ex:150: Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/1
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (phoenix_live_view 0.20.3) lib/phoenix_live_view/engine.ex:166: Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/3
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (phoenix 1.7.11) lib/phoenix/controller.ex:1008: anonymous fn/5 in Phoenix.Controller.template_render_to_iodata/4
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (telemetry 1.2.1) /tmp/mirra_backend/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (phoenix 1.7.11) lib/phoenix/controller.ex:974: Phoenix.Controller.render_and_send/4
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]:     (configurator 0.1.0) lib/configurator_web/controllers/home_controller.ex:1: ConfiguratorWeb.HomeController.action/2
Apr 10 11:44:26 mirra-central-europe-testing entrypoint.sh[105200]: Last message: {:continue, :handle_connection}
```

## Summary of changes

- added configurator config `env`
- use `Application.get_env/2` instead of `Mix.get_env`

## How to test it?

The behavior should be similar, locally you should not need to be logged in to use the configurator. If you are logged in it should work as usual.

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
