### PR TITLE
Update workflows and scripts due to grafana and loadtests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,11 @@ server-specs:
 	./devops/server_specs.sh
 
 ## New server. Setup dependencies.
-## Run these as admin user
+## Run one of these (arena or central) as admin user
 
-admin-setup-arena-server: debian-install-deps setup-caddy create-env-file
+admin-setup-arena-server: debian-install-deps setup-caddy-arena create-env-file
+
+admin-setup-central-server: debian-install-deps debian-setup-grafana setup-caddy-central setup-prometheus create-env-file
 
 debian-install-deps:
 	sudo apt update -y
@@ -93,16 +95,6 @@ debian-install-deps:
 	rm /tmp/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
 	rm /tmp/esl-erlang_26.2.3-1~debian~buster_amd64.deb
 	rm /tmp/elixir-otp-26.zip
-
-setup-caddy:
-	sudo ufw allow 80
-	sudo ufw allow 443
-	sudo truncate -s 0 /etc/caddy/Caddyfile && \
-	echo "$$(hostname).championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
-	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
-	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
-	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
-	sudo systemctl restart caddy
 
 create-env-file:
 	sudo truncate -s0 /home/$(SSH_APP_USERNAME)/.env
@@ -131,6 +123,81 @@ create-env-file:
 	sudo echo "LOADTEST_CHILE_HOST=" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
 	sudo echo "NEWRELIC_APP_NAME=$$(hostname)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
 	sudo echo "NEWRELIC_KEY=$(NEWRELIC_KEY)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+	sudo echo "LOADTEST_ALONE_MODE=$(LOADTEST_ALONE_MODE)" | sudo tee -a /home/$(SSH_APP_USERNAME)/.env > /dev/null
+
+## ARENA SERVER ONLY
+
+setup-caddy-arena:
+	sudo ufw allow 80
+	sudo ufw allow 443
+	sudo truncate -s 0 /etc/caddy/Caddyfile && \
+	echo "$$(hostname).championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
+	echo "$$(hostname).prometheus.championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  basicauth {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "    $$(PROMETHEUS_USER) $$(PROMETHEUS_PASSWORD)" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  }" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:9568" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
+	sudo systemctl restart caddy
+
+## CENTRAL SERVER ONLY
+
+debian-setup-grafana:
+	wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
+	sudo apt-get update
+	sudo apt-get install grafana -y
+	sudo systemctl enable grafana-server
+	sudo systemctl start grafana-server
+
+setup-prometheus:
+	curl -s https://$(GATEWAY_URL)/api/arena_servers | \
+	jq -r '.servers[].url | "          - \(. | sub("^arena-"; "arena-") + ".prometheus.championsofmirra.com")"' > /tmp/targets.txt && \
+	echo "scrape_configs:" > /etc/prometheus/prometheus.yml && \
+	echo "  - job_name: 'arena_servers'" >> /etc/prometheus/prometheus.yml && \
+	echo "    scheme: https" >> /etc/prometheus/prometheus.yml && \
+	echo "    metrics_path: '/metrics'" >> /etc/prometheus/prometheus.yml && \
+	echo "    basic_auth:" >> /etc/prometheus/prometheus.yml && \
+	echo "      username: $$(PROMETHEUS_USER)" >> /etc/prometheus/prometheus.yml && \
+	echo "      password: $$(PROMETHEUS_PASSWORD)" >> /etc/prometheus/prometheus.yml && \
+	echo "    static_configs:" >> /etc/prometheus/prometheus.yml && \
+	echo "      - targets:" >> /etc/prometheus/prometheus.yml && \
+	cat /tmp/targets.txt >> /etc/prometheus/prometheus.yml && \
+	rm /tmp/targets.txt
+	sudo systemctl restart prometheus
+
+setup-central-caddy:
+	sudo ufw allow 80
+	sudo ufw allow 443
+	sudo truncate -s 0 /etc/caddy/Caddyfile && \
+	echo "$$(hostname).championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
+	echo "$$(hostname).grafana.championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
+	sudo systemctl restart caddy
+
+setup-aws-central-dns:
+	@AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
+	AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
+	AWS_REGION=us-west-2 \
+	aws route53 change-resource-record-sets \
+		--hosted-zone-id "Z10155211PTW2X4H9NGDM" \
+		--change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$$(hostname).championsofmirra.com\",\"Type\":\"A\",\"TTL\":300,\"ResourceRecords\":[{\"Value\":\"$$(curl -s ipinfo.io/ip)\"}]}}]}"
+
+	@AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
+	AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
+	AWS_REGION=us-west-2 \
+	aws route53 change-resource-record-sets \
+		--hosted-zone-id "Z10155211PTW2X4H9NGDM" \
+		--change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$$(hostname).grafana.championsofmirra.com\",\"Type\":\"A\",\"TTL\":300,\"ResourceRecords\":[{\"Value\":\"$$(curl -s ipinfo.io/ip)\"}]}}]}"
+
 
 ## Run this as app or dev user
 

