### PR TITLE
New alone loadtest run

### DIFF
--- a/apps/arena/lib/arena/matchmaking/duo_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/duo_mode.ex
@@ -26,7 +26,15 @@ defmodule Arena.Matchmaking.DuoMode do
   def init(_) do
     Process.send_after(self(), :launch_game?, 300)
     Process.send_after(self(), :update_params, 30_000)
-    {:ok, %{clients: [], batch_start_at: 0}}
+
+    state =
+      if Application.get_env(:arena, :loadtest_alone_mode?) do
+        %{clients: [], batch_start_at: 0, launch_game_interval: 10, amount_of_players: 1}
+      else
+        %{clients: [], batch_start_at: 0, launch_game_interval: 300, amount_of_players: nil}
+      end
+
+    {:ok, state}
   end
 
   @impl true
@@ -58,15 +66,15 @@ defmodule Arena.Matchmaking.DuoMode do
 
   @impl true
   def handle_info(:launch_game?, %{clients: clients} = state) do
-    Process.send_after(self(), :launch_game?, 300)
-
+    Process.send_after(self(), :launch_game?, state.launch_game_interval)
+    diff = System.monotonic_time(:millisecond) - state.batch_start_at
     state = Matchmaking.get_matchmaking_configuration(state, 2, "battle_royale")
 
-    diff = System.monotonic_time(:millisecond) - state.batch_start_at
+    amount_of_players = state.amount_of_players || state.current_map.amount_of_players
+    has_enough_players? = length(clients) >= amount_of_players
+    is_queue_timed_out? = diff >= Utils.start_timeout_ms() and length(clients) > 0
 
-    if Map.has_key?(state, :game_mode_configuration) &&
-         (length(clients) >= state.current_map.amount_of_players or
-            (diff >= Utils.start_timeout_ms() and length(clients) > 0)) do
+    if Map.has_key?(state, :game_mode_configuration) && (has_enough_players? or is_queue_timed_out?) do
       send(self(), :start_game)
     end
 

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -3,6 +3,7 @@ defmodule Arena.Matchmaking.GameLauncher do
   alias Arena.Utils
   alias Ecto.UUID
   alias Arena.Matchmaking
+  alias Arena.Bots.BotSupervisor
 
   use GenServer
 

--- a/apps/arena/lib/arena/matchmaking/game_launcher.ex
+++ b/apps/arena/lib/arena/matchmaking/game_launcher.ex
@@ -1,6 +1,5 @@
 defmodule Arena.Matchmaking.GameLauncher do
   @moduledoc false
-  alias Arena.Bots.BotSupervisor
   alias Arena.Utils
   alias Ecto.UUID
   alias Arena.Matchmaking
@@ -57,14 +56,22 @@ defmodule Arena.Matchmaking.GameLauncher do
 
   @impl true
   def handle_info(:launch_game?, %{clients: clients} = state) do
-    Process.send_after(self(), :launch_game?, 300)
+    is_loadtest_alone_mode? = System.get_env("LOADTEST_ALONE_MODE") == "true"
+
+    launch_game_interval =
+      if is_loadtest_alone_mode?, do: 30, else: 300
+
+    Process.send_after(self(), :launch_game?, launch_game_interval)
     diff = System.monotonic_time(:millisecond) - state.batch_start_at
-
     state = Matchmaking.get_matchmaking_configuration(state, 1, "battle_royale")
+    # is_loadtest_alone_mode? = System.get_env("LOADTEST_ALONE_MODE") == "true"
+    amount_of_players =
+      if is_loadtest_alone_mode?, do: 1, else: state.current_map.amount_of_players
 
-    if Map.has_key?(state, :game_mode_configuration) &&
-         (length(clients) >= state.current_map.amount_of_players or
-            (diff >= Utils.start_timeout_ms() and length(clients) > 0)) do
+    has_enough_players? = length(clients) >= amount_of_players
+    is_queue_timed_out? = diff >= Utils.start_timeout_ms() and length(clients) > 0
+
+    if Map.has_key?(state, :game_mode_configuration) && (has_enough_players? or is_queue_timed_out?) do
       send(self(), :start_game)
     end
 
@@ -72,7 +79,10 @@ defmodule Arena.Matchmaking.GameLauncher do
   end
 
   def handle_info(:start_game, state) do
-    {game_clients, remaining_clients} = Enum.split(state.clients, state.current_map.amount_of_players)
+    amount_of_players =
+      if System.get_env("LOADTEST_ALONE_MODE") == "true", do: 1, else: state.current_map.amount_of_players
+
+    {game_clients, remaining_clients} = Enum.split(state.clients, amount_of_players)
     create_game_for_clients(game_clients, state.game_mode_configuration, state.current_map)
     next_map = Enum.random(state.game_mode_configuration.map_mode_params)
 

--- a/apps/arena/lib/arena/matchmaking/trio_mode.ex
+++ b/apps/arena/lib/arena/matchmaking/trio_mode.ex
@@ -26,7 +26,15 @@ defmodule Arena.Matchmaking.TrioMode do
   def init(_) do
     Process.send_after(self(), :launch_game?, 300)
     Process.send_after(self(), :update_params, 30_000)
-    {:ok, %{clients: [], batch_start_at: 0}}
+
+    state =
+      if Application.get_env(:arena, :loadtest_alone_mode?) do
+        %{clients: [], batch_start_at: 0, launch_game_interval: 10, amount_of_players: 1}
+      else
+        %{clients: [], batch_start_at: 0, launch_game_interval: 300, amount_of_players: nil}
+      end
+
+    {:ok, state}
   end
 
   @impl true
