### PR TITLE
Add new broadcast update size metric and give Grafana panels some love

### DIFF
--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -308,7 +308,7 @@ defmodule Arena.GameUpdater do
     game_state = %{game_state | killfeed: [], damage_taken: %{}, damage_done: %{}}
 
     tick_duration = System.monotonic_time() - tick_duration_start_at
-    :telemetry.execute([:arena, :game, :tick], %{duration: tick_duration, duration_measure: tick_duration})
+    :telemetry.execute([:arena, :game, :tick], %{duration: System.convert_time_unit(tick_duration, :native, :millisecond)})
     {:noreply, %{state | game_state: game_state, last_broadcasted_game_state: last_broadcasted_game_state}}
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -831,6 +831,8 @@ defmodule Arena.GameUpdater do
         event: {:update, game_state}
       })
 
+    :telemetry.execute([:game_updater, :broadcast], %{binary_size: bit_size(encoded_state) / 1_000_000})
+
     PubSub.broadcast(Arena.PubSub, game_id, {:game_update, encoded_state})
   end
 

--- a/apps/arena/lib/arena/game_updater.ex
+++ b/apps/arena/lib/arena/game_updater.ex
@@ -308,7 +308,11 @@ defmodule Arena.GameUpdater do
     game_state = %{game_state | killfeed: [], damage_taken: %{}, damage_done: %{}}
 
     tick_duration = System.monotonic_time() - tick_duration_start_at
-    :telemetry.execute([:arena, :game, :tick], %{duration: System.convert_time_unit(tick_duration, :native, :millisecond)})
+
+    :telemetry.execute([:arena, :game, :tick], %{
+      duration: System.convert_time_unit(tick_duration, :native, :millisecond)
+    })
+
     {:noreply, %{state | game_state: game_state, last_broadcasted_game_state: last_broadcasted_game_state}}
   end
 

--- a/apps/arena/lib/arena/prom_ex_plugin.ex
+++ b/apps/arena/lib/arena/prom_ex_plugin.ex
@@ -13,6 +13,7 @@ defmodule Arena.PromExPlugin do
         sum("arena.game.count", description: "Number of games in progress"),
         distribution("arena.game.tick.duration",
           description: "Time spent on running a game update tick",
+          unit: {:native, :millisecond},
           reporter_options: [buckets: [0, 5, 10, 30, 100, 1_000]]
         ),
         sum("arena.clients.count", description: "Number of clients (websockets) connected"),

--- a/apps/arena/lib/arena/prom_ex_plugin.ex
+++ b/apps/arena/lib/arena/prom_ex_plugin.ex
@@ -11,16 +11,9 @@ defmodule Arena.PromExPlugin do
     [
       Event.build(:game_metrics, [
         sum("arena.game.count", description: "Number of games in progress"),
-        ## TODO: this metric is an attempt to gather data to properly set the buckets for the distribution metric below
-        last_value("arena.game.tick.duration_measure",
-          description: "Last game tick duration",
-          unit: {:native, :nanosecond}
-        ),
-        ## TODO: Buckets probably need to be redefined, currently they all fall under the first bucket
         distribution("arena.game.tick.duration",
-          description: "Time spent on running a game tick",
-          unit: {:native, :nanosecond},
-          reporter_options: [buckets: [7_500_000.0, 15_000_000.0, 22_500_000.0]]
+          description: "Time spent on running a game update tick",
+          reporter_options: [buckets: [0, 5, 10, 30, 100, 1_000]]
         ),
         sum("arena.clients.count", description: "Number of clients (websockets) connected"),
         sum([:bots, :count], description: "Amount of active bots"),

--- a/apps/arena/lib/arena/prom_ex_plugin.ex
+++ b/apps/arena/lib/arena/prom_ex_plugin.ex
@@ -23,7 +23,11 @@ defmodule Arena.PromExPlugin do
           reporter_options: [buckets: [7_500_000.0, 15_000_000.0, 22_500_000.0]]
         ),
         sum("arena.clients.count", description: "Number of clients (websockets) connected"),
-        sum([:bots, :count], description: "Amount of active bots")
+        sum([:bots, :count], description: "Amount of active bots"),
+        distribution([:game_updater, :broadcast, :binary_size],
+          reporter_options: [buckets: [0, 10, 100, 1_000, 10_000, 100_000]],
+          description: "Size of encoded game update broadcast in Megabits"
+        )
       ]),
       Event.build(:vm_metrics, [
         last_value("vm.memory.total", unit: {:byte, :kilobyte}),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - '--storage.tsdb.path=/prometheus'
     ports:
       - 9090:9090
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   grafana:
     image: grafana/grafana-oss
     container_name: grafana

--- a/grafana_arena_dashboard.json
+++ b/grafana_arena_dashboard.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.5.2"
+      "version": "12.0.0"
     },
     {
       "type": "datasource",
@@ -100,15 +100,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -132,9 +132,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "disableTextWrap": false,
           "editorMode": "builder",
           "expr": "os_cpu_usage",
@@ -143,11 +147,7 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
+          "useBackend": false
         }
       ],
       "title": "CPU Usage (%)",
