### PR TITLE
[GH-1191] fix add missing character level to queues

### DIFF
--- a/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/deathmatch_mode.ex
@@ -38,6 +38,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
     client = %{
       client_id: params.client_id,
       character_name: params.character_name,
+      character_level: params.character_level,
       skin_name: params.skin_name,
       name: params.player_name,
       from_pid: from_pid,
@@ -121,6 +122,7 @@ defmodule Arena.Matchmaking.DeathmatchMode do
         client_id: client_id,
         skin_name: "Basic",
         character_name: Enum.random(characters).name,
+        character_level: 1,
         name: Enum.at(bot_names, i - 1),
         type: :bot
       }

--- a/apps/arena/lib/arena/matchmaking/duo_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/duo_mode.ex
@@ -37,6 +37,7 @@ defmodule Arena.Matchmaking.DuoMode do
       client_id: params.client_id,
       character_name: params.character_name,
       skin_name: params.skin_name,
+      character_level: params.character_level,
       name: params.player_name,
       from_pid: from_pid,
       type: :human
@@ -118,6 +119,7 @@ defmodule Arena.Matchmaking.DuoMode do
         client_id: client_id,
         skin_name: "Basic",
         character_name: Enum.random(characters).name,
+        character_level: 1,
         name: Enum.at(bot_names, i - 1),
         type: :bot
       }

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -27,6 +27,8 @@ defmodule Arena.Matchmaking.QuickGameMode do
     client = %{
       client_id: client_id,
       character_name: character_name,
+      # TODO: fetch this? Is it relevant for a quick game?
+      character_level: 1,
       name: player_name,
       from_pid: from_pid,
       type: :human

--- a/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/quick_game_mode.ex
@@ -27,8 +27,6 @@ defmodule Arena.Matchmaking.QuickGameMode do
     client = %{
       client_id: client_id,
       character_name: character_name,
-      # TODO: fetch this? Is it relevant for a quick game?
-      character_level: 1,
       name: player_name,
       from_pid: from_pid,
       type: :human

--- a/apps/arena/lib/arena/matchmaking/trio_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/trio_mode.ex
@@ -33,8 +33,6 @@ defmodule Arena.Matchmaking.TrioMode do
   def handle_call({:join, params}, {from_pid, _}, %{clients: clients} = state) do
     batch_start_at = maybe_make_batch_start_at(state.clients, state.batch_start_at)
 
-    IO.inspect("HOLA")
-
     client = %{
       client_id: params.client_id,
       character_name: params.character_name,
@@ -44,8 +42,6 @@ defmodule Arena.Matchmaking.TrioMode do
       from_pid: from_pid,
       type: :human
     }
-
-    IO.inspect("CHAU")
 
     {:reply, :ok,
      %{
@@ -64,11 +60,7 @@ defmodule Arena.Matchmaking.TrioMode do
   def handle_info(:launch_game?, %{clients: clients} = state) do
     Process.send_after(self(), :launch_game?, 300)
 
-    IO.inspect("Launch Game?")
-
     state = Matchmaking.get_matchmaking_configuration(state, 3, "battle_royale")
-
-    IO.inspect(Map.has_key?(state, :game_mode_configuration), label: "HAS KEY")
 
     diff = System.monotonic_time(:millisecond) - state.batch_start_at
 

--- a/apps/arena/lib/arena/matchmaking/trio_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/trio_mode.ex
@@ -33,14 +33,19 @@ defmodule Arena.Matchmaking.TrioMode do
   def handle_call({:join, params}, {from_pid, _}, %{clients: clients} = state) do
     batch_start_at = maybe_make_batch_start_at(state.clients, state.batch_start_at)
 
+    IO.inspect("HOLA")
+
     client = %{
       client_id: params.client_id,
       character_name: params.character_name,
       skin_name: params.skin_name,
+      character_level: params.character_level,
       name: params.player_name,
       from_pid: from_pid,
       type: :human
     }
+
+    IO.inspect("CHAU")
 
     {:reply, :ok,
      %{
@@ -59,7 +64,11 @@ defmodule Arena.Matchmaking.TrioMode do
   def handle_info(:launch_game?, %{clients: clients} = state) do
     Process.send_after(self(), :launch_game?, 300)
 
+    IO.inspect("Launch Game?")
+
     state = Matchmaking.get_matchmaking_configuration(state, 3, "battle_royale")
+
+    IO.inspect(Map.has_key?(state, :game_mode_configuration), label: "HAS KEY")
 
     diff = System.monotonic_time(:millisecond) - state.batch_start_at
 
@@ -118,6 +127,7 @@ defmodule Arena.Matchmaking.TrioMode do
         client_id: client_id,
         skin_name: "Basic",
         character_name: Enum.random(characters).name,
+        character_level: 1,
         name: Enum.at(bot_names, i - 1),
         type: :bot
       }


### PR DESCRIPTION
## Motivation

If you try to join a duo game, trio or deadmatch the game never starts. The problem also happened with quickgame but it was already broken on main

Closes #1191

## Summary of changes

- added missing `character_level` key to the data built by the matchmaking queues

## How to test it?

Start a duo and trio games from unity. Deadmatch can only be tested on the browser. 

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
