### PR TITLE
Fix performance regression by reducing data broadcasted

### DIFF
--- a/apps/arena/lib/arena/bots/bot.ex
+++ b/apps/arena/lib/arena/bots/bot.ex
@@ -48,8 +48,14 @@ defmodule Arena.Bots.Bot do
     {:noreply, %{state | attack_blocked: false}}
   end
 
-  def handle_info({:game_update, game_state, config}, state) do
-    state = maybe_update_state_params(state, game_state, config)
+  def handle_info({:game_config_update, config}, state) do
+    state = update_config(state, config)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:game_update, game_state}, state) do
+    state = maybe_update_state_params(state, game_state)
 
     case game_state.status do
       :RUNNING ->
@@ -72,13 +78,17 @@ defmodule Arena.Bots.Bot do
     {:noreply, %{state | bot_state_machine: %{state.bot_state_machine | collision_grid: grid}}}
   end
 
-  defp maybe_update_state_params(state, game_state, config) do
+  defp update_config(state, config) do
     if is_nil(state.bot_state_machine.collision_grid) do
       PathfindingGrid.get_map_collision_grid(config.map.name, self())
     end
 
     state
     |> Map.put_new(:config, config)
+  end
+
+  defp maybe_update_state_params(state, game_state) do
+    state
     |> Map.put_new(:bot_player_id, get_in(game_state, [:client_to_player_map, state.bot_id]))
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -73,7 +73,6 @@ defmodule Arena.GameUpdater do
     match_id = Ecto.UUID.generate()
 
     send(self(), :update_game)
-    
     bounties_enabled? = game_config.game.bounty_pick_time_ms > 0
 
     if bounties_enabled? do
@@ -320,7 +319,7 @@ defmodule Arena.GameUpdater do
   end
 
   def broadcast_config_to_bots(bots_topic, game_config) do
-    PubSub.broadcast(Arena.PubSub, bots_topic, {:game_config_update,  game_config})
+    PubSub.broadcast(Arena.PubSub, bots_topic, {:game_config_update, game_config})
   end
 
   def handle_info(:game_start, state) do

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -318,10 +318,6 @@ defmodule Arena.GameUpdater do
     {:noreply, put_in(state, [:game_state, :status], :SELECTING_BOUNTY)}
   end
 
-  def broadcast_config_to_bots(bots_topic, game_config) do
-    PubSub.broadcast(Arena.PubSub, bots_topic, {:game_config_update, game_config})
-  end
-
   def handle_info(:game_start, state) do
     broadcast_config_to_bots(state.bots_topic, state.game_config)
     broadcast_enable_incomming_messages(state.game_state.game_id)
@@ -816,6 +812,10 @@ defmodule Arena.GameUpdater do
       traps: complete_entities(state[:traps], :trap),
       external_wall: complete_entity(state[:external_wall], :obstacle)
     })
+  end
+
+  defp broadcast_config_to_bots(bots_topic, game_config) do
+    PubSub.broadcast(Arena.PubSub, bots_topic, {:game_config_update, game_config})
   end
 
   defp broadcast_game_state_to_bots(state, %{bots_topic: bots_topic}) do


### PR DESCRIPTION
## Motivation

Closes #1197

We noticed that the updates the game updater broadcasted to the bots were very big:

```
DIFF NON ENCODED SIZE IN BYTES: 14312
CONFIG NON ENCODED SIZE IN BYTES: 217336
NON ENCODED SIZE IN BYTES: 231648 (DIFF + CONFIG)

# This is the updates we broadcast to the socket processes for real clients
ENCODED SIZE IN BYTES: 48
```

with some rough estimations, on loadtests with 200 games (of which 1 is a full client and 11 are bots), we were copying (to send the message) ~400MB once every 33ms. 

## Summary of changes

*List your changes here.*

## How to test it?

We ran a few loadtests, but you can test locally that the games are still running properly locally (or run your own loadtest). The main change is the moment at which the bots receive the game config. Make sure their behavior does not break by this.

## Checklist
- [X] Tested the changes locally.
- [X] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