@@ -201,15 +201,15 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decmbytes"
         },
         "overrides": []
       },
@@ -233,9 +233,13 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "disableTextWrap": false,
           "editorMode": "code",
           "expr": "os_free_memory",
@@ -244,11 +248,7 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
+          "useBackend": false
         },
         {
           "datasource": {
@@ -285,7 +285,7 @@
           "useBackend": false
         }
       ],
-      "title": "OS Memory usage (MB)",
+      "title": "OS Memory usage",
       "type": "timeseries"
     },
     {
@@ -337,8 +337,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -369,7 +368,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -439,8 +438,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -471,7 +469,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -541,8 +539,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -573,7 +570,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -638,8 +635,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -670,7 +666,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -766,7 +762,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -831,8 +827,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -863,7 +858,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.2",
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
@@ -1081,6 +1076,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Amount of game matches being played.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1182,7 +1178,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "Size of encoded game update broadcasted to each player.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1234,7 +1230,7 @@
               }
             ]
           },
-          "unit": "count"
+          "unit": "Mbits"
         },
         "overrides": []
       },
@@ -1244,7 +1240,7 @@
         "x": 12,
         "y": 40
       },
-      "id": 2,
+      "id": 21,
       "options": {
         "legend": {
           "calcs": [],
@@ -1261,23 +1257,22 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "avg by(le) (arena_game_tick_duration_bucket)",
+          "editorMode": "code",
+          "expr": "rate(game_updater_broadcast_binary_size_sum[5m]) / rate(game_updater_broadcast_binary_size_count[5m]) * 30\n",
           "fullMetaSearch": false,
-          "includeNullMetadata": false,
-          "instant": false,
+          "includeNullMetadata": true,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "useBackend": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
         }
       ],
-      "title": "(Do not use) Game tick duration",
+      "title": "Avg broadcast binary size",
       "type": "timeseries"
     },
     {
@@ -1285,6 +1280,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Average time to process a game state update in milliseconds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1336,7 +1332,7 @@
               }
             ]
           },
-          "unit": "ns"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1368,8 +1364,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "avg by(host) (arena_game_tick_duration_measure)",
+          "editorMode": "code",
+          "expr": "rate(arena_game_tick_duration_sum[5m]) / rate(arena_game_tick_duration_count[5m])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1379,7 +1375,7 @@
           "useBackend": false
         }
       ],
-      "title": "Game tick last duration",
+      "title": "Avg game update tick duration (ms)",
       "type": "timeseries"
     },
     {
@@ -1646,8 +1642,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 64
+        "x": 12,
+        "y": 56
       },
       "id": 3,
       "options": {
@@ -1687,19 +1683,19 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 40,
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Arena",
   "uid": "fdixa7yyhidxca",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Motivation

Some Grafana panels in our dashboard are hard to understand.
The game tick panel isn't showing the right information.

## Summary of changes

- [Add new telemetry event to track size of broadcasted updates](https://github.com/lambdaclass/mirra_backend/commit/dbe4a6c2d3007d0898b9b897c85e6ed07b91db9f)
- [Fix game update tick metrics event](https://github.com/lambdaclass/mirra_backend/commit/1fc9ac05d3e0671332bb5dcf163236e38d14fc2a)
- [Update Grafana dashboard: show tick panel properly and add units for every panel](https://github.com/lambdaclass/mirra_backend/commit/71447bfcc310ab3394295dc9e7aa60d11a3a8515) 

## How to test it?

Just play a game and open your grafana dashboard (re-import the new one)!

## Checklist
- [x] Tested the changes locally.
- [x] Reviewed the changes on GitHub, line by line.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
