### PR TITLE
[GH-1188] BUG-Merliot: center lake doesnt have the correct collider type 

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -3120,12 +3120,12 @@ merliot_map_config = %{
     },
     %{
       "base_status" => nil,
-      "name" => "Center altar",
-      "position" => %{"x" => "31", "y" => "-140"},
-      "radius" => "400",
+      "name" => "Center",
+      "position" => %{"x" => "-25.95077", "y" => "-25.9697"},
+      "radius" => "446.8141",
       "shape" => "circle",
       "statuses_cycle" => nil,
-      "type" => "static",
+      "type" => "lake",
       "vertices" => []
     },
     %{


### PR DESCRIPTION
## Motivation
player cannot shoot above (or through) the center of the map. it should have the lake collider type

Closes #1188

## Summary of changes

changed the center collider type to lake. in seeds it had the old center shrine collider in static

https://github.com/user-attachments/assets/92de43d3-651b-4e04-ad90-65febb5adc9c


```
 "base_status" => nil,
      "name" => "Center",
      "position" => %{"x" => "-25.95077", "y" => "-25.9697"},
      "radius" => "446.8141",
      "shape" => "circle",
      "statuses_cycle" => nil,
      "type" => "lake",
      "vertices" => []
```

## How to test it?

1. using the 1188-bug-merliot-center-fix-collider-type branch, start up the local backend
2. notice the player now can shoot above the center piece

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