@@ -58,15 +66,15 @@ defmodule Arena.Matchmaking.TrioMode do
 
   @impl true
   def handle_info(:launch_game?, %{clients: clients} = state) do
-    Process.send_after(self(), :launch_game?, 300)
-
+    Process.send_after(self(), :launch_game?, state.launch_game_interval)
+    diff = System.monotonic_time(:millisecond) - state.batch_start_at
     state = Matchmaking.get_matchmaking_configuration(state, 3, "battle_royale")
 
-    diff = System.monotonic_time(:millisecond) - state.batch_start_at
+    amount_of_players = state.amount_of_players || state.current_map.amount_of_players
+    has_enough_players? = length(clients) >= amount_of_players
+    is_queue_timed_out? = diff >= Utils.start_timeout_ms() and length(clients) > 0
 
-    if Map.has_key?(state, :game_mode_configuration) &&
-         (length(clients) >= state.current_map.amount_of_players or
-            (diff >= Utils.start_timeout_ms() and length(clients) > 0)) do
+    if Map.has_key?(state, :game_mode_configuration) && (has_enough_players? or is_queue_timed_out?) do
       send(self(), :start_game)
     end
 

--- a/apps/arena_load_test/README.md
+++ b/apps/arena_load_test/README.md
@@ -42,7 +42,16 @@ It's important to note that the Arena application defines how many players play 
 ### Games filled with arena bots
 We can run our loadtests using not only our mock players but also the bots in arena application.
 To do so, set the following environment variable:
+
 ```bash
-System.put_env("LOADTEST_ALONE_MODE", "true")
+export LOADTEST_ALONE_MODE=true
 ```
-With this enabled, each game will be filled with one player and the remaining players will be bots.
+
+With this enabled, each game will be filled with one player and the remaining players will be bots. 
+
+You'll need to restart the app for this to take effect. Alternatively you can do:
+
+```elixir
+# This will not update the env var, beware
+Application.put_env(:arena, :loadtest_alone_mode?, true)
+```

--- a/apps/arena_load_test/README.md
+++ b/apps/arena_load_test/README.md
@@ -42,16 +42,8 @@ It's important to note that the Arena application defines how many players play 
 ### Games filled with arena bots
 We can run our loadtests using not only our mock players but also the bots in arena application.
 To do so, set the following environment variable:
-
 ```bash
 export LOADTEST_ALONE_MODE=true
 ```
-
 With this enabled, each game will be filled with one player and the remaining players will be bots. 
-
-You'll need to restart the app for this to take effect. Alternatively you can do:
-
-```elixir
-# This will not update the env var, beware
-Application.put_env(:arena, :loadtest_alone_mode?, true)
-```
+You'll need to restart the app for this to take effect.

--- a/apps/arena_load_test/README.md
+++ b/apps/arena_load_test/README.md
@@ -17,7 +17,8 @@ make run
 Inside the Elixir shell:
 ```elixir
 # number_of_simulated_players must be a positive integer
-System.get_env("LOADTEST_ALONE_MODE") == "true"
+System.put_env("LOADTEST_ALONE_MODE", "true")
+System.put_env("LOADTEST_EUROPE_HOST", "176.9.26.172")
 number_of_simulated_players = 25
 ArenaLoadTest.SocketSupervisor.spawn_players(number_of_simulated_players)
 ```

--- a/apps/arena_load_test/README.md
+++ b/apps/arena_load_test/README.md
@@ -17,9 +17,7 @@ make run
 Inside the Elixir shell:
 ```elixir
 # number_of_simulated_players must be a positive integer
-System.put_env("LOADTEST_ALONE_MODE", "true")
-System.put_env("LOADTEST_EUROPE_HOST", "176.9.26.172")
-number_of_simulated_players = 25
+number_of_simulated_players = 500
 ArenaLoadTest.SocketSupervisor.spawn_players(number_of_simulated_players)
 ```
 
@@ -40,3 +38,11 @@ ulimit -n
 
 ### Amount of players per game
 It's important to note that the Arena application defines how many players play in the same game match. If you want to increase the number of players in a game, you have to deploy the Arena application in the desired server with that configuration.
+
+### Games filled with arena bots
+We can run our loadtests using not only our mock players but also the bots in arena application.
+To do so, set the following environment variable:
+```bash
+System.put_env("LOADTEST_ALONE_MODE", "true")
+```
+With this enabled, each game will be filled with one player and the remaining players will be bots.

--- a/apps/arena_load_test/README.md
+++ b/apps/arena_load_test/README.md
@@ -17,7 +17,8 @@ make run
 Inside the Elixir shell:
 ```elixir
 # number_of_simulated_players must be a positive integer
-number_of_simulated_players = 5000
+System.get_env("LOADTEST_ALONE_MODE") == "true"
+number_of_simulated_players = 25
 ArenaLoadTest.SocketSupervisor.spawn_players(number_of_simulated_players)
 ```
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -72,6 +72,8 @@ if System.get_env("USE_PROXY") do
   ])
 end
 
+config :arena, :loadtest_alone_mode?, System.get_env("LOADTEST_ALONE_MODE") == "true"
+
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you


### PR DESCRIPTION
## Motivation

We need a way to test matches of 1 player filled with bots.

## Summary of changes

- [Add new loadtest alone mode application env var](https://github.com/lambdaclass/mirra_backend/pull/1196/commits/321e337f66f8c83df906c4fb42f32a1f9b2606d3)
- [Update matchmaking queues to use loadtest params when env var is set](https://github.com/lambdaclass/mirra_backend/pull/1196/commits/7d8f284e21838c90b7b8e30ded1b428a09d88d4c)

## How to test it?

This has been tested many times but never did a PR. You can test locally using the env var.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