--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,13 @@ setup-central-caddy:
 	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
 	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
 	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
+	sudo truncate -s 0 /etc/caddy/Caddyfile && \
+	echo "$$(hostname).configurator.championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:4100" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
 	echo "$$(hostname).grafana.championsofmirra.com {" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
-	echo "  reverse_proxy localhost:4000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
+	echo "  reverse_proxy localhost:3000" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
 	echo "}" | sudo tee -a /etc/caddy/Caddyfile > /dev/null && \
 	sudo sh -c 'echo "" >> /etc/caddy/Caddyfile'
 	sudo systemctl restart caddy

--- a/devops/infra_docs.md
+++ b/devops/infra_docs.md
@@ -1,0 +1,39 @@
+# Champions of Mirra Deployment Architecture
+
+This document outlines the two server roles (**Central** and **Arena**) and the associated Makefile targets used to deploy its correspondent applications. The Central server hosts core game services and dashboards (Grafana), while each Arena server runs the game logic for individual battles. Caddy is used on each server as a reverse proxy (with automatic HTTPS) for the main app, Grafana, and Prometheus. DNS is managed via AWS Route 53.
+
+## Central vs. Arena Servers
+
+- **Central server:** Hosts the general backend services for the Mirra game (e.g. the **ChampionsOfMirra** app). This includes modules for battles, campaigns, items, units, and user management. It also runs shared infrastructure like Grafana and Prometheus for monitoring.
+
+- **Arena server:** Hosts the Arena service that runs the actual game logic and physics for matches. Each Arena server manages player connections and game simulation (including a 2D physics engine). In other words, Arena servers handle live gameplay and the matchmaking queues.
+
+## Arena Monitoring (Prometheus + Grafana)
+
+Monitoring is a shared responsibility between the Central and Arena servers:
+
+- **Prometheus** is installed on both Central and Arena servers.
+- **Grafana** runs only on the Central server and serves as the primary dashboard interface.
+- The Central server holds the `prometheus.yml` configuration, which is set up to **scrape metrics from all Arena servers** via their `/metrics` endpoints.
+- Each Arena server exposes its metrics endpoint through Caddy.
+- Grafana dashboards on the Central server visualize the collected data from all servers.
+- The Central server exposes Grafana over a public DNS name using AWS Route 53. Arena servers similarly expose their Prometheus metrics (auth required) for Central to scrape.
+
+## Makefile Deployment Targets
+
+Key Makefile targets automate server provisioning and configuration. In general, the `admin-setup-*` targets perform initial OS setup (users, packages, firewall, SSH keys, etc.), while `setup-*` targets configure specific services.
+
+- `make admin-setup-arena-server` — Bootstraps a new Arena machine. Installs system packages, creates an `admin` user with SSH keys, disables root login, and configures the firewall (e.g. allow SSH and app ports). These are standard initial setup tasks.
+
+- `make admin-setup-central-server` — Same as above but for a Central machine. It prepares the OS and network settings needed for Central role.
+
+- `make setup-caddy-arena` — Configures Caddy on the Arena server. This sets up Caddy as a reverse proxy for the Arena app and any monitoring UIs (Prometheus) on that host, obtaining TLS certificates automatically.
+
+- `make setup-central-caddy` — Installs/configures Caddy on the Central server. It reverse-proxies the ChampionsOfMirra API and Grafana.
+
+- `make setup-prometheus` — Configures Prometheus for Central server. It includes the `prometheus.yml` that scrapes the `/metrics` endpoints exposed by Arena services. Prometheus automatically collects time-series metrics by scraping HTTP endpoints.
+
+- `make create-env-file` — Generates the environment file (e.g. `.env`) with environment secrets and variables.
+
+- `make setup-aws-central-dns` — Updates DNS records in AWS Route 53 for the Central server. It creates or modifies the hosted zone entries (e.g. `central.example.com`) so that client requests resolve to the correct IP.
+    * Note: for Arena server, we do this in `.github/workflows/deploy-new-arena-server.yml` already.


### PR DESCRIPTION
## Motivation

We did a lot of changes in our infraestructure due to Grafana and Prometheus additions.
We need to update our Makefile and write some docs about it.

## Summary of changes

- [Update Makefile commands to setup prometheus + Grafana properly](https://github.com/lambdaclass/mirra_backend/commit/6c2974649ca664e91f36bd15cca25e85bc620ec9)
- [Add docs explaining the key-differences between Arena and Central servers, explaining Grafana and Prometheus responsibilities](https://github.com/lambdaclass/mirra_backend/commit/fb19c097a46b586cbb437afb2a0d98aac0d94108) 

## How to test it?

There's no need to test this because it was already done in our servers.
We can just try them out when needed and do the proper fixes there.
If you still want to do it, just run the makefile commands in a server. Be careful, it may break existing behavior.

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
