### PR TITLE
Add new prometheus metrics

### DIFF
--- a/apps/arena/lib/arena/application.ex
+++ b/apps/arena/lib/arena/application.ex
@@ -8,7 +8,8 @@ defmodule Arena.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      ArenaWeb.Telemetry,
+      {Registry, keys: :unique, name: BotRegistry},
+      {Registry, keys: :unique, name: GameUpdaterRegistry},
       {DNSCluster, query: Application.get_env(:arena, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Arena.PubSub},
       # Start the Finch HTTP client for sending emails
@@ -23,10 +24,10 @@ defmodule Arena.Application do
       Arena.Authentication.GatewaySigner,
       Arena.Bots.BotSupervisor,
       Arena.Bots.PathfindingGrid,
-      {Registry, keys: :unique, name: BotRegistry},
       # Start a worker by calling: Arena.Worker.start_link(arg)
       # {Arena.Worker, arg},
       # Start to serve requests, typically the last entry
+      ArenaWeb.Telemetry,
       ArenaWeb.Endpoint
     ]
 

--- a/apps/arena/lib/arena/bots/bot.ex
+++ b/apps/arena/lib/arena/bots/bot.ex
@@ -21,6 +21,8 @@ defmodule Arena.Bots.Bot do
     send(self(), :decide_action)
     send(self(), :perform_action)
 
