### PR TITLE
feat: give gold to top 3 in game

### DIFF
--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -72,21 +72,27 @@ defmodule GameBackend.CurseOfMirra.Matches do
   end
 
   defp give_gold(multi, results) do
-    multi = Multi.run(multi, :get_gold_currency, fn _repo, _changes -> 
-      Currencies.get_currency_by_name_and_game("Gold", Utils.get_game_id(:curse_of_mirra))
-    end)
+    multi =
+      Multi.run(multi, :get_gold_currency, fn _repo, _changes ->
+        Currencies.get_currency_by_name_and_game("Gold", Utils.get_game_id(:curse_of_mirra))
+      end)
 
     Enum.reduce(results, multi, fn result, transaction_acc ->
-      Multi.run(transaction_acc, {:gold_reward, result["user_id"]}, fn _repo, %{get_users: users, get_gold_currency: gold_currency} ->
+      Multi.run(transaction_acc, {:gold_reward, result["user_id"]}, fn _repo,
+                                                                       %{
+                                                                         get_users: users,
+                                                                         get_gold_currency: gold_currency
+                                                                       } ->
         user = Enum.find(users, fn user -> user.id == result["user_id"] end)
 
         if result["position"] <= 3 do
-          gold_reward_amount = case result["position"] do
-            1 -> 40
-            2 -> 15
-            3 -> 5
-            _ -> 0
-          end
+          gold_reward_amount =
+            case result["position"] do
+              1 -> 40
+              2 -> 15
+              3 -> 5
+              _ -> 0
+            end
 
           Currencies.add_currency(user.id, gold_currency.id, gold_reward_amount)
         end

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -97,6 +97,8 @@ defmodule GameBackend.CurseOfMirra.Matches do
           gold_reward_amount = Map.get(@gold_rewards_per_position, resulting_position)
 
           Currencies.add_currency(user.id, gold_currency.id, gold_reward_amount)
+        else
+          {:ok, nil}
         end
       end)
     end)

--- a/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
+++ b/apps/game_backend/lib/game_backend/curse_of_mirra/matches.ex
@@ -12,6 +12,12 @@ defmodule GameBackend.CurseOfMirra.Matches do
   alias GameBackend.Matches.ArenaMatchResult
   alias GameBackend.Repo
 
+  @gold_rewards_per_position %{
+    1 => 40,
+    2 => 15,
+    3 => 5
+  }
+
   def create_arena_match_results(match_id, results) do
     Multi.new()
     |> create_arena_match_results(match_id, results)
@@ -85,14 +91,10 @@ defmodule GameBackend.CurseOfMirra.Matches do
                                                                        } ->
         user = Enum.find(users, fn user -> user.id == result["user_id"] end)
 
-        if result["position"] <= 3 do
-          gold_reward_amount =
-            case result["position"] do
-              1 -> 40
-              2 -> 15
-              3 -> 5
-              _ -> 0
-            end
+        resulting_position = result["position"]
+
+        if Map.has_key?(@gold_rewards_per_position, resulting_position) do
+          gold_reward_amount = Map.get(@gold_rewards_per_position, resulting_position)
 
           Currencies.add_currency(user.id, gold_currency.id, gold_reward_amount)
         end


### PR DESCRIPTION
## Motivation
We need an incentive for players to play even with quests completed.

Closes #1157 

> [!NOTE]
> There's a separate follow up issue to tackle tweaking this values from the configurator: #1172

## Summary of changes

- added a step to `create_arena_match_results` to give gold to players based on the final position

## How to test it?

run the backend locally. Win a match. See that you get 40 gold. End up second you should get 15 gold. End up third you should get 5 gold. Any other position does not earn gold.

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