+    :telemetry.execute([:bots], %{count: 1})
+
     {:ok,
      %{
        bot_id: bot_id,
@@ -148,6 +150,7 @@ defmodule Arena.Bots.Bot do
   defp send_current_action(_), do: nil
 
   def terminate(reason, state) do
+    :telemetry.execute([:bots], %{count: -1})
     Logger.error("Bot #{state.bot_id} terminating: #{inspect(reason)}")
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -62,6 +62,7 @@ defmodule Arena.GameUpdater do
 
   def init(%{players: players, game_params: game_params, map_mode_params: map_mode_params}) do
     game_id = self() |> :erlang.term_to_binary() |> Base58.encode()
+    {:ok, _} = Registry.register(GameUpdaterRegistry, game_id, :game_updater)
     game_config = Configuration.get_game_config(map_mode_params.map.name)
 
     game_config =

--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -4,6 +4,8 @@ defmodule Arena.Utils do
   It contains utility functions like math functions.
   """
 
+  alias Arena.Matchmaking
+
   @bot_prefixes [
     "Astro",
     "Blaze",
@@ -140,4 +142,58 @@ defmodule Arena.Utils do
 
   # Time to wait to start game with any amount of clients
   def start_timeout_ms(), do: 4_000
+
+  def message_queue_lengths() do
+    [
+      Matchmaking.DeathmatchMode,
+      Matchmaking.DuoMode,
+      Matchmaking.GameLauncher,
+      Matchmaking.QuickGameMode,
+      Matchmaking.TrioMode,
+      Arena.GameBountiesFetcher,
+      Arena.GameTracker,
+      Arena.Bots.PathfindingGrid
+    ]
+    |> Enum.each(fn registered_name ->
+      Process.whereis(registered_name)
+      |> register_process_info()
+    end)
+
+    register_bots_queues()
+    register_game_updater_queues()
+  end
+
+  defp register_process_info(nil), do: nil
+
+  defp register_process_info(pid) do
+    case Process.info(pid, [:message_queue_len, :registered_name]) do
+      [message_queue_len: len, registered_name: name] -> register_queue_length(name, len)
+      [message_queue_len: len] -> register_queue_length(pid, len)
+      _ -> nil
+    end
+  end
+
+  defp register_queue_length(name, len) do
+    :telemetry.execute([:vm, :message_queue], %{length: len}, %{process: inspect(name)})
+  end
+
+  defp register_bots_queues() do
+    Registry.select(BotRegistry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.each(fn {_bot_id, pid} ->
+      case Process.info(pid, [:message_queue_len]) do
+        [message_queue_len: len] -> :telemetry.execute([:bots, :message_queue], %{length: len}, %{})
+        _ -> nil
+      end
+    end)
+  end
+
+  defp register_game_updater_queues() do
+    Registry.select(GameUpdaterRegistry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.each(fn {_game_id, pid} ->
+      case Process.info(pid, [:message_queue_len]) do
+        [message_queue_len: len] -> :telemetry.execute([:game_updater, :message_queue], %{length: len}, %{})
+        _ -> nil
+      end
+    end)
+  end
 end

--- a/apps/arena/lib/arena/utils.ex
+++ b/apps/arena/lib/arena/utils.ex
@@ -4,8 +4,6 @@ defmodule Arena.Utils do
   It contains utility functions like math functions.
   """
 
-  alias Arena.Matchmaking
-
   @bot_prefixes [
     "Astro",
     "Blaze",
@@ -144,33 +142,20 @@ defmodule Arena.Utils do
   def start_timeout_ms(), do: 4_000
 
   def message_queue_lengths() do
-    [
-      Matchmaking.DeathmatchMode,
-      Matchmaking.DuoMode,
-      Matchmaking.GameLauncher,
-      Matchmaking.QuickGameMode,
-      Matchmaking.TrioMode,
-      Arena.GameBountiesFetcher,
-      Arena.GameTracker,
-      Arena.Bots.PathfindingGrid
-    ]
-    |> Enum.each(fn registered_name ->
-      Process.whereis(registered_name)
-      |> register_process_info()
-    end)
-
+    register_all_processes_queues()
     register_bots_queues()
     register_game_updater_queues()
   end
 
-  defp register_process_info(nil), do: nil
-
-  defp register_process_info(pid) do
-    case Process.info(pid, [:message_queue_len, :registered_name]) do
-      [message_queue_len: len, registered_name: name] -> register_queue_length(name, len)
-      [message_queue_len: len] -> register_queue_length(pid, len)
-      _ -> nil
-    end
+  def register_all_processes_queues() do
+    Process.list()
+    |> Enum.each(fn pid ->
+      case Process.info(pid, [:message_queue_len, :registered_name]) do
+        [message_queue_len: len, registered_name: name] -> register_queue_length(name, len)
+        [message_queue_len: len] -> register_queue_length(pid, len)
+        _ -> nil
+      end
+    end)
   end
 
   defp register_queue_length(name, len) do

--- a/apps/arena/lib/arena_web/telemetry.ex
+++ b/apps/arena/lib/arena_web/telemetry.ex
@@ -34,6 +34,7 @@ defmodule ArenaWeb.Telemetry do
       # Bots
       summary([:bots, :message_queue, :length]),
       distribution([:bots, :message_queue, :length], reporter_options: [buckets: [0, 10, 100, 1000, 10000, 100_000]]),
+      sum([:bots, :count], description: "Amount of active bots"),
 
       # GameUpdater
       summary([:game_updater, :message_queue, :length]),

--- a/apps/arena/lib/arena_web/telemetry.ex
+++ b/apps/arena/lib/arena_web/telemetry.ex
@@ -28,6 +28,19 @@ defmodule ArenaWeb.Telemetry do
       last_value("vm.total_run_queue_lengths.cpu"),
       last_value("vm.total_run_queue_lengths.io"),
 
+      # Single instance GenServers' message queues
+      last_value([:vm, :message_queue, :length], tags: [:process]),
+
+      # Bots
+      summary([:bots, :message_queue, :length]),
+      distribution([:bots, :message_queue, :length], reporter_options: [buckets: [0, 10, 100, 1000, 10000, 100_000]]),
+
+      # GameUpdater
+      summary([:game_updater, :message_queue, :length]),
+      distribution([:game_updater, :message_queue, :length],
+        reporter_options: [buckets: [0, 10, 100, 1000, 10000, 100_000]]
+      ),
+
       ## Arena (game) metrics
       sum("arena.game.count", description: "Number of games in progress"),
       ## TODO: this metric is an attempt to gather data to properly set the buckets for the distribution metric below
@@ -50,6 +63,7 @@ defmodule ArenaWeb.Telemetry do
       # A module, function and arguments to be invoked periodically.
       # This function must call :telemetry.execute/3 and a metric must be added above.
       # {ArenaWeb, :count_users, []}
+      {Arena.Utils, :message_queue_lengths, []}
     ]
   end
 end

--- a/apps/arena/lib/arena_web/telemetry.ex
+++ b/apps/arena/lib/arena_web/telemetry.ex
@@ -28,7 +28,7 @@ defmodule ArenaWeb.Telemetry do
       last_value("vm.total_run_queue_lengths.cpu"),
       last_value("vm.total_run_queue_lengths.io"),
 
-      # Single instance GenServers' message queues
+      # All BEAM processes message queues
       last_value([:vm, :message_queue, :length], tags: [:process]),
 
       # Bots

--- a/apps/arena/lib/arena_web/telemetry.ex
+++ b/apps/arena/lib/arena_web/telemetry.ex
@@ -33,13 +33,13 @@ defmodule ArenaWeb.Telemetry do
 
       # Bots
       summary([:bots, :message_queue, :length]),
-      distribution([:bots, :message_queue, :length], reporter_options: [buckets: [0, 10, 100, 1000, 10000, 100_000]]),
+      distribution([:bots, :message_queue, :length], reporter_options: [buckets: [0, 10, 100, 1_000, 10_000, 100_000]]),
       sum([:bots, :count], description: "Amount of active bots"),
 
       # GameUpdater
       summary([:game_updater, :message_queue, :length]),
       distribution([:game_updater, :message_queue, :length],
-        reporter_options: [buckets: [0, 10, 100, 1000, 10000, 100_000]]
+        reporter_options: [buckets: [0, 10, 100, 1_000, 10_000, 100_000]]
       ),
 
       ## Arena (game) metrics

--- a/grafana_arena_dashboard.json
+++ b/grafana_arena_dashboard.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.4.2"
+      "version": "11.5.2"
     },
     {
       "type": "datasource",
@@ -57,6 +57,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Amount of active bots.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -69,6 +70,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -117,7 +119,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 8,
+      "id": 18,
       "options": {
         "legend": {
           "calcs": [],
@@ -126,30 +128,30 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.2",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "arena_game_count",
+          "expr": "bots_count",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "useBackend": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "Game count",
+      "title": "[BOTS] Count",
       "type": "timeseries"
     },
     {
@@ -169,6 +171,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -217,7 +220,7 @@
         "x": 12,
         "y": 0
       },
-      "id": 7,
+      "id": 15,
       "options": {
         "legend": {
           "calcs": [],
@@ -226,30 +229,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.2",
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "arena_clients_count",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(game_updater_message_queue_length_bucket[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "Current connected players",
+      "title": "[GameUpdater] 95th percentile msg queue (1 min)",
       "type": "timeseries"
     },
     {
@@ -269,6 +268,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -307,8 +307,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "ns"
+          }
         },
         "overrides": []
       },
@@ -318,7 +317,7 @@
         "x": 0,
         "y": 8
       },
-      "id": 9,
+      "id": 14,
       "options": {
         "legend": {
           "calcs": [],
@@ -327,29 +326,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "avg by(host) (arena_game_tick_duration_measure)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(bots_message_queue_length_bucket[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "Game tick last duration",
+      "title": "[BOTS] 95th percentile msg queue (1 min)",
       "type": "timeseries"
     },
     {
@@ -357,7 +353,6 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -370,6 +365,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -408,8 +404,7 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "count"
+          }
         },
         "overrides": []
       },
@@ -419,7 +414,7 @@
         "x": 12,
         "y": 8
       },
-      "id": 2,
+      "id": 17,
       "options": {
         "legend": {
           "calcs": [],
@@ -428,29 +423,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "avg by(le) (arena_game_tick_duration_bucket)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, rate(game_updater_message_queue_length_bucket[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "(Do not use) Game tick duration",
+      "title": "[GameUpdater] Median msg queue (1 min)",
       "type": "timeseries"
     },
     {
@@ -470,6 +462,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -518,7 +511,7 @@
         "x": 0,
         "y": 16
       },
-      "id": 5,
+      "id": 16,
       "options": {
         "legend": {
           "calcs": [],
@@ -527,29 +520,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "vm_total_run_queue_lengths_total",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, rate(bots_message_queue_length_bucket[1m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "VM total run queue lengths total",
+      "title": "[BOTS] Median msg queue (1 min)",
       "type": "timeseries"
     },
     {
@@ -569,6 +559,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -617,7 +608,7 @@
         "x": 12,
         "y": 16
       },
-      "id": 4,
+      "id": 12,
       "options": {
         "legend": {
           "calcs": [],
@@ -626,29 +617,30 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "vm_total_run_queue_lengths_io",
+          "editorMode": "code",
+          "expr": "rate(bots_message_queue_length_sum[1m]) / rate(bots_message_queue_length_count[1m])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "useBackend": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "VM total run queue lengths IO",
+      "title": "[BOTS] Avg msg queue per avg count (1 min)",
       "type": "timeseries"
     },
     {
@@ -668,6 +660,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -716,6 +709,712 @@
         "x": 0,
         "y": 24
       },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(game_updater_message_queue_length_sum[1m]) / rate(game_updater_message_queue_length_count[1m])\n",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "title": "[GameUpdater] Avg msg queue per avg count (1 min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "arena_clients_count",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Current connected players",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "arena_game_count",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Game count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "count"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg by(le) (arena_game_tick_duration_bucket)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "(Do not use) Game tick duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg by(host) (arena_game_tick_duration_measure)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Game tick last duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "vm_total_run_queue_lengths_io",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "VM total run queue lengths IO",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "vm_total_run_queue_lengths_total",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "VM total run queue lengths total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
       "id": 3,
       "options": {
         "legend": {
@@ -725,10 +1424,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -752,7 +1453,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [],
   "templating": {
     "list": []
@@ -765,6 +1466,6 @@
   "timezone": "browser",
   "title": "Arena",
   "uid": "fdixa7yyhidxca",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: 'arena'
     scrape_interval: 1m
     static_configs:
-      - targets: ['host.docker.internal:9568']
+      - targets: ['arena-chile-testing.prometheus.championsofmirra.com/metrics']

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,4 +5,6 @@ scrape_configs:
   - job_name: 'arena'
     scrape_interval: 1m
     static_configs:
-      - targets: ['arena-chile-testing.prometheus.championsofmirra.com/metrics']
+      - targets: 
+        - 'arena-chile-testing.prometheus.championsofmirra.com'
+    metrics_path: '/metrics'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -5,6 +5,4 @@ scrape_configs:
   - job_name: 'arena'
     scrape_interval: 1m
     static_configs:
-      - targets: 
-        - 'arena-chile-testing.prometheus.championsofmirra.com'
-    metrics_path: '/metrics'
+      - targets: ['host.docker.internal:9568']


### PR DESCRIPTION
## Motivation

Since we got grafana deployed now, we need more metrics to get more useful insights of our game matches.

## Summary of changes

- [Start Registry processes before Telemetry to avoid errors](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/03e58b8e8ec342ee8561a80bb045f8b973e839f7)
- [Register each GameUpdater process to use telemetry on them](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/f946e58e5d6647f6b57f7efd344c2717974f1f2b)
- [Add functions to gather message queue lengths from desired processes](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/5d2d32b37ff9c6967680d7fb7fb80eb7da47f019)
- [Add telemetry config to use new message queue functions](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/11d4bbb94fbd7bc1edfaf4be80c503e4a12b5673)
- [Send telemetry events for all BEAM processes instead of a few genservers](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/83c9a744dafaa2c3ac5a7405fabf8b28c9940db9)
- [Add telemetry events to count amount of active bots](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/3003893d330c52d1e842018a695f12f39d07f061)
- [Export new dashboard](https://github.com/lambdaclass/mirra_backend/pull/1187/commits/c92895fc33580bc9de0eeb71b99be4bb989e1b36)

## How to test it?

You can play a match and go to:
- http://localhost:9568/metrics to see metrics.
- http://localhost:9100/ to see them in grafana (add new panel/dashboard).

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
